### PR TITLE
chore(governance): remove Claude-specific instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,0 @@
-# Claude Code instructions
-
-Read and follow [`AGENTS.md`](AGENTS.md) in full before working in this
-repository. Use [`docs/README.md`](docs/README.md) to select task-specific
-records, and inspect `docs/STATUS.md` and `TODO.md` before changing files.
-
-`AGENTS.md` is the canonical repository instruction file. This file
-intentionally does not duplicate its policy; if the two ever conflict, follow
-`AGENTS.md` and report the inconsistency before mutation.


### PR DESCRIPTION
## Summary

- Delete the accidentally added CLAUDE.md.
- Keep AGENTS.md as the sole canonical repository instruction file.

## Evidence

- deletion-only diff
- git diff --check
- remaining CLAUDE.md mention is historical in the 2026-09-05 log

Refs #10