### PR TITLE
research(config): observe Boolean and Long conversion cases

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,8 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0021` and `T-0012/S01` are `In Progress`; and every other item is
-`Backlog`. No item is `Ready`, `Review`, or `Blocked`. This is the two-item
-WIP limit.
+`T-0021` is `In Progress`, `T-0012/S02` is `Review`, and every other item is
+`Backlog`. No item is `Ready` or `Blocked`. This is the two-item WIP limit.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -35,7 +34,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S02: Boolean/Long conversion reference probe; S01 integrated) | In Progress | P0 | 5 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S02: Boolean/Long conversion reference probe; S01 integrated) | Review | P0 | 5 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics | Backlog | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -131,5 +130,6 @@ Maven-style input plugin, rather than assembling the core POM graph. It
 integrated through PR #61 as `e2532e2` after recording nine
 presence/null/default observations. This is Reference Observation / Integration
 evidence only and cannot complete the parent Differential gate. T-0012/S02
-now owns a separate, nine-case Boolean/Long conversion probe. T-0021 and
+owns a separate, nine-case Boolean/Long conversion probe. Its independent
+source acceptance passed at `86970ea`; it awaits PR integration. T-0021 and
 T-0012/S02 occupy the combined `In Progress` plus `Review` WIP limit of two.

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S01: presence reference probe) | In Progress | P0 | 5 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S02: Boolean/Long conversion reference probe; S01 integrated) | In Progress | P0 | 5 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics | Backlog | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -126,8 +126,10 @@ These estimates are within the parent's 5 SP, not additional points or accepted
 velocity. Parent completion retains its listed dependencies.
 
 T-0003 is complete through PR #62, and T-0004/S01 is complete through PR #63.
-T-0012/S01 uses the official self-contained executable through a local-only
-Maven-style input plugin, rather than assembling the core POM graph. It probes
-only presence/null/default behavior from the pinned reference and cannot
-complete the parent Differential gate. T-0021 and T-0012/S01 occupy the
-combined `In Progress` plus `Review` WIP limit of two.
+T-0012/S01 used the official self-contained executable through a local-only
+Maven-style input plugin, rather than assembling the core POM graph. It
+integrated through PR #61 as `e2532e2` after recording nine
+presence/null/default observations. This is Reference Observation / Integration
+evidence only and cannot complete the parent Differential gate. T-0012/S02
+now owns a separate, nine-case Boolean/Long conversion probe. T-0021 and
+T-0012/S02 occupy the combined `In Progress` plus `Review` WIP limit of two.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,9 +27,9 @@ T-0012/S01 gathered a narrow absent/null/default observation via the pinned
 official self-contained executable and a local-only probe plugin. Its annotated
 String/Optional reference observation integrated through PR #61 as `e2532e2`;
 it does not itself satisfy the configuration/schema/value contract or the
-Phase 0 exit gate. T-0012/S02 has a preliminary independent Boolean/Long
-conversion observation awaiting Tester reproduction and likewise cannot satisfy
-that gate without an independently implemented Emburk comparator.
+Phase 0 exit gate. T-0012/S02 has an independently reproduced Boolean/Long
+conversion observation at `86970ea` and awaits PR integration. It likewise
+cannot satisfy that gate without an independently implemented Emburk comparator.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,9 +27,9 @@ T-0012/S01 gathered a narrow absent/null/default observation via the pinned
 official self-contained executable and a local-only probe plugin. Its annotated
 String/Optional reference observation integrated through PR #61 as `e2532e2`;
 it does not itself satisfy the configuration/schema/value contract or the
-Phase 0 exit gate. T-0012/S02 is packeted for an independent Boolean/Long
-conversion observation and likewise cannot satisfy that gate without an
-independently implemented Emburk comparator.
+Phase 0 exit gate. T-0012/S02 has a preliminary independent Boolean/Long
+conversion observation awaiting Tester reproduction and likewise cannot satisfy
+that gate without an independently implemented Emburk comparator.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,11 +23,13 @@ T-0021/S02 supplies the [Rust design worksheet](RUST_RUNTIME_DESIGN.md) for
 configuration/value fixtures and lifecycle/failure traces. Its proposed
 structure does not satisfy this exit gate; T-0012 and T-0013 must resolve the
 reference-dependent questions before semantic APIs are accepted.
-T-0012/S01 is actively gathering a narrow absent/null/default observation via
-the pinned official self-contained executable and a local-only probe plugin.
-Its annotated String/Optional reference observation is complete and awaits
-serial review; it does not itself satisfy the configuration/schema/value
-contract or the Phase 0 exit gate.
+T-0012/S01 gathered a narrow absent/null/default observation via the pinned
+official self-contained executable and a local-only probe plugin. Its annotated
+String/Optional reference observation integrated through PR #61 as `e2532e2`;
+it does not itself satisfy the configuration/schema/value contract or the
+Phase 0 exit gate. T-0012/S02 is packeted for an independent Boolean/Long
+conversion observation and likewise cannot satisfy that gate without an
+independently implemented Emburk comparator.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,7 +24,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021 and T-0012/S01 are the only active work items, meeting the two-item
+T-0021 and T-0012/S02 are the only active work items, meeting the two-item
 combined `In Progress`/`Review` WIP limit. No work item is currently `Ready`,
 `Review`, or `Blocked`.
 
@@ -34,7 +34,7 @@ combined `In Progress`/`Review` WIP limit. No work item is currently `Ready`,
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S01 | In Progress | Local-only probe through the pinned official self-contained executable |
+| T-0012/S02 | In Progress | Local-only Boolean/Long conversion probe through the pinned official executable |
 | T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
@@ -97,9 +97,10 @@ This is Planning evidence only. T-0012/T-0013 contracts and differential
 verification remain prerequisites to completing the parent task.
 
 T-0012/S01 initially diagnosed why the core POM graph cannot initialize its
-configuration delegate; that graph was not expanded. The active, bounded route
-uses the pinned official self-contained executable and a local-only Maven-style
-input plugin, following the executable's normal initialization path. Its nine
-annotated String/Optional fixture cases now pass as Reference Observation /
-Integration evidence. This is not a generic typed-getter contract, a verified
-Emburk semantic, or the parent task's Differential (Embulk) evidence.
+configuration delegate; that graph was not expanded. Its bounded official-
+executable route and local-only Maven-style input plugin recorded nine
+annotated String/Optional fixture observations and integrated through PR #61
+as `e2532e2`. This is Reference Observation / Integration evidence only, not a
+generic typed-getter contract, a verified Emburk semantic, or the parent task's
+Differential (Embulk) evidence. T-0012/S02 is packeted to observe a separate
+Boolean/Long conversion matrix; it has no runtime result yet.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,9 +24,9 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021 and T-0012/S02 are the only active work items, meeting the two-item
-combined `In Progress`/`Review` WIP limit. No work item is currently `Ready`,
-`Review`, or `Blocked`.
+T-0021 (`In Progress`) and T-0012/S02 (`Review`) are the only active work
+items, meeting the two-item combined `In Progress`/`Review` WIP limit. No work
+item is currently `Ready` or `Blocked`.
 
 | Item | State | Purpose |
 |---|---|---|
@@ -34,7 +34,7 @@ combined `In Progress`/`Review` WIP limit. No work item is currently `Ready`,
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S02 | In Progress | Local-only Boolean/Long conversion probe through the pinned official executable |
+| T-0012/S02 | Review | Local-only Boolean/Long conversion probe accepted at `86970ea`; awaits PR integration |
 | T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
@@ -102,6 +102,7 @@ executable route and local-only Maven-style input plugin recorded nine
 annotated String/Optional fixture observations and integrated through PR #61
 as `e2532e2`. This is Reference Observation / Integration evidence only, not a
 generic typed-getter contract, a verified Emburk semantic, or the parent task's
-Differential (Embulk) evidence. T-0012/S02 has a preliminary nine-case
-Boolean/Long runtime observation through the same pinned executable; independent
-Tester reproduction remains required before it is accepted.
+Differential (Embulk) evidence. T-0012/S02 has a nine-case Boolean/Long
+runtime observation through the same pinned executable. An independent
+primary-agent reproduction passed at `86970ea`; this is Review-stage Reference
+Observation / Integration evidence only, pending PR integration.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -102,5 +102,6 @@ executable route and local-only Maven-style input plugin recorded nine
 annotated String/Optional fixture observations and integrated through PR #61
 as `e2532e2`. This is Reference Observation / Integration evidence only, not a
 generic typed-getter contract, a verified Emburk semantic, or the parent task's
-Differential (Embulk) evidence. T-0012/S02 is packeted to observe a separate
-Boolean/Long conversion matrix; it has no runtime result yet.
+Differential (Embulk) evidence. T-0012/S02 has a preliminary nine-case
+Boolean/Long runtime observation through the same pinned executable; independent
+Tester reproduction remains required before it is accepted.

--- a/docs/log/2026-09-05.md
+++ b/docs/log/2026-09-05.md
@@ -158,3 +158,8 @@ lifecycle transition.
   records for invalid Boolean and above-maximum Long. This remains preliminary
   Reference Observation / Integration evidence pending independent Tester
   reproduction at the reviewed commit.
+- Independently reproduced both exact S01 and S02 Demo commands at
+  `86970ea`; both exited 0 and each exercised the checksum-rejection exit 3
+  and unavailable-runtime exit 56 controls. The S02 run emitted all nine
+  `probe config load` rows with exit 0. This accepted source evidence remains
+  Reference Observation / Integration only and awaits PR integration.

--- a/docs/log/2026-09-05.md
+++ b/docs/log/2026-09-05.md
@@ -138,3 +138,17 @@ lifecycle transition.
   repository has no `PROJECTS_TOKEN` secret yet, so no hosted scheduled or
   ready-for-review run is claimed; the owner must add the narrowly scoped
   Project credential before those jobs can succeed.
+
+## T-0012/S01 Closeout and S02 Packet
+
+- Integrated T-0012/S01 through PR #61 as `e2532e2` after the Project Manager
+  manually recorded Review for the partial, non-closing Issue #15 slice.
+  The parent Issue remains open and no parent completion is claimed.
+- Independently reproduced the required Demo Command at `1f2e737` before the
+  documentation-only merge-main revision. It passed its nine required
+  String/Optional observations plus corrupt-copy exit 3 and unavailable-runtime
+  exit 56 controls. This remains Reference Observation / Integration evidence.
+- Prepared T-0012/S02 as a bounded, independently authored Boolean/Long
+  conversion probe. It reuses the pinned official executable route and local
+  test-plugin boundary, records phase without diagnosing an unobserved parser,
+  and does not add Emburk semantics, a product plugin, or a compatibility claim.

--- a/docs/log/2026-09-05.md
+++ b/docs/log/2026-09-05.md
@@ -152,3 +152,9 @@ lifecycle transition.
   conversion probe. It reuses the pinned official executable route and local
   test-plugin boundary, records phase without diagnosing an unobserved parser,
   and does not add Emburk semantics, a product plugin, or a compatibility claim.
+- Ran the S02 candidate's nine cases through the pinned executable. It retained
+  raw local inputs/logs/exits and observed successful Boolean true/false/quoted
+  true and Long 37/quoted 37/maximum/fractional fixtures, plus ConfigException
+  records for invalid Boolean and above-maximum Long. This remains preliminary
+  Reference Observation / Integration evidence pending independent Tester
+  reproduction at the reviewed commit.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -7,4 +7,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | Record | Status |
 | --- | --- |
 | [T-0011 Embulk reference inventory](T-0011-embulk-reference-inventory.md) | Done (Planning evidence) |
-| [T-0012/S01 configuration-presence reference probe](T-0012-config-presence-probe.md) | In Progress |
+| [T-0012/S01 configuration-presence reference probe](T-0012-config-presence-probe.md) | Done (Reference Observation / Integration) |
+| [T-0012/S02 configuration-conversion reference probe](T-0012-config-conversion-probe.md) | In Progress (packet only) |

--- a/docs/provenance/T-0012-config-conversion-probe.md
+++ b/docs/provenance/T-0012-config-conversion-probe.md
@@ -7,11 +7,10 @@
 - Branch: `research/t-0012-config-conversion`
 - Lifecycle owner: Project Manager
 - Mutation owner: Compatibility Host Implementer
-- Required reviewer: Librarian (Vreji), reviewed 2026-09-05; independent Tester
-  review is required before acceptance.
+- Required reviewer: Librarian (Vreji), reviewed 2026-09-05; independent
+  primary-agent reproduction passed on 2026-09-05.
 - Access date: 2026-09-05
-- State: `In Progress` (runtime candidate recorded; independent Tester review
-  remains required before acceptance)
+- State: `Review` (accepted source evidence recorded; PR integration pending)
 
 ## Outcome and boundary
 
@@ -86,7 +85,7 @@ remain unreviewed. The Librarian found no material provenance blocker for this
 observation-only packet, conditional on retaining S01 identity and isolation
 controls. That review is not legal advice or patent/FTO clearance.
 
-## Preliminary runtime evidence
+## Runtime evidence
 
 - Command: `tests/t0012_config_conversion_probe_test.sh` exited 0 on
   2026-09-05 after `bash -n` also checked the S01 runner and both Demo scripts.
@@ -98,7 +97,8 @@ controls. That review is not legal advice or patent/FTO clearance.
   `a0ea3894e9674e2129c3495557adace6ef2fb6d3c813e142dba0922e2375fb3d`;
   generated JAR SHA-256:
   `43918a93153a3bb295bf84092dcc8dc35f8c27bd7ed0a4dac2aac664d90aa114`.
-  Both are external temporary artifacts and are not distributed.
+  The independently authored source is tracked in this repository; only the
+  generated JAR is an external temporary artifact and is not distributed.
 - All nine case records reached `probe config load` with exit 0. Within this
   pinned fixture, Boolean true/false and quoted true succeeded; invalid Boolean
   recorded a `ConfigException`; Long 37, quoted 37, maximum Long, and
@@ -106,10 +106,13 @@ controls. That review is not legal advice or patent/FTO clearance.
   above-maximum Long recorded a `ConfigException`. Raw exception messages,
   inputs, exits, and logs remain local because they may include personal paths.
 
-This is preliminary Reference Observation / Integration evidence only. It is
-not accepted until an independent Tester reproduces the Demo Command at the
-reviewed commit. The listed outcomes do not establish general conversion,
-rounding, default, parser-cause, or Emburk behavior.
+An independent primary-agent reproduction ran both exact Demo commands at
+`86970ea4064a64260bfa2863c68a200bf15ce1fb` on 2026-09-05. Both exited 0 with
+their checksum and unavailable-runtime controls exiting 3 and 56; it recorded
+nine S02 rows at `probe config load` with exit 0. The source evidence is
+accepted as Reference Observation / Integration only; PR integration remains
+required before this slice can be closed. The listed outcomes do not establish
+general conversion, rounding, default, parser-cause, or Emburk behavior.
 
 ## Stop rule and non-claims
 

--- a/docs/provenance/T-0012-config-conversion-probe.md
+++ b/docs/provenance/T-0012-config-conversion-probe.md
@@ -10,7 +10,8 @@
 - Required reviewer: Librarian (Vreji), reviewed 2026-09-05; independent Tester
   review is required before acceptance.
 - Access date: 2026-09-05
-- State: `In Progress` (packet prepared; no runtime observation yet)
+- State: `In Progress` (runtime candidate recorded; independent Tester review
+  remains required before acceptance)
 
 ## Outcome and boundary
 
@@ -84,6 +85,31 @@ redistribution, security, patent/standards, and freedom-to-operate questions
 remain unreviewed. The Librarian found no material provenance blocker for this
 observation-only packet, conditional on retaining S01 identity and isolation
 controls. That review is not legal advice or patent/FTO clearance.
+
+## Preliminary runtime evidence
+
+- Command: `tests/t0012_config_conversion_probe_test.sh` exited 0 on
+  2026-09-05 after `bash -n` also checked the S01 runner and both Demo scripts.
+  The unchanged S01 Demo Command passed in the same candidate run. The S02
+  corrupt-copy and unavailable-runtime controls exited 3 and 56 respectively.
+- Environment: Temurin Java 17.0.20 on macOS arm64. The pinned executable hash
+  remained `e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`.
+- Generated local test-plugin source SHA-256:
+  `a0ea3894e9674e2129c3495557adace6ef2fb6d3c813e142dba0922e2375fb3d`;
+  generated JAR SHA-256:
+  `43918a93153a3bb295bf84092dcc8dc35f8c27bd7ed0a4dac2aac664d90aa114`.
+  Both are external temporary artifacts and are not distributed.
+- All nine case records reached `probe config load` with exit 0. Within this
+  pinned fixture, Boolean true/false and quoted true succeeded; invalid Boolean
+  recorded a `ConfigException`; Long 37, quoted 37, maximum Long, and
+  fractional 37.5 succeeded (the fractional observation rendered 37); and an
+  above-maximum Long recorded a `ConfigException`. Raw exception messages,
+  inputs, exits, and logs remain local because they may include personal paths.
+
+This is preliminary Reference Observation / Integration evidence only. It is
+not accepted until an independent Tester reproduces the Demo Command at the
+reviewed commit. The listed outcomes do not establish general conversion,
+rounding, default, parser-cause, or Emburk behavior.
 
 ## Stop rule and non-claims
 

--- a/docs/provenance/T-0012-config-conversion-probe.md
+++ b/docs/provenance/T-0012-config-conversion-probe.md
@@ -1,0 +1,97 @@
+# T-0012/S02 configuration-conversion reference probe
+
+- Tracking issue: [#15](https://github.com/bhind/emburk/issues/15)
+- Parent work item: `T-0012`; S02 is an independently acceptable
+  reference-observation slice and does not replace its Differential (Embulk)
+  evidence gate.
+- Branch: `research/t-0012-config-conversion`
+- Lifecycle owner: Project Manager
+- Mutation owner: Compatibility Host Implementer
+- Required reviewer: Librarian (Vreji), reviewed 2026-09-05; independent Tester
+  review is required before acceptance.
+- Access date: 2026-09-05
+- State: `In Progress` (packet prepared; no runtime observation yet)
+
+## Outcome and boundary
+
+Record nine independently authored observations of a pinned Embulk loader's
+handling of selected annotated Boolean and Long values. Each isolated fixture
+must preserve the raw result or exception, process exit, and an observable
+phase marker. `probe config load` means the local test plugin emitted its marker
+while loading its annotated configuration; `before probe callback` means no
+such marker was emitted and the raw process log/exit is retained. The latter is
+an observation label, not a claim that a YAML or CLI parser caused the result.
+
+This slice deliberately excludes absent, explicit-null, and default behavior;
+S01 already observed those states only for String/Optional fixtures. It does
+not establish Boolean/Long defaults, primitive-versus-boxed behavior, a generic
+typed-getter contract, Emburk behavior, or a complete configuration contract.
+
+## Matrix and acceptance
+
+The runner must execute the following nine isolated configurations with a
+required annotated `Boolean` or `Long` field, retaining each raw input spelling
+in local evidence:
+
+| Case | Field type | YAML value | Permitted observation phase |
+| --- | --- | --- | --- |
+| `boolean-true` | `Boolean` | `true` | probe config load |
+| `boolean-false` | `Boolean` | `false` | probe config load |
+| `boolean-quoted-true` | `Boolean` | `"true"` | probe config load |
+| `boolean-invalid` | `Boolean` | `not-boolean` | probe config load |
+| `long-37` | `Long` | `37` | probe config load |
+| `long-quoted-37` | `Long` | `"37"` | probe config load |
+| `long-max` | `Long` | `9223372036854775807` | probe config load |
+| `long-fractional` | `Long` | `37.5` | probe config load |
+| `long-overflow` | `Long` | `9223372036854775808` | probe config load or before probe callback |
+
+The required Demo Command will be
+`tests/t0012_config_conversion_probe_test.sh`. It must invoke the runtime
+probe, validate nine unique complete case records, retain per-case raw logs and
+process exits, and prove known controls `boolean-true` and `long-37` reached
+`probe config load` successfully. A permitted `before probe callback` record
+is valid only for `long-overflow` with a nonzero process exit and retained raw
+log; it must not turn a global startup/linkage failure into nine accepted case
+records. Existing S01 Demo behavior must remain unchanged. Corrupt-checksum and
+unavailable-runtime controls must still reject before semantic observations.
+
+The implementation allowlist is limited to:
+
+- `tools/t0012-config-presence/run.sh`;
+- `tools/t0012-config-presence/src/T0012InputPlugin.java`;
+- `tests/t0012_config_conversion_probe_test.sh`;
+- `TODO.md`, `docs/STATUS.md`, `docs/ROADMAP.md`, `docs/log/2026-09-05.md`, and
+  `docs/provenance/` for this packet and results.
+
+No Rust production code, Cargo manifest, upstream source or test, executable
+binary, generated plugin JAR, raw output, credentials, or product plugin may be
+committed. The runner must keep all downloads and evidence in a safe external
+temporary directory. The official executable and generated test plugin remain
+local runtime artifacts only.
+
+## Reference locators, rights, and reuse decision
+
+| Reference | Immutable locator | Observation use | Reuse decision |
+| --- | --- | --- | --- |
+| Core annotations and task API | Embulk v0.11.5 commit `c5ac2d471edac465b45088669d376a7e2a525f8f`: `embulk-core/src/main/java/org/embulk/config/Config.java`, `ConfigDefault.java`, `Task.java`, and `ModelManager.java` | Locate public annotation syntax and task/configuration entry points | Interface observation only; no source text, implementation, test, or vector is reused. |
+| Plugin lifecycle | Embulk SPI v0.11 commit `576e98033a14ba8ac994ed581d3c9d8fcdda2749`: `src/main/java/org/embulk/spi/InputPlugin.java` | Locate public input-plugin lifecycle signatures for the local test plugin | Interface observation only; no source text or implementation is reused. |
+| Executable route | Official v0.11.5 executable `https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar`, SHA-256 `e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`, manifest `Main-Class: org.embulk.cli.Main`, embedded `META-INF/LICENSE` and `META-INF/NOTICE` | Same pinned local-runtime route as S01 | Download for local execution only; no artifact redistribution. |
+
+The core and SPI source licenses are Apache-2.0, as recorded in T-0011. The
+downloaded executable's embedded NOTICE and licenses are evidence locators, not
+an admission of every bundled dependency. Transitive runtime licensing,
+redistribution, security, patent/standards, and freedom-to-operate questions
+remain unreviewed. The Librarian found no material provenance blocker for this
+observation-only packet, conditional on retaining S01 identity and isolation
+controls. That review is not legal advice or patent/FTO clearance.
+
+## Stop rule and non-claims
+
+Retain ordinary retrieval, compilation, startup, linkage, and case failures
+with their exact local evidence and repair only the bounded harness when safe.
+Stop scope expansion for a material license, NOTICE, redistribution,
+reimplementation-boundary, or security uncertainty, or before any Rust
+semantic implementation, upstream build, external plugin admission, or artifact
+redistribution. A successful upstream-only run remains Reference Observation /
+Integration evidence, never Differential evidence or an Emburk compatibility
+claim.

--- a/docs/provenance/T-0012-config-presence-probe.md
+++ b/docs/provenance/T-0012-config-presence-probe.md
@@ -9,8 +9,8 @@
 - Required reviewer: Librarian (Vreji), reviewed 2026-09-05; Project Manager
   independently reproduced the Demo Command at `1f2e737` on 2026-09-05
 - Access date: 2026-09-05
-- State: `In Progress`; the core-POM diagnosis is retained, while the active
-  route uses the official self-contained executable's normal initialization.
+- State: `Done` as a slice; integrated through PR #61 as
+  `e2532e245bff8114d075c8f35e9871d889d717a3`. The parent T-0012 remains open.
 
 ## Outcome and boundary
 
@@ -117,6 +117,10 @@ request head and acceptance evidence are reconciled.
 - Demo Command: `tests/t0012_config_presence_probe_test.sh` passed at
   `1f2e73767d6091375c89b7355b2a44d24f3495c2` on 2026-09-05; corrupt-copy
   checksum rejection exited 3 and unavailable-asset retrieval exited 56.
+- Integration: PR #61 was manually moved to Review because it references,
+  rather than closes, parent Issue #15. It was then squash-merged as
+  `e2532e245bff8114d075c8f35e9871d889d717a3`; Issue #15 remains open for
+  subsequent slices.
 - Environment: Temurin Java 17.0.20 on macOS arm64.
 - Official executable: v0.11.5 asset URL recorded above; SHA-256
   `e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`;

--- a/tests/t0012_config_conversion_probe_test.sh
+++ b/tests/t0012_config_conversion_probe_test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+runner="$repository_root/tools/t0012-config-presence/run.sh"
+[[ -x "$runner" ]] || {
+  printf 'runner is not executable: %s\n' "$runner" >&2
+  exit 2
+}
+
+run_negative_control() {
+  local control=$1 expected_exit=$2 output actual_exit
+  if output=$(T0012_MODE=conversion T0012_NEGATIVE="$control" "$runner" 2>&1); then
+    printf 'negative control unexpectedly passed: %s\n' "$control" >&2
+    exit 1
+  else
+    actual_exit=$?
+  fi
+  [[ "$actual_exit" == "$expected_exit" ]] || {
+    printf 'negative control %s exited %s; expected %s\n' "$control" "$actual_exit" "$expected_exit" >&2
+    exit 1
+  }
+  printf '%s\n' "$output"
+}
+
+corrupt_output=$(run_negative_control corrupt-hash 3)
+corrupt_evidence=$(printf '%s\n' "$corrupt_output" | sed -n 's/^T0012_EVIDENCE_DIR=//p' | tail -1)
+[[ -s "$corrupt_evidence/negative-control.txt" ]]
+grep -Fxq 'corrupt-copy-injected' "$corrupt_evidence/negative-control.txt"
+run_negative_control unavailable-runtime 56 >/dev/null
+
+output=$(T0012_MODE=conversion "$runner")
+printf '%s\n' "$output"
+evidence_dir=$(printf '%s\n' "$output" | sed -n 's/^T0012_EVIDENCE_DIR=//p' | tail -1)
+case_rows=$(printf '%s\n' "$output" | grep '^CONVERSION_CASE|' || true)
+[[ $(printf '%s\n' "$case_rows" | sed '/^$/d' | wc -l | tr -d ' ') == 9 ]]
+
+for file in executable-url.txt executable.sha256 executable-manifest.txt LICENSE-executable NOTICE-executable java-version.txt os-family.txt plugin-source.sha256 plugin-jar.sha256 plugin-coordinate.txt observations.raw.bin conversion-cases.raw conversion-results.raw; do
+  [[ -s "$evidence_dir/$file" ]]
+done
+grep -Fxq 'e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47' "$evidence_dir/executable.sha256"
+
+for case_name in boolean-true boolean-false boolean-quoted-true boolean-invalid long-37 long-quoted-37 long-max long-fractional long-overflow; do
+  [[ $(grep -Ec "^CONVERSION_CASE\\|$case_name\\|" "$evidence_dir/conversion-cases.raw") == 1 ]]
+  [[ -s "$evidence_dir/$case_name.raw.log" ]]
+  [[ -s "$evidence_dir/$case_name.input.yml-value" ]]
+done
+grep -Eq '^CONVERSION_CASE\|(boolean-true|boolean-false|boolean-quoted-true|boolean-invalid)\|boolean\|probe config load\|[0-9]+$' "$evidence_dir/conversion-cases.raw"
+grep -Eq '^CONVERSION_CASE\|(long-37|long-quoted-37|long-max|long-fractional)\|long\|probe config load\|[0-9]+$' "$evidence_dir/conversion-cases.raw"
+grep -Eq '^CONVERSION_CASE\|long-overflow\|long\|(probe config load\|[0-9]+|before probe callback\|[1-9][0-9]*)$' "$evidence_dir/conversion-cases.raw"
+grep -Fqx 'CONVERSION_CASE|boolean-true|boolean|probe config load|0' "$evidence_dir/conversion-cases.raw"
+grep -Fqx 'CONVERSION_CASE|long-37|long|probe config load|0' "$evidence_dir/conversion-cases.raw"
+grep -Fqx 'CONVERSION_CASE|boolean|boolean-true|SUCCESS|dHJ1ZQ==|' "$evidence_dir/conversion-results.raw"
+grep -Fqx 'CONVERSION_CASE|long|long-37|SUCCESS|Mzc=|' "$evidence_dir/conversion-results.raw"

--- a/tools/t0012-config-presence/run.sh
+++ b/tools/t0012-config-presence/run.sh
@@ -81,43 +81,116 @@ printf '%s\n' '<project><modelVersion>4.0.0</modelVersion><groupId>org.embulk.t0
 shasum -a 256 "$plugin_jar" | awk '{print $1}' > "$evidence_dir/plugin-jar.sha256"
 printf '%s\n' 'source=maven|group=org.embulk.t0012|name=t0012|version=0.0.1|artifact=embulk-input-t0012|local-only' > "$evidence_dir/plugin-coordinate.txt"
 
-: > "$evidence_dir/observations.raw.bin"
-: > "$evidence_dir/probe-output.raw"
-for declaration in required defaulted optional; do
-  for state in absent null value; do
-    config_file="$run_dir/$declaration-$state.yml"
-    {
-      printf '%s\n' 'in:' '  type:' '    source: maven' '    group: org.embulk.t0012' '    name: t0012' '    version: 0.0.1'
-      if [[ "$state" != absent ]]; then
-        [[ "$state" == null ]] && printf '%s\n' '  field: null' || printf '%s\n' '  field: observed-value'
-      fi
-      printf '%s\n' 'out:' '  type: "null"'
-    } > "$config_file"
-    T0012_DECLARATION="$declaration" T0012_STATE="$state" T0012_RAW_FILE="$evidence_dir/observations.raw.bin" \
-      java -jar "$executable" "-Xembulk_home=$EMBULK_HOME" run "$config_file" >> "$evidence_dir/probe-output.raw" 2>&1
+run_presence() {
+  : > "$evidence_dir/observations.raw.bin"
+  : > "$evidence_dir/probe-output.raw"
+  for declaration in required defaulted optional; do
+    for state in absent null value; do
+      config_file="$run_dir/$declaration-$state.yml"
+      {
+        printf '%s\n' 'in:' '  type:' '    source: maven' '    group: org.embulk.t0012' '    name: t0012' '    version: 0.0.1'
+        if [[ "$state" != absent ]]; then
+          [[ "$state" == null ]] && printf '%s\n' '  field: null' || printf '%s\n' '  field: observed-value'
+        fi
+        printf '%s\n' 'out:' '  type: "null"'
+      } > "$config_file"
+      T0012_DECLARATION="$declaration" T0012_STATE="$state" T0012_RAW_FILE="$evidence_dir/observations.raw.bin" \
+        java -jar "$executable" "-Xembulk_home=$EMBULK_HOME" run "$config_file" >> "$evidence_dir/probe-output.raw" 2>&1
+    done
   done
-done
 
-grep '^CASE|' "$evidence_dir/probe-output.raw" > "$evidence_dir/cases.raw" || true
-case_count=$(wc -l < "$evidence_dir/cases.raw" | tr -d ' ')
-if [[ "$case_count" != 9 ]]; then
-  printf 'expected 9 complete runtime case rows, found %s\n' "$case_count" >&2
-  exit 4
-fi
-if grep -Ev '^CASE\|(required|defaulted|optional)\|(absent|null|value)\|(SUCCESS|EXCEPTION)\|([A-Za-z0-9+/=]*|-)\|([A-Za-z0-9+/=]*|-)$' "$evidence_dir/cases.raw" > /dev/null; then
-  printf '%s\n' 'one or more case rows is incomplete' >&2
-  exit 4
-fi
-for key in required:absent required:null required:value defaulted:absent defaulted:null defaulted:value optional:absent optional:null optional:value; do
-  declaration=${key%%:*}
-  state=${key##*:}
-  if [[ $(grep -Ec "^CASE\\|$declaration\\|$state\\|" "$evidence_dir/cases.raw") != 1 ]]; then
-    printf 'missing or duplicate case key: %s\n' "$key" >&2
+  grep '^CASE|' "$evidence_dir/probe-output.raw" > "$evidence_dir/cases.raw" || true
+  case_count=$(wc -l < "$evidence_dir/cases.raw" | tr -d ' ')
+  if [[ "$case_count" != 9 ]]; then
+    printf 'expected 9 complete runtime case rows, found %s\n' "$case_count" >&2
     exit 4
   fi
-done
-grep -Fqx 'CASE|required|value|SUCCESS|b2JzZXJ2ZWQtdmFsdWU=|' "$evidence_dir/cases.raw"
-grep -Fqx 'CASE|defaulted|value|SUCCESS|b2JzZXJ2ZWQtdmFsdWU=|' "$evidence_dir/cases.raw"
-grep -Fqx 'CASE|optional|value|SUCCESS|cHJlc2VudDpvYnNlcnZlZC12YWx1ZQ==|' "$evidence_dir/cases.raw"
-[[ -s "$evidence_dir/observations.raw.bin" ]] || exit 4
-cat "$evidence_dir/cases.raw"
+  if grep -Ev '^CASE\|(required|defaulted|optional)\|(absent|null|value)\|(SUCCESS|EXCEPTION)\|([A-Za-z0-9+/=]*|-)\|([A-Za-z0-9+/=]*|-)$' "$evidence_dir/cases.raw" > /dev/null; then
+    printf '%s\n' 'one or more case rows is incomplete' >&2
+    exit 4
+  fi
+  for key in required:absent required:null required:value defaulted:absent defaulted:null defaulted:value optional:absent optional:null optional:value; do
+    declaration=${key%%:*}
+    state=${key##*:}
+    if [[ $(grep -Ec "^CASE\\|$declaration\\|$state\\|" "$evidence_dir/cases.raw") != 1 ]]; then
+      printf 'missing or duplicate case key: %s\n' "$key" >&2
+      exit 4
+    fi
+  done
+  grep -Fqx 'CASE|required|value|SUCCESS|b2JzZXJ2ZWQtdmFsdWU=|' "$evidence_dir/cases.raw"
+  grep -Fqx 'CASE|defaulted|value|SUCCESS|b2JzZXJ2ZWQtdmFsdWU=|' "$evidence_dir/cases.raw"
+  grep -Fqx 'CASE|optional|value|SUCCESS|cHJlc2VudDpvYnNlcnZlZC12YWx1ZQ==|' "$evidence_dir/cases.raw"
+  [[ -s "$evidence_dir/observations.raw.bin" ]] || exit 4
+  cat "$evidence_dir/cases.raw"
+}
+
+run_conversion() {
+  : > "$evidence_dir/observations.raw.bin"
+  : > "$evidence_dir/conversion-cases.raw"
+  local cases=(
+    'boolean|boolean-true|true'
+    'boolean|boolean-false|false'
+    'boolean|boolean-quoted-true|"true"'
+    'boolean|boolean-invalid|not-boolean'
+    'long|long-37|37'
+    'long|long-quoted-37|"37"'
+    'long|long-max|9223372036854775807'
+    'long|long-fractional|37.5'
+    'long|long-overflow|9223372036854775808'
+  )
+  local entry type case_name value config_file raw_log exit_code marker row phase
+  for entry in "${cases[@]}"; do
+    IFS='|' read -r type case_name value <<< "$entry"
+    config_file="$run_dir/$case_name.yml"
+    raw_log="$evidence_dir/$case_name.raw.log"
+    {
+      printf '%s\n' 'in:' '  type:' '    source: maven' '    group: org.embulk.t0012' '    name: t0012' '    version: 0.0.1'
+      printf '  field: %s\n' "$value"
+      printf '%s\n' 'out:' '  type: "null"'
+    } > "$config_file"
+    printf '%s\n' "$value" > "$evidence_dir/$case_name.input.yml-value"
+    if T0012_MODE=conversion T0012_TYPE="$type" T0012_CASE="$case_name" T0012_RAW_FILE="$evidence_dir/observations.raw.bin" \
+      java -jar "$executable" "-Xembulk_home=$EMBULK_HOME" run "$config_file" > "$raw_log" 2>&1; then
+      exit_code=0
+    else
+      exit_code=$?
+    fi
+    marker=$(grep -Ec '^probe config load$' "$raw_log" || true)
+    row=$(grep '^CONVERSION_CASE|' "$raw_log" || true)
+    if [[ "$marker" == 1 && "$exit_code" == 0 \
+      && $(printf '%s\n' "$row" | sed '/^$/d' | wc -l | tr -d ' ') == 1 \
+      && "$row" =~ ^CONVERSION_CASE\|$type\|$case_name\|(SUCCESS\|([A-Za-z0-9+/=]*|-)\|([A-Za-z0-9+/=]*|-)|EXCEPTION\|([A-Za-z0-9+/=]+|-)\|([A-Za-z0-9+/=]*|-))$ ]]; then
+      phase='probe config load'
+      printf 'CONVERSION_CASE|%s|%s|%s|%s\n' "$case_name" "$type" "$phase" "$exit_code" >> "$evidence_dir/conversion-cases.raw"
+      printf '%s\n' "$row" >> "$evidence_dir/conversion-results.raw"
+    elif [[ "$case_name" == long-overflow && "$marker" == 0 && "$exit_code" != 0 ]]; then
+      phase='before probe callback'
+      printf 'CONVERSION_CASE|%s|%s|%s|%s\n' "$case_name" "$type" "$phase" "$exit_code" >> "$evidence_dir/conversion-cases.raw"
+      printf 'NO_PLUGIN_RESULT|%s\n' "$case_name" >> "$evidence_dir/conversion-results.raw"
+    else
+      printf 'invalid conversion observation for %s (marker=%s exit=%s rows=%s)\n' \
+        "$case_name" "$marker" "$exit_code" "$(printf '%s\n' "$row" | sed '/^$/d' | wc -l | tr -d ' ')" >&2
+      exit 4
+    fi
+  done
+  if [[ $(wc -l < "$evidence_dir/conversion-cases.raw" | tr -d ' ') != 9 ]]; then
+    printf '%s\n' 'expected 9 complete conversion case rows' >&2
+    exit 4
+  fi
+  for case_name in boolean-true boolean-false boolean-quoted-true boolean-invalid long-37 long-quoted-37 long-max long-fractional long-overflow; do
+    [[ $(grep -Ec "^CONVERSION_CASE\\|$case_name\\|" "$evidence_dir/conversion-cases.raw") == 1 ]] || exit 4
+  done
+  [[ $(wc -l < "$evidence_dir/conversion-results.raw" | tr -d ' ') == 9 ]] || exit 4
+  grep -Fqx 'CONVERSION_CASE|boolean-true|boolean|probe config load|0' "$evidence_dir/conversion-cases.raw"
+  grep -Fqx 'CONVERSION_CASE|long-37|long|probe config load|0' "$evidence_dir/conversion-cases.raw"
+  grep -Fqx 'CONVERSION_CASE|boolean|boolean-true|SUCCESS|dHJ1ZQ==|' "$evidence_dir/conversion-results.raw"
+  grep -Fqx 'CONVERSION_CASE|long|long-37|SUCCESS|Mzc=|' "$evidence_dir/conversion-results.raw"
+  [[ -s "$evidence_dir/observations.raw.bin" ]] || exit 4
+  cat "$evidence_dir/conversion-cases.raw"
+}
+
+case ${T0012_MODE:-presence} in
+  presence) run_presence ;;
+  conversion) run_conversion ;;
+  *) printf 'unknown T0012_MODE: %s\n' "${T0012_MODE}" >&2; exit 2 ;;
+esac

--- a/tools/t0012-config-presence/src/T0012InputPlugin.java
+++ b/tools/t0012-config-presence/src/T0012InputPlugin.java
@@ -20,7 +20,7 @@ import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
 
 /**
- * Test-only local input plugin for the T-0012/S01 presence-observation matrix.
+ * Test-only local input plugin for the T-0012/S01 and S02 observation matrices.
  * It is neither distributed nor an admitted Embulk plugin.
  */
 public final class T0012InputPlugin implements InputPlugin {
@@ -41,10 +41,24 @@ public final class T0012InputPlugin implements InputPlugin {
         Optional<String> getField();
     }
 
+    public interface BooleanField extends Task {
+        @Config("field")
+        Boolean getField();
+    }
+
+    public interface LongField extends Task {
+        @Config("field")
+        Long getField();
+    }
+
     @Override
     public ConfigDiff transaction(ConfigSource config, Control control) {
         String declaration = System.getenv("T0012_DECLARATION");
         String state = System.getenv("T0012_STATE");
+        if ("conversion".equals(System.getenv("T0012_MODE"))) {
+            observeConversion(config, control, System.getenv("T0012_TYPE"), System.getenv("T0012_CASE"));
+            return Exec.newConfigDiff();
+        }
         String outcome;
         String first;
         String message;
@@ -111,6 +125,50 @@ public final class T0012InputPlugin implements InputPlugin {
         throw new IllegalArgumentException("unknown declaration: " + declaration);
     }
 
+    private static void observeConversion(ConfigSource config, Control control, String type, String caseName) {
+        String outcome;
+        String first;
+        String message;
+        Class<? extends Task> configurationType = conversionType(type);
+        System.out.println("probe config load");
+        try {
+            Object value = configurationType.getMethod("getField").invoke(config.loadConfig(configurationType));
+            outcome = "SUCCESS";
+            first = renderValue(value);
+            message = "";
+        } catch (InvocationTargetException failure) {
+            Throwable cause = failure.getCause();
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            if (!(cause instanceof RuntimeException)) {
+                throw new IllegalStateException(cause);
+            }
+            outcome = "EXCEPTION";
+            first = cause.getClass().getName();
+            message = cause.getMessage();
+        } catch (RuntimeException failure) {
+            outcome = "EXCEPTION";
+            first = failure.getClass().getName();
+            message = failure.getMessage();
+        } catch (ReflectiveOperationException failure) {
+            throw new IllegalStateException(failure);
+        }
+
+        emitConversion(type, caseName, outcome, first, message);
+        control.run(Exec.newTaskSource(), Schema.builder().build(), 1);
+    }
+
+    private static Class<? extends Task> conversionType(String type) {
+        if ("boolean".equals(type)) {
+            return BooleanField.class;
+        }
+        if ("long".equals(type)) {
+            return LongField.class;
+        }
+        throw new IllegalArgumentException("unknown conversion type: " + type);
+    }
+
     private static String renderValue(Object value) {
         if (value instanceof Optional) {
             Optional<?> optional = (Optional<?>) value;
@@ -122,6 +180,12 @@ public final class T0012InputPlugin implements InputPlugin {
     private static void emit(String declaration, String state, String outcome, String first, String message) {
         writeRawObservation(declaration, state, outcome, first, message);
         System.out.println("CASE|" + declaration + "|" + state + "|" + outcome + "|"
+                + encode(first) + "|" + encode(message));
+    }
+
+    private static void emitConversion(String type, String caseName, String outcome, String first, String message) {
+        writeRawObservation(type, caseName, outcome, first, message);
+        System.out.println("CONVERSION_CASE|" + type + "|" + caseName + "|" + outcome + "|"
                 + encode(first) + "|" + encode(message));
     }
 


### PR DESCRIPTION
Refs #15. T-0012/S02 extends the existing local-only reference-probe route with exactly nine annotated Boolean/Long conversion fixtures and preserves S01 as the default mode.

Accepted source evidence at `86970ea`, with documentation-only reconciliation at `fa3bda5`: independent primary-agent reproduction ran both S01 and S02 Demo commands successfully. S02 asserts known Boolean true and Long 37 values, retains per-case raw inputs/logs/exits, accepts a no-marker nonzero result only for long-overflow, and exercises corrupt-checksum (exit 3) and unavailable-runtime (exit 56) controls.

This is Review-stage Reference Observation / Integration evidence only. It does not implement Emburk semantics, establish generic conversion/default/parser behavior, admit a product plugin, verify compatibility, or clear licensing, redistribution, security, patent, or FTO questions. This partial slice references rather than closes parent Issue #15; its Project Review transition is manually recorded.