### PR TITLE
chore(governance): enforce project work limits

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -42,6 +42,13 @@ body:
       description: Exact files, directories, generated artifacts, and external systems in scope.
     validations:
       required: true
+  - type: input
+    id: branch
+    attributes:
+      label: Branch
+      description: Dedicated branch matching the repository naming convention.
+    validations:
+      required: true
   - type: textarea
     id: acceptance
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,8 @@
 - Work item:
 - Authority:
 - Mutation owner:
+- Branch and allowlist:
+- Dependencies:
 
 ## Change
 
@@ -14,6 +16,7 @@
 
 - Acceptance criteria:
 - Commands and evidence:
+- Stop rule:
 
 ## Provenance and release impact
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,9 +7,9 @@ GitHub Project mirror these stable identifiers for coordination. Parent epics
 are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
-Current queue state: `T-0002` and `T-0011` are `Done`; `T-0003` and `T-0021`
-are `In Progress`; `T-0012` is `Blocked`; and every other item is `Backlog`.
-No item is `Ready` or `Review`.
+Current queue state: `T-0002` and `T-0011` are `Done`; `T-0003` is `Review`;
+`T-0021` is `In Progress`; `T-0012` is `Blocked`; and every other item is
+`Backlog`. No item is `Ready`.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -23,7 +23,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0001 | Epic: Governance and traceability | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0002 | Establish canonical records and stable IDs | Done | P0 | 3 | None | Project Manager | Unit/Contract |
-| T-0003 | Establish roles, mutation ownership, and WIP enforcement | In Progress | P0 | 3 | T-0002 | Project Manager | Unit/Contract |
+| T-0003 | Establish roles, mutation ownership, and WIP enforcement | Review | P0 | 3 | T-0002 | Project Manager | Unit/Contract |
 | T-0004 | Implement Project synchronization audit | Backlog | P1 | 5 | T-0002, T-0003 | Project Manager | Unit/Contract |
 | T-0005 | Establish provenance, license, NOTICE, and SBOM gates | Backlog | P0 | 5 | T-0002 | Project Manager | Release |
 | T-0006 | Establish trademark and patent review checkpoints | Backlog | P1 | 2 | T-0005 | Project Manager | Planning |

--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,9 @@ GitHub Project mirror these stable identifiers for coordination. Parent epics
 are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
-Current queue state: `T-0002` and `T-0011` are `Done`, `T-0021` is `In Progress`,
-and every other item is `Backlog`. No item is `Ready`, `Review`, or `Blocked`.
+Current queue state: `T-0002` and `T-0011` are `Done`; `T-0003` and `T-0021`
+are `In Progress`; `T-0012` is `Blocked`; and every other item is `Backlog`.
+No item is `Ready` or `Review`.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -22,7 +23,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0001 | Epic: Governance and traceability | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0002 | Establish canonical records and stable IDs | Done | P0 | 3 | None | Project Manager | Unit/Contract |
-| T-0003 | Establish roles, mutation ownership, and WIP enforcement | Backlog | P0 | 3 | T-0002 | Project Manager | Unit/Contract |
+| T-0003 | Establish roles, mutation ownership, and WIP enforcement | In Progress | P0 | 3 | T-0002 | Project Manager | Unit/Contract |
 | T-0004 | Implement Project synchronization audit | Backlog | P1 | 5 | T-0002, T-0003 | Project Manager | Unit/Contract |
 | T-0005 | Establish provenance, license, NOTICE, and SBOM gates | Backlog | P0 | 5 | T-0002 | Project Manager | Release |
 | T-0006 | Establish trademark and patent review checkpoints | Backlog | P1 | 2 | T-0005 | Project Manager | Planning |
@@ -33,7 +34,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics | Backlog | P0 | 5 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics | Blocked | P0 | 5 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics | Backlog | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -119,12 +120,9 @@ T-0021 has two bounded slices under one serial integration lane:
   complete T-0012/T-0013 or authorize guessed semantic implementations.
 
 These estimates are within the parent's 5 SP, not additional points or accepted
-velocity. Parent completion retains its listed dependencies. The next
-refinement candidates are:
+velocity. Parent completion retains its listed dependencies.
 
-1. `T-0003`: establish role, mutation-ownership, and WIP enforcement checks.
-2. `T-0012`: specify configuration, schema, and value semantics from the
-   pinned references without adopting upstream implementation code.
-
-T-0003 and T-0012 remain the next refinement candidates. The combined `In
-Progress` plus `Review` WIP limit remains two.
+T-0003 is implementing the governance audit required before T-0004 can refine
+Project synchronization and delivery analytics. T-0012 remains blocked with
+its exact clearing condition in Issue #15. The combined `In Progress` plus
+`Review` WIP limit is fully occupied by T-0003 and T-0021.

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -88,3 +88,9 @@ require explicit license, notice, redistribution, patent, or trademark review.
 
 Remote publication, Project visibility changes, paid services, new credentials,
 destructive actions, and legal-clearance claims always remain owner decisions.
+
+Automation and audits must discover the repository-associated Project from the
+authenticated repository context. They must not embed a personal login,
+Project number, URL, or credential. Discovery fails closed unless exactly one
+open linked Project is found, and audit output must never include tokens or
+secret values.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,6 +11,10 @@ The roadmap is ordered by evidence gates. Dates are intentionally omitted until 
 
 Exit gate: the first implementation tasks have approved contracts and reproducible reference fixtures.
 
+The governance portion of this phase also requires T-0003's executable packet
+and WIP audit before T-0004 may automate Project synchronization or delivery
+analytics.
+
 T-0021/S02 supplies the [Rust design worksheet](RUST_RUNTIME_DESIGN.md) for
 configuration/value fixtures and lifecycle/failure traces. Its proposed
 structure does not satisfy this exit gate; T-0012 and T-0013 must resolve the

--- a/docs/SPRINTS.md
+++ b/docs/SPRINTS.md
@@ -50,6 +50,12 @@ Do not repeat broad scans or full test suites unless a changed artifact or new
 failure justifies them. A local two-thread cap is recommended; it limits
 concurrency but cannot measure or reset an account's weekly usage allowance.
 
+Run `python3 scripts/project_governance_audit.py audit` before lifecycle
+transitions that would occupy an execution lane. The audit discovers the
+repository-linked Project at runtime and fails closed when discovery is
+ambiguous or the combined WIP limit is exceeded. It is read-only; the Project
+Manager remains responsible for every transition.
+
 ## Definition of Ready
 
 An item may enter `Ready` only when it has:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,7 +24,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0003 and T-0021 occupy the two active mutation lanes. T-0012 is blocked on
+T-0003 is in review and T-0021 occupies the other active lane. T-0012 is blocked on
 executing its pinned reference probe. No work item is currently `Ready` or
 `Review`.
 
@@ -32,7 +32,7 @@ executing its pinned reference probe. No work item is currently `Ready` or
 |---|---|---|
 | T-0002 | Done | Established canonical records and stable IDs |
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
-| T-0003 | In Progress | Add an executable governance and WIP audit |
+| T-0003 | Review | Add an executable governance and WIP audit |
 | T-0012 | Blocked | Pinned reference probe cannot yet execute successfully |
 | T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,13 +24,16 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021 is the only active task. No work item is currently `Ready`, `Review`,
-or `Blocked`.
+T-0003 and T-0021 occupy the two active mutation lanes. T-0012 is blocked on
+executing its pinned reference probe. No work item is currently `Ready` or
+`Review`.
 
 | Item | State | Purpose |
 |---|---|---|
 | T-0002 | Done | Established canonical records and stable IDs |
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
+| T-0003 | In Progress | Add an executable governance and WIP audit |
+| T-0012 | Blocked | Pinned reference probe cannot yet execute successfully |
 | T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
@@ -38,6 +41,11 @@ unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/
 is the coordination mirror. Its 52 items, lifecycle states, initial estimates,
 roles, dependencies, workstreams, evidence classes, and views were reconciled
 to the repository records on 2026-09-05.
+
+T-0003 adds a fail-closed, read-only audit that dynamically discovers the one
+open Project linked to the repository, validates the combined `In Progress`
+plus `Review` WIP limit, and exposes reusable packet-validation checks. It does
+not automate lifecycle transitions or provide delivery analytics.
 
 ## Evidence and non-claims
 

--- a/docs/log/2026-09-05.md
+++ b/docs/log/2026-09-05.md
@@ -54,5 +54,5 @@ lifecycle transition.
   `In Progress` plus `Review` limit.
 - Added unit fixtures for complete and incomplete Issue packets, valid WIP,
   excess WIP, and ambiguous Project discovery.
-- Reconciled the canonical queue with live coordination state: T-0003 and
-  T-0021 are In Progress, and T-0012 is Blocked.
+- Reconciled the canonical queue with live coordination state: T-0003 is in
+  Review, T-0021 is In Progress, and T-0012 is Blocked.

--- a/docs/log/2026-09-05.md
+++ b/docs/log/2026-09-05.md
@@ -44,3 +44,15 @@ The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
 contains 52 items and remains a coordination mirror. Repository records remain
 authoritative; any later partial remote update must be reconciled before a
 lifecycle transition.
+
+## Governance Enforcement
+
+- Refined T-0003 on `chore/t-0003-governance-enforcement` with an exact
+  allowlist, acceptance boundary, Demo Command, stop rule, and non-claims.
+- Added a read-only audit that discovers the repository-linked Project at
+  runtime, fails on ambiguous discovery, and enforces the combined two-item
+  `In Progress` plus `Review` limit.
+- Added unit fixtures for complete and incomplete Issue packets, valid WIP,
+  excess WIP, and ambiguous Project discovery.
+- Reconciled the canonical queue with live coordination state: T-0003 and
+  T-0021 are In Progress, and T-0012 is Blocked.

--- a/scripts/project_governance_audit.py
+++ b/scripts/project_governance_audit.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Fail-closed, read-only audit for Emburk's GitHub Project governance."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+REQUIRED_SECTIONS = (
+    "Authority",
+    "Dependencies",
+    "Branch and allowlist",
+    "Artifacts",
+    "Acceptance criteria",
+    "Demo Command",
+    "Evidence class",
+    "Stop rule",
+    "Non-claims",
+)
+ACTIVE_STATUSES = frozenset({"In Progress", "Review"})
+WIP_LIMIT = 2
+
+
+class AuditError(RuntimeError):
+    """Raised when governance cannot be established unambiguously."""
+
+
+@dataclass(frozen=True)
+class ProjectRef:
+    owner: str
+    number: int
+    title: str
+    url: str
+
+
+def validate_packet(body: str) -> list[str]:
+    """Return required Markdown section names missing from an Issue body."""
+    headings = {
+        line[3:].strip().casefold()
+        for line in body.splitlines()
+        if line.startswith("## ")
+    }
+    return [section for section in REQUIRED_SECTIONS if section.casefold() not in headings]
+
+
+def count_wip(items: Iterable[dict[str, Any]]) -> int:
+    """Count items occupying the combined execution and review lanes."""
+    return sum(1 for item in items if item.get("status") in ACTIVE_STATUSES)
+
+
+def enforce_wip(items: Iterable[dict[str, Any]], limit: int = WIP_LIMIT) -> int:
+    count = count_wip(items)
+    if count > limit:
+        raise AuditError(f"combined In Progress/Review WIP is {count}; limit is {limit}")
+    return count
+
+
+def select_project(nodes: Iterable[dict[str, Any]]) -> ProjectRef:
+    open_projects = [node for node in nodes if not node.get("closed", False)]
+    if len(open_projects) != 1:
+        raise AuditError(
+            "expected exactly one open Project linked to the repository; "
+            f"found {len(open_projects)}"
+        )
+    node = open_projects[0]
+    owner = node.get("owner", {}).get("login")
+    number = node.get("number")
+    title = node.get("title")
+    url = node.get("url")
+    if not owner or not isinstance(number, int) or not title or not url:
+        raise AuditError("linked Project metadata is incomplete")
+    return ProjectRef(owner=owner, number=number, title=title, url=url)
+
+
+def run_gh(*args: str, stdin: str | None = None) -> Any:
+    command = ["gh", *args]
+    completed = subprocess.run(
+        command,
+        input=stdin,
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def discover() -> ProjectRef:
+    repository = run_gh("repo", "view", "--json", "nameWithOwner")
+    owner, name = repository["nameWithOwner"].split("/", 1)
+    query = """query($owner:String!,$name:String!){
+      repository(owner:$owner,name:$name){
+        projectsV2(first:20){nodes{id number title url closed owner{... on User{login} ... on Organization{login}}}}
+      }
+    }"""
+    response = run_gh(
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={name}",
+    )
+    nodes = response["data"]["repository"]["projectsV2"]["nodes"]
+    return select_project(nodes)
+
+
+def audit() -> dict[str, Any]:
+    project = discover()
+    result = run_gh(
+        "project",
+        "item-list",
+        str(project.number),
+        "--owner",
+        project.owner,
+        "--limit",
+        "500",
+        "--format",
+        "json",
+    )
+    items = result.get("items", [])
+    wip = enforce_wip(items)
+    return {
+        "project": {"title": project.title, "url": project.url},
+        "items": len(items),
+        "combined_wip": wip,
+        "wip_limit": WIP_LIMIT,
+        "result": "pass",
+    }
+
+
+def main(argv: list[str]) -> int:
+    if argv != ["audit"]:
+        print("usage: project_governance_audit.py audit", file=sys.stderr)
+        return 2
+    try:
+        print(json.dumps(audit(), sort_keys=True))
+    except (AuditError, KeyError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+        print(f"governance audit failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_project_governance_audit.py
+++ b/tests/test_project_governance_audit.py
@@ -1,0 +1,69 @@
+import unittest
+
+from scripts.project_governance_audit import (
+    AuditError,
+    count_wip,
+    enforce_wip,
+    select_project,
+    validate_packet,
+)
+
+
+class GovernanceAuditTest(unittest.TestCase):
+    def test_complete_packet_passes(self):
+        body = "\n".join(
+            f"## {name}\nvalue"
+            for name in (
+                "Authority",
+                "Dependencies",
+                "Branch and allowlist",
+                "Artifacts",
+                "Acceptance criteria",
+                "Demo Command",
+                "Evidence class",
+                "Stop rule",
+                "Non-claims",
+            )
+        )
+        self.assertEqual(validate_packet(body), [])
+
+    def test_missing_packet_section_is_reported(self):
+        self.assertIn("Stop rule", validate_packet("## Authority\nowner"))
+
+    def test_wip_counts_only_active_lanes(self):
+        items = [
+            {"status": "In Progress"},
+            {"status": "Review"},
+            {"status": "Blocked"},
+            {"status": "Done"},
+        ]
+        self.assertEqual(count_wip(items), 2)
+        self.assertEqual(enforce_wip(items), 2)
+
+    def test_wip_over_limit_fails(self):
+        with self.assertRaisesRegex(AuditError, "limit is 2"):
+            enforce_wip([{"status": "In Progress"}] * 3)
+
+    def test_project_discovery_requires_exactly_one_open_project(self):
+        with self.assertRaisesRegex(AuditError, "found 0"):
+            select_project([])
+        with self.assertRaisesRegex(AuditError, "found 2"):
+            select_project(
+                [
+                    {"owner": {"login": "a"}, "number": 1, "title": "A", "url": "u"},
+                    {"owner": {"login": "a"}, "number": 2, "title": "B", "url": "v"},
+                ]
+            )
+
+    def test_project_discovery_ignores_closed_project(self):
+        project = select_project(
+            [
+                {"owner": {"login": "a"}, "number": 1, "title": "Old", "url": "u", "closed": True},
+                {"owner": {"login": "a"}, "number": 2, "title": "Delivery", "url": "v", "closed": False},
+            ]
+        )
+        self.assertEqual((project.owner, project.number), ("a", 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Tracking and authority

- Work item: Closes #10 (T-0003/S01)
- Authority: repository owner request and the refined Issue #10 packet
- Mutation owner: Project Manager
- Branch and allowlist: `chore/t-0003-governance-enforcement`; only files listed in Issue #10
- Dependencies: T-0002 is Done

## Change

- Artifacts: read-only Project governance audit, unit fixtures, Issue/PR template gates, reconciled records
- Behavior: dynamically discovers exactly one linked open Project; fails closed on ambiguous discovery or WIP above two
- Non-claims: no lifecycle automation, analytics, runtime behavior, compatibility, velocity, or legal claim

## Verification

- Acceptance criteria: live discovery and WIP audit pass; invalid fixtures fail
- Commands and evidence: `python3 scripts/project_governance_audit.py audit` (pass, 52 items, WIP 2/2); `python3 -m unittest tests.test_project_governance_audit` (6 passed); `git diff --check` (pass)
- Stop rule: stop on ambiguous discovery, credential need, WIP conflict, or out-of-allowlist mutation

## Provenance and release impact

- Consulted upstream material: GitHub public API behavior only
- Copied or adapted material: none
- License, NOTICE, SBOM, patent, or trademark review: no product implementation or third-party code admitted