### PR TITLE
feat(core): add private raw scalar resolution

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,8 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0021` is `In Progress`, `T-0012/S03` is `Ready`, and every other item is
-`Backlog`. No item is `Review` or `Blocked`. This is within the two-item WIP
-limit.
+`T-0021` and `T-0012/S03` are `In Progress`, and every other item is
+`Backlog`. No item is `Review` or `Blocked`. This is the two-item WIP limit.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -35,7 +34,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S03: internal raw scalar resolution; S01/S02 integrated) | Ready | P0 | 5 | T-0011 | Rust Core Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S03: internal raw scalar resolution; S01/S02 integrated) | In Progress | P0 | 5 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics | Backlog | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,8 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0021` and `T-0012/S03` are `In Progress`, and every other item is
-`Backlog`. No item is `Review` or `Blocked`. This is the two-item WIP limit.
+`T-0021` is `In Progress`, `T-0012/S03` is `Review`, and every other item is
+`Backlog`. No item is `Blocked`. This is the two-item WIP limit.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -34,7 +34,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S03: internal raw scalar resolution; S01/S02 integrated) | In Progress | P0 | 5 | T-0011 | Rust Core Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S03: internal raw scalar resolution; S01/S02 integrated) | Review | P0 | 5 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics | Backlog | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0021` is `In Progress`, `T-0012/S02` is `Review`, and every other item is
+`T-0021` and `T-0012/S03` are `In Progress`, and every other item is
 `Backlog`. No item is `Ready` or `Blocked`. This is the two-item WIP limit.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -34,7 +34,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S02: Boolean/Long conversion reference probe; S01 integrated) | Review | P0 | 5 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S03: internal raw scalar resolution; S01/S02 integrated) | In Progress | P0 | 5 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics | Backlog | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -130,6 +130,8 @@ Maven-style input plugin, rather than assembling the core POM graph. It
 integrated through PR #61 as `e2532e2` after recording nine
 presence/null/default observations. This is Reference Observation / Integration
 evidence only and cannot complete the parent Differential gate. T-0012/S02
-owns a separate, nine-case Boolean/Long conversion probe. Its independent
-source acceptance passed at `86970ea`; it awaits PR integration. T-0021 and
-T-0012/S02 occupy the combined `In Progress` plus `Review` WIP limit of two.
+owned a separate, nine-case Boolean/Long conversion probe. It integrated
+through PR #65 as `d7b4838`. T-0012/S03 now owns a bounded original-Rust raw
+scalar resolver and project-owned contract tests. It is Unit/Contract work,
+not a Differential claim. T-0021 and T-0012/S03 occupy the combined `In
+Progress` plus `Review` WIP limit of two.

--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,9 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0021` and `T-0012/S03` are `In Progress`, and every other item is
-`Backlog`. No item is `Ready` or `Blocked`. This is the two-item WIP limit.
+`T-0021` is `In Progress`, `T-0012/S03` is `Ready`, and every other item is
+`Backlog`. No item is `Review` or `Blocked`. This is within the two-item WIP
+limit.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -34,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S03: internal raw scalar resolution; S01/S02 integrated) | In Progress | P0 | 5 | T-0011 | Rust Core Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S03: internal raw scalar resolution; S01/S02 integrated) | Ready | P0 | 5 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics | Backlog | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -1,5 +1,12 @@
 #![forbid(unsafe_code)]
 
+// This is deliberately private until a later packet authorizes an API consumer.
+#[allow(
+    dead_code,
+    reason = "T-0012/S03 is an internal resolver without a public consumer"
+)]
+mod scalar_resolution;
+
 pub const DEVELOPMENT_STATUS: &str =
     "emburk: development environment ready (data transfer not implemented yet)";
 

--- a/crates/emburk-core/src/scalar_resolution.rs
+++ b/crates/emburk-core/src/scalar_resolution.rs
@@ -69,6 +69,8 @@ enum ScalarResolution {
     OptionalString(Option<String>),
     Boolean(bool),
     I64(i64),
+    MissingRequired,
+    NullNotAllowed,
     Unsupported {
         raw: RawScalarKind,
         requested: ScalarRequestKind,
@@ -77,6 +79,8 @@ enum ScalarResolution {
 
 fn resolve(raw: RawScalar, request: ScalarRequest) -> ScalarResolution {
     match (raw, request) {
+        (RawScalar::Missing, ScalarRequest::RequiredString) => ScalarResolution::MissingRequired,
+        (RawScalar::Null, ScalarRequest::RequiredString) => ScalarResolution::NullNotAllowed,
         (RawScalar::String(value), ScalarRequest::RequiredString) => {
             ScalarResolution::String(value)
         }
@@ -86,6 +90,7 @@ fn resolve(raw: RawScalar, request: ScalarRequest) -> ScalarResolution {
         (RawScalar::String(value), ScalarRequest::DefaultString { .. }) => {
             ScalarResolution::String(value)
         }
+        (RawScalar::Null, ScalarRequest::DefaultString { .. }) => ScalarResolution::NullNotAllowed,
         (RawScalar::Missing | RawScalar::Null, ScalarRequest::OptionalStringNullDefault) => {
             ScalarResolution::OptionalString(None)
         }
@@ -128,6 +133,29 @@ mod tests {
             ),
             ScalarResolution::String(defaulted)
         );
+        assert_eq!(
+            resolve(
+                RawScalar::String(String::new()),
+                ScalarRequest::RequiredString
+            ),
+            ScalarResolution::String(String::new())
+        );
+        assert_eq!(
+            resolve(
+                RawScalar::String(String::new()),
+                ScalarRequest::DefaultString {
+                    value: "fallback".to_owned(),
+                },
+            ),
+            ScalarResolution::String(String::new())
+        );
+        assert_eq!(
+            resolve(
+                RawScalar::String(String::new()),
+                ScalarRequest::OptionalStringNullDefault,
+            ),
+            ScalarResolution::OptionalString(Some(String::new()))
+        );
     }
 
     #[test]
@@ -142,10 +170,7 @@ mod tests {
         );
         assert_eq!(
             resolve(RawScalar::Null, request),
-            ScalarResolution::Unsupported {
-                raw: RawScalarKind::Null,
-                requested: ScalarRequestKind::DefaultString,
-            }
+            ScalarResolution::NullNotAllowed
         );
     }
 
@@ -168,20 +193,14 @@ mod tests {
     }
 
     #[test]
-    fn missing_and_null_remain_distinct_when_not_covered_by_a_policy() {
+    fn required_string_preserves_observed_missing_and_null_outcomes() {
         assert_eq!(
             resolve(RawScalar::Missing, ScalarRequest::RequiredString),
-            ScalarResolution::Unsupported {
-                raw: RawScalarKind::Missing,
-                requested: ScalarRequestKind::RequiredString,
-            }
+            ScalarResolution::MissingRequired
         );
         assert_eq!(
             resolve(RawScalar::Null, ScalarRequest::RequiredString),
-            ScalarResolution::Unsupported {
-                raw: RawScalarKind::Null,
-                requested: ScalarRequestKind::RequiredString,
-            }
+            ScalarResolution::NullNotAllowed
         );
     }
 

--- a/crates/emburk-core/src/scalar_resolution.rs
+++ b/crates/emburk-core/src/scalar_resolution.rs
@@ -1,0 +1,234 @@
+//! Private, dependency-free resolution for project-constructed scalar values.
+//!
+//! This module intentionally has no parser or public API. It models only the
+//! native values and policies admitted by T-0012/S03.
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RawScalar {
+    Missing,
+    Null,
+    String(String),
+    Boolean(bool),
+    I64(i64),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RawScalarKind {
+    Missing,
+    Null,
+    String,
+    Boolean,
+    I64,
+}
+
+impl RawScalar {
+    fn kind(&self) -> RawScalarKind {
+        match self {
+            Self::Missing => RawScalarKind::Missing,
+            Self::Null => RawScalarKind::Null,
+            Self::String(_) => RawScalarKind::String,
+            Self::Boolean(_) => RawScalarKind::Boolean,
+            Self::I64(_) => RawScalarKind::I64,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ScalarRequest {
+    RequiredString,
+    DefaultString { value: String },
+    OptionalStringNullDefault,
+    Boolean,
+    I64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScalarRequestKind {
+    RequiredString,
+    DefaultString,
+    OptionalStringNullDefault,
+    Boolean,
+    I64,
+}
+
+impl ScalarRequest {
+    fn kind(&self) -> ScalarRequestKind {
+        match self {
+            Self::RequiredString => ScalarRequestKind::RequiredString,
+            Self::DefaultString { .. } => ScalarRequestKind::DefaultString,
+            Self::OptionalStringNullDefault => ScalarRequestKind::OptionalStringNullDefault,
+            Self::Boolean => ScalarRequestKind::Boolean,
+            Self::I64 => ScalarRequestKind::I64,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ScalarResolution {
+    String(String),
+    OptionalString(Option<String>),
+    Boolean(bool),
+    I64(i64),
+    Unsupported {
+        raw: RawScalarKind,
+        requested: ScalarRequestKind,
+    },
+}
+
+fn resolve(raw: RawScalar, request: ScalarRequest) -> ScalarResolution {
+    match (raw, request) {
+        (RawScalar::String(value), ScalarRequest::RequiredString) => {
+            ScalarResolution::String(value)
+        }
+        (RawScalar::Missing, ScalarRequest::DefaultString { value }) => {
+            ScalarResolution::String(value)
+        }
+        (RawScalar::String(value), ScalarRequest::DefaultString { .. }) => {
+            ScalarResolution::String(value)
+        }
+        (RawScalar::Missing | RawScalar::Null, ScalarRequest::OptionalStringNullDefault) => {
+            ScalarResolution::OptionalString(None)
+        }
+        (RawScalar::String(value), ScalarRequest::OptionalStringNullDefault) => {
+            ScalarResolution::OptionalString(Some(value))
+        }
+        (RawScalar::Boolean(value), ScalarRequest::Boolean) => ScalarResolution::Boolean(value),
+        (RawScalar::I64(value), ScalarRequest::I64) => ScalarResolution::I64(value),
+        (raw, request) => ScalarResolution::Unsupported {
+            raw: raw.kind(),
+            requested: request.kind(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RawScalar, RawScalarKind, ScalarRequest, ScalarRequestKind, ScalarResolution, resolve,
+    };
+
+    #[test]
+    fn strings_preserve_arbitrary_contents() {
+        let required = "emoji: \u{1f980}\nleading and trailing ".to_owned();
+        let defaulted = "different\0string".to_owned();
+
+        assert_eq!(
+            resolve(
+                RawScalar::String(required.clone()),
+                ScalarRequest::RequiredString
+            ),
+            ScalarResolution::String(required)
+        );
+        assert_eq!(
+            resolve(
+                RawScalar::String(defaulted.clone()),
+                ScalarRequest::DefaultString {
+                    value: "unused fallback".to_owned(),
+                },
+            ),
+            ScalarResolution::String(defaulted)
+        );
+    }
+
+    #[test]
+    fn string_default_applies_only_to_missing() {
+        let request = ScalarRequest::DefaultString {
+            value: "fallback".to_owned(),
+        };
+
+        assert_eq!(
+            resolve(RawScalar::Missing, request.clone()),
+            ScalarResolution::String("fallback".to_owned())
+        );
+        assert_eq!(
+            resolve(RawScalar::Null, request),
+            ScalarResolution::Unsupported {
+                raw: RawScalarKind::Null,
+                requested: ScalarRequestKind::DefaultString,
+            }
+        );
+    }
+
+    #[test]
+    fn optional_string_null_default_maps_missing_and_null_to_none() {
+        let request = ScalarRequest::OptionalStringNullDefault;
+
+        assert_eq!(
+            resolve(RawScalar::Missing, request.clone()),
+            ScalarResolution::OptionalString(None)
+        );
+        assert_eq!(
+            resolve(RawScalar::Null, request.clone()),
+            ScalarResolution::OptionalString(None)
+        );
+        assert_eq!(
+            resolve(RawScalar::String("present".to_owned()), request),
+            ScalarResolution::OptionalString(Some("present".to_owned()))
+        );
+    }
+
+    #[test]
+    fn missing_and_null_remain_distinct_when_not_covered_by_a_policy() {
+        assert_eq!(
+            resolve(RawScalar::Missing, ScalarRequest::RequiredString),
+            ScalarResolution::Unsupported {
+                raw: RawScalarKind::Missing,
+                requested: ScalarRequestKind::RequiredString,
+            }
+        );
+        assert_eq!(
+            resolve(RawScalar::Null, ScalarRequest::RequiredString),
+            ScalarResolution::Unsupported {
+                raw: RawScalarKind::Null,
+                requested: ScalarRequestKind::RequiredString,
+            }
+        );
+    }
+
+    #[test]
+    fn booleans_preserve_both_native_values() {
+        assert_eq!(
+            resolve(RawScalar::Boolean(true), ScalarRequest::Boolean),
+            ScalarResolution::Boolean(true)
+        );
+        assert_eq!(
+            resolve(RawScalar::Boolean(false), ScalarRequest::Boolean),
+            ScalarResolution::Boolean(false)
+        );
+    }
+
+    #[test]
+    fn signed_64_bit_integers_preserve_both_bounds() {
+        assert_eq!(
+            resolve(RawScalar::I64(i64::MIN), ScalarRequest::I64),
+            ScalarResolution::I64(i64::MIN)
+        );
+        assert_eq!(
+            resolve(RawScalar::I64(i64::MAX), ScalarRequest::I64),
+            ScalarResolution::I64(i64::MAX)
+        );
+    }
+
+    #[test]
+    fn unsupported_combinations_are_not_errors_or_coercions() {
+        assert_eq!(
+            resolve(RawScalar::String("true".to_owned()), ScalarRequest::Boolean),
+            ScalarResolution::Unsupported {
+                raw: RawScalarKind::String,
+                requested: ScalarRequestKind::Boolean,
+            }
+        );
+        assert_eq!(
+            resolve(
+                RawScalar::I64(42),
+                ScalarRequest::DefaultString {
+                    value: "fallback".to_owned(),
+                }
+            ),
+            ScalarResolution::Unsupported {
+                raw: RawScalarKind::I64,
+                requested: ScalarRequestKind::DefaultString,
+            }
+        );
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ The first structural slice contains only two crates:
 The initial dependency direction is therefore `emburk-cli -> emburk-core`.
 Plugin traits, public configuration types, schema and value representations,
 runtime scheduling, transactions, resume state, and process protocols remain
-deferred until their compatibility contracts are accepted. T-0012/S03 may add a
+deferred until their compatibility contracts are accepted. ADR-0006 proposes a
 private, dependency-free raw-scalar resolver inside `emburk-core`; it is neither
 a YAML loader nor a stable public API. Creating crate directories does not make
 their eventual Rust API stable.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ The first structural slice contains only two crates:
 The initial dependency direction is therefore `emburk-cli -> emburk-core`.
 Plugin traits, public configuration types, schema and value representations,
 runtime scheduling, transactions, resume state, and process protocols remain
-deferred until their compatibility contracts are accepted. ADR-0006 proposes a
+deferred until their compatibility contracts are accepted. ADR-0006 permits a
 private, dependency-free raw-scalar resolver inside `emburk-core`; it is neither
 a YAML loader nor a stable public API. Creating crate directories does not make
 their eventual Rust API stable.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,10 +19,12 @@ The first structural slice contains only two crates:
   `emburk-core`; the reverse dependency is forbidden.
 
 The initial dependency direction is therefore `emburk-cli -> emburk-core`.
-Plugin traits, configuration types, schema and value representations, runtime
-scheduling, transactions, resume state, and process protocols remain deferred
-until their compatibility contracts are accepted. Creating crate directories
-does not make their eventual Rust API stable.
+Plugin traits, public configuration types, schema and value representations,
+runtime scheduling, transactions, resume state, and process protocols remain
+deferred until their compatibility contracts are accepted. T-0012/S03 may add a
+private, dependency-free raw-scalar resolver inside `emburk-core`; it is neither
+a YAML loader nor a stable public API. Creating crate directories does not make
+their eventual Rust API stable.
 
 ## Runtime Layers
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,9 +27,10 @@ T-0012/S01 gathered a narrow absent/null/default observation via the pinned
 official self-contained executable and a local-only probe plugin. Its annotated
 String/Optional reference observation integrated through PR #61 as `e2532e2`;
 it does not itself satisfy the configuration/schema/value contract or the
-Phase 0 exit gate. T-0012/S02 has an independently reproduced Boolean/Long
-conversion observation at `86970ea` and awaits PR integration. It likewise
-cannot satisfy that gate without an independently implemented Emburk comparator.
+Phase 0 exit gate. T-0012/S02's Boolean/Long observation integrated through PR
+#65 as `d7b4838`. T-0012/S03 may add a private original-Rust scalar resolver
+and contract tests, but neither slice can satisfy the gate without an
+independently implemented Emburk comparator.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,9 +24,8 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021 is the only active work item. T-0012/S03 is `Ready` pending architecture
-approval. The combined `In Progress`/`Review` WIP is one of two; no item is
-`Blocked`.
+T-0021 and T-0012/S03 are the only active work items. The combined `In
+Progress`/`Review` WIP is two of two; no item is `Ready` or `Blocked`.
 
 | Item | State | Purpose |
 |---|---|---|
@@ -34,7 +33,7 @@ approval. The combined `In Progress`/`Review` WIP is one of two; no item is
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S03 | Ready | Proposed internal raw scalar resolver bounded by S01/S02 observations |
+| T-0012/S03 | In Progress | Accepted private raw scalar resolver bounded by S01/S02 observations |
 | T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,7 +24,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021 (`In Progress`) and T-0012/S02 (`Review`) are the only active work
+T-0021 and T-0012/S03 are the only active work
 items, meeting the two-item combined `In Progress`/`Review` WIP limit. No work
 item is currently `Ready` or `Blocked`.
 
@@ -34,7 +34,7 @@ item is currently `Ready` or `Blocked`.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S02 | Review | Local-only Boolean/Long conversion probe accepted at `86970ea`; awaits PR integration |
+| T-0012/S03 | In Progress | Internal raw scalar resolver bounded by S01/S02 observations |
 | T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
@@ -102,7 +102,7 @@ executable route and local-only Maven-style input plugin recorded nine
 annotated String/Optional fixture observations and integrated through PR #61
 as `e2532e2`. This is Reference Observation / Integration evidence only, not a
 generic typed-getter contract, a verified Emburk semantic, or the parent task's
-Differential (Embulk) evidence. T-0012/S02 has a nine-case Boolean/Long
-runtime observation through the same pinned executable. An independent
-primary-agent reproduction passed at `86970ea`; this is Review-stage Reference
-Observation / Integration evidence only, pending PR integration.
+Differential (Embulk) evidence. T-0012/S02's nine-case Boolean/Long runtime
+observation integrated through PR #65 as `d7b4838`. Its evidence remains
+Reference Observation / Integration only. T-0012/S03 is packeted for a private
+Rust raw-scalar resolver and contract tests; it has no implementation result.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,8 +24,8 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021 and T-0012/S03 are the only active work items. The combined `In
-Progress`/`Review` WIP is two of two; no item is `Ready` or `Blocked`.
+T-0021 (`In Progress`) and T-0012/S03 (`Review`) are the only active work
+items. The combined WIP is two of two; no item is `Ready` or `Blocked`.
 
 | Item | State | Purpose |
 |---|---|---|
@@ -33,7 +33,7 @@ Progress`/`Review` WIP is two of two; no item is `Ready` or `Blocked`.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S03 | In Progress | Accepted private raw scalar resolver bounded by S01/S02 observations |
+| T-0012/S03 | Review | Private raw scalar resolver accepted at `8432391`; awaits Tester and PR integration |
 | T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,9 +24,9 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021 and T-0012/S03 are the only active work
-items, meeting the two-item combined `In Progress`/`Review` WIP limit. No work
-item is currently `Ready` or `Blocked`.
+T-0021 is the only active work item. T-0012/S03 is `Ready` pending architecture
+approval. The combined `In Progress`/`Review` WIP is one of two; no item is
+`Blocked`.
 
 | Item | State | Purpose |
 |---|---|---|
@@ -34,7 +34,7 @@ item is currently `Ready` or `Blocked`.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S03 | In Progress | Internal raw scalar resolver bounded by S01/S02 observations |
+| T-0012/S03 | Ready | Proposed internal raw scalar resolver bounded by S01/S02 observations |
 | T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are

--- a/docs/decisions/ADR-0006-private-raw-scalar-resolution-before-parser.md
+++ b/docs/decisions/ADR-0006-private-raw-scalar-resolution-before-parser.md
@@ -1,6 +1,6 @@
 # ADR-0006: Private Raw Scalar Resolution Before Parser Adoption
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-09-05
 
 ## Context
@@ -16,13 +16,16 @@ If accepted, allow T-0012/S03 to add a dependency-free, private raw-scalar
 resolver in `emburk-core`. Its inputs are constructed by project-owned tests,
 not parsed YAML. It resolves complete native domains only: Missing/Null and
 String identity/presence, Boolean identity, and signed-64-bit integer identity.
-No CLI wiring, parser, public API, plugin interface, schema, lexical Boolean or
-Long conversion, decimal conversion, or default Boolean/Long policy is adopted.
+It also permits the explicit S01 String-default and null-default Optional<String>
+policies only. No CLI wiring, parser, public API, plugin interface, schema,
+lexical Boolean or Long conversion, decimal conversion, or default Boolean/Long
+policy is adopted.
 
 ## Consequences
 
 The slice supplies original Rust code and Unit/Contract regression tests traced
-to S01/S02 without treating observed tokens as a general lexical algorithm. It
-is not a live differential harness or an Emburk compatibility claim. Lexical
-spellings, decimal conversion, a parser, defaults, or public exposure require
-a new packet and evidence.
+to S01/S02 without treating observed tokens as a general lexical algorithm.
+Unsupported combinations are distinct internal outcomes, not claims about an
+Embulk rejection. It is not a live differential harness or an Emburk
+compatibility claim. Lexical spellings, decimal conversion, Boolean/Long
+defaults, a parser, or public exposure require a new packet and evidence.

--- a/docs/decisions/ADR-0006-private-raw-scalar-resolution-before-parser.md
+++ b/docs/decisions/ADR-0006-private-raw-scalar-resolution-before-parser.md
@@ -1,0 +1,26 @@
+# ADR-0006: Private Raw Scalar Resolution Before Parser Adoption
+
+- Status: Accepted
+- Date: 2026-09-05
+
+## Context
+
+T-0012/S01 and S02 recorded bounded reference observations for selected
+presence, string, Boolean, and Long values. Emburk has no configuration parser
+or public configuration API yet. Adopting a YAML dependency or exposing an API
+would exceed those observations and couple later compatibility work prematurely.
+
+## Decision
+
+Allow T-0012/S03 to add a dependency-free, private raw-scalar resolver in
+`emburk-core`. Its inputs are constructed by project-owned tests, not parsed
+YAML. It may resolve only the explicitly observed Missing/Null/String/Boolean/
+Long cases and named decimal token cases. No CLI wiring, parser, public API,
+plugin interface, schema, or default Boolean/Long policy is adopted.
+
+## Consequences
+
+The slice supplies original Rust code and Unit/Contract regression tests traced
+to S01/S02. It is not a live differential harness or an Emburk compatibility
+claim. New input spellings, a parser, defaults, or public exposure require a
+new packet and evidence.

--- a/docs/decisions/ADR-0006-private-raw-scalar-resolution-before-parser.md
+++ b/docs/decisions/ADR-0006-private-raw-scalar-resolution-before-parser.md
@@ -1,6 +1,6 @@
 # ADR-0006: Private Raw Scalar Resolution Before Parser Adoption
 
-- Status: Accepted
+- Status: Proposed
 - Date: 2026-09-05
 
 ## Context
@@ -12,15 +12,17 @@ would exceed those observations and couple later compatibility work prematurely.
 
 ## Decision
 
-Allow T-0012/S03 to add a dependency-free, private raw-scalar resolver in
-`emburk-core`. Its inputs are constructed by project-owned tests, not parsed
-YAML. It may resolve only the explicitly observed Missing/Null/String/Boolean/
-Long cases and named decimal token cases. No CLI wiring, parser, public API,
-plugin interface, schema, or default Boolean/Long policy is adopted.
+If accepted, allow T-0012/S03 to add a dependency-free, private raw-scalar
+resolver in `emburk-core`. Its inputs are constructed by project-owned tests,
+not parsed YAML. It resolves complete native domains only: Missing/Null and
+String identity/presence, Boolean identity, and signed-64-bit integer identity.
+No CLI wiring, parser, public API, plugin interface, schema, lexical Boolean or
+Long conversion, decimal conversion, or default Boolean/Long policy is adopted.
 
 ## Consequences
 
 The slice supplies original Rust code and Unit/Contract regression tests traced
-to S01/S02. It is not a live differential harness or an Emburk compatibility
-claim. New input spellings, a parser, defaults, or public exposure require a
-new packet and evidence.
+to S01/S02 without treating observed tokens as a general lexical algorithm. It
+is not a live differential harness or an Emburk compatibility claim. Lexical
+spellings, decimal conversion, a parser, defaults, or public exposure require
+a new packet and evidence.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -9,3 +9,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0003](ADR-0003-optional-out-of-process-legacy-hosts.md) | Optional out-of-process legacy hosts | Accepted |
 | [ADR-0004](ADR-0004-arrow-compatible-logical-batches.md) | Arrow-compatible logical batches | Accepted |
 | [ADR-0005](ADR-0005-traceable-license-aware-reimplementation.md) | Traceable, license-aware reimplementation | Accepted |
+| [ADR-0006](ADR-0006-private-raw-scalar-resolution-before-parser.md) | Private raw scalar resolution before parser adoption | Accepted |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -9,4 +9,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0003](ADR-0003-optional-out-of-process-legacy-hosts.md) | Optional out-of-process legacy hosts | Accepted |
 | [ADR-0004](ADR-0004-arrow-compatible-logical-batches.md) | Arrow-compatible logical batches | Accepted |
 | [ADR-0005](ADR-0005-traceable-license-aware-reimplementation.md) | Traceable, license-aware reimplementation | Accepted |
-| [ADR-0006](ADR-0006-private-raw-scalar-resolution-before-parser.md) | Private raw scalar resolution before parser adoption | Proposed |
+| [ADR-0006](ADR-0006-private-raw-scalar-resolution-before-parser.md) | Private raw scalar resolution before parser adoption | Accepted |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -9,4 +9,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0003](ADR-0003-optional-out-of-process-legacy-hosts.md) | Optional out-of-process legacy hosts | Accepted |
 | [ADR-0004](ADR-0004-arrow-compatible-logical-batches.md) | Arrow-compatible logical batches | Accepted |
 | [ADR-0005](ADR-0005-traceable-license-aware-reimplementation.md) | Traceable, license-aware reimplementation | Accepted |
-| [ADR-0006](ADR-0006-private-raw-scalar-resolution-before-parser.md) | Private raw scalar resolution before parser adoption | Accepted |
+| [ADR-0006](ADR-0006-private-raw-scalar-resolution-before-parser.md) | Private raw scalar resolution before parser adoption | Proposed |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -8,4 +8,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | --- | --- |
 | [T-0011 Embulk reference inventory](T-0011-embulk-reference-inventory.md) | Done (Planning evidence) |
 | [T-0012/S01 configuration-presence reference probe](T-0012-config-presence-probe.md) | Done (Reference Observation / Integration) |
-| [T-0012/S02 configuration-conversion reference probe](T-0012-config-conversion-probe.md) | In Progress (packet only) |
+| [T-0012/S02 configuration-conversion reference probe](T-0012-config-conversion-probe.md) | Done (Reference Observation / Integration) |
+| [T-0012/S03 internal scalar resolution](T-0012-scalar-resolution.md) | In Progress (packet only) |

--- a/docs/provenance/T-0012-config-conversion-probe.md
+++ b/docs/provenance/T-0012-config-conversion-probe.md
@@ -10,7 +10,8 @@
 - Required reviewer: Librarian (Vreji), reviewed 2026-09-05; independent
   primary-agent reproduction passed on 2026-09-05.
 - Access date: 2026-09-05
-- State: `Review` (accepted source evidence recorded; PR integration pending)
+- State: `Done` as a slice; integrated through PR #65 as
+  `d7b4838661660e43a039e1710f83397d289af3b1`. The parent T-0012 remains open.
 
 ## Outcome and boundary
 
@@ -110,8 +111,8 @@ An independent primary-agent reproduction ran both exact Demo commands at
 `86970ea4064a64260bfa2863c68a200bf15ce1fb` on 2026-09-05. Both exited 0 with
 their checksum and unavailable-runtime controls exiting 3 and 56; it recorded
 nine S02 rows at `probe config load` with exit 0. The source evidence is
-accepted as Reference Observation / Integration only; PR integration remains
-required before this slice can be closed. The listed outcomes do not establish
+accepted as Reference Observation / Integration only. PR #65 integrated as
+`d7b4838661660e43a039e1710f83397d289af3b1`; the listed outcomes do not establish
 general conversion, rounding, default, parser-cause, or Emburk behavior.
 
 ## Stop rule and non-claims

--- a/docs/provenance/T-0012-scalar-resolution.md
+++ b/docs/provenance/T-0012-scalar-resolution.md
@@ -4,8 +4,8 @@
 - Branch: `feat/t-0012-scalar-resolution`
 - Owner: Rust Core Implementer; canonical records and lifecycle: Project Manager
 - Estimate: 3 SP within the existing T-0012 parent estimate
-- State: `Review` (independent source acceptance passed at `8432391`; named
-  Tester reproduction and PR integration pending)
+- State: `Review` (independent source and Tester acceptance passed; PR
+  integration pending)
 
 ## Authority, inputs, and boundary
 
@@ -58,3 +58,8 @@ general rule.
 - This is Unit/Contract evidence for the private original Rust resolver only.
   It does not compare an Emburk execution, reproduce Java exception text or
   timing, add a parser, or satisfy T-0012's Differential gate.
+- Named read-only Tester reproduction at `8432391` also passed core tests,
+  format, workspace Clippy with warnings denied, and diff check. Its local raw
+  log SHA-256 was
+  `297ac906ecc9030d5997ac0ad809207153806927b58af5fd7f92a7730d927657`;
+  the path is deliberately omitted from this public record.

--- a/docs/provenance/T-0012-scalar-resolution.md
+++ b/docs/provenance/T-0012-scalar-resolution.md
@@ -4,7 +4,8 @@
 - Branch: `feat/t-0012-scalar-resolution`
 - Owner: Rust Core Implementer; canonical records and lifecycle: Project Manager
 - Estimate: 3 SP within the existing T-0012 parent estimate
-- State: `In Progress` (ADR-0006 accepted; implementation not yet recorded)
+- State: `Review` (independent source acceptance passed at `8432391`; named
+  Tester reproduction and PR integration pending)
 
 ## Authority, inputs, and boundary
 
@@ -46,3 +47,14 @@ general rule.
   material provenance, license, security, or reimplementation uncertainty.
 - Non-claims: no complete Emburk configuration behavior, compatibility,
   parser, external plugin, performance, security, patent, or FTO claim.
+
+## Runtime evidence
+
+- Independent primary-agent acceptance at
+  `8432391837a7877b7ab2d9e987b3720cbdc570d4` passed `cargo fmt --check`,
+  `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p
+  emburk-core` (8 tests), `cargo test --workspace` (8 core tests and 0 CLI
+  tests), and `git diff --check`.
+- This is Unit/Contract evidence for the private original Rust resolver only.
+  It does not compare an Emburk execution, reproduce Java exception text or
+  timing, add a parser, or satisfy T-0012's Differential gate.

--- a/docs/provenance/T-0012-scalar-resolution.md
+++ b/docs/provenance/T-0012-scalar-resolution.md
@@ -4,7 +4,7 @@
 - Branch: `feat/t-0012-scalar-resolution`
 - Owner: Rust Core Implementer; canonical records and lifecycle: Project Manager
 - Estimate: 3 SP within the existing T-0012 parent estimate
-- State: `Ready` (revised packet awaiting ADR-0006 acceptance)
+- State: `In Progress` (ADR-0006 accepted; implementation not yet recorded)
 
 ## Authority, inputs, and boundary
 
@@ -16,12 +16,15 @@ artifact, dependency, source text, test, or implementation is consulted or
 reused.
 
 The resolver may cover complete native domains: required/defaulted/optional
-String identity and Missing/Null presence rules; Boolean identity; and signed
-64-bit integer identity. It must not identify cases by fixture ID or call the
-reference runtime. Lexical Boolean/Long conversion (including quoted values),
-decimal conversion (including 37.5), overflow-token handling, Boolean/Long
-defaults, YAML parsing, public APIs, CLI wiring, and plugins remain out of
-scope until separate evidence supports a general rule.
+String identity and Missing/Null presence rules; the explicit S01 String-default
+policy; the explicit S01 Optional<String> null-default policy (Missing/Null to
+None only for that named policy); Boolean identity; and signed-64-bit integer
+identity. Unsupported type combinations must be distinct internal outcomes, not
+claimed Embulk rejections. It must not identify cases by fixture ID or call the
+reference runtime. Lexical Boolean/Long conversion, decimal conversion,
+overflow-token handling, Boolean/Long defaults, YAML parsing, public APIs, CLI
+wiring, and plugins remain out of scope until separate evidence supports a
+general rule.
 
 ## Packet
 
@@ -33,8 +36,10 @@ scope until separate evidence supports a general rule.
 - Demo Command: `cargo test -p emburk-core`.
 - Acceptance: the Demo, `cargo fmt --check`, `cargo clippy -p emburk-core
   -- -D warnings`, and existing core tests pass; an independent reproduction is
-  required. Tests assert project-owned values and errors rather than an
-  invented general YAML contract.
+  required. Tests cover arbitrary Strings, Boolean true/false, i64 minimum/
+  maximum, and Missing versus Null; no fixture-ID dispatch is permitted. A
+  documented narrow `dead_code` allowance is permitted only if needed to keep
+  the resolver private; warnings must not be disabled globally.
 - Evidence: Unit/Contract, traceable to reference observations; not
   Differential.
 - Stop rule: stop expansion for any parser/public API/dependency request or

--- a/docs/provenance/T-0012-scalar-resolution.md
+++ b/docs/provenance/T-0012-scalar-resolution.md
@@ -4,7 +4,7 @@
 - Branch: `feat/t-0012-scalar-resolution`
 - Owner: Rust Core Implementer; canonical records and lifecycle: Project Manager
 - Estimate: 3 SP within the existing T-0012 parent estimate
-- State: `In Progress` (packet only)
+- State: `Ready` (revised packet awaiting ADR-0006 acceptance)
 
 ## Authority, inputs, and boundary
 
@@ -15,13 +15,13 @@ and S02's integrated Reference Observation / Integration records (PR #61
 artifact, dependency, source text, test, or implementation is consulted or
 reused.
 
-The resolver may cover only: required/defaulted/optional String presence rules;
-native Boolean true/false and quoted `"true"`; invalid Boolean; native Long 37
-and maximum; quoted Long 37; decimal token `37.5` resolving to 37; and an
-above-maximum Long error. It must not identify cases by fixture ID or call the
-reference runtime. Unobserved spellings, Boolean/Long defaults, negative and
-other decimals, YAML parsing, public APIs, CLI wiring, and plugins remain out
-of scope.
+The resolver may cover complete native domains: required/defaulted/optional
+String identity and Missing/Null presence rules; Boolean identity; and signed
+64-bit integer identity. It must not identify cases by fixture ID or call the
+reference runtime. Lexical Boolean/Long conversion (including quoted values),
+decimal conversion (including 37.5), overflow-token handling, Boolean/Long
+defaults, YAML parsing, public APIs, CLI wiring, and plugins remain out of
+scope until separate evidence supports a general rule.
 
 ## Packet
 

--- a/docs/provenance/T-0012-scalar-resolution.md
+++ b/docs/provenance/T-0012-scalar-resolution.md
@@ -1,0 +1,43 @@
+# T-0012/S03 internal scalar resolution
+
+- Tracking issue: [#15](https://github.com/bhind/emburk/issues/15)
+- Branch: `feat/t-0012-scalar-resolution`
+- Owner: Rust Core Implementer; canonical records and lifecycle: Project Manager
+- Estimate: 3 SP within the existing T-0012 parent estimate
+- State: `In Progress` (packet only)
+
+## Authority, inputs, and boundary
+
+Implement original, dependency-free Rust code in `emburk-core` that resolves
+project-constructed raw scalar values. Its only compatibility inputs are S01
+and S02's integrated Reference Observation / Integration records (PR #61
+`e2532e2`, PR #65 `d7b4838`) and ADR-0006. No additional upstream source,
+artifact, dependency, source text, test, or implementation is consulted or
+reused.
+
+The resolver may cover only: required/defaulted/optional String presence rules;
+native Boolean true/false and quoted `"true"`; invalid Boolean; native Long 37
+and maximum; quoted Long 37; decimal token `37.5` resolving to 37; and an
+above-maximum Long error. It must not identify cases by fixture ID or call the
+reference runtime. Unobserved spellings, Boolean/Long defaults, negative and
+other decimals, YAML parsing, public APIs, CLI wiring, and plugins remain out
+of scope.
+
+## Packet
+
+- Allowlist: `crates/emburk-core/src/lib.rs` and one new private module under
+  `crates/emburk-core/src/` containing its unit tests; the canonical records,
+  ADR-0006, log, and this provenance record only.
+- Artifacts/dependencies: none beyond the existing workspace; no network or
+  third-party dependency resolution.
+- Demo Command: `cargo test -p emburk-core`.
+- Acceptance: the Demo, `cargo fmt --check`, `cargo clippy -p emburk-core
+  -- -D warnings`, and existing core tests pass; an independent reproduction is
+  required. Tests assert project-owned values and errors rather than an
+  invented general YAML contract.
+- Evidence: Unit/Contract, traceable to reference observations; not
+  Differential.
+- Stop rule: stop expansion for any parser/public API/dependency request or
+  material provenance, license, security, or reimplementation uncertainty.
+- Non-claims: no complete Emburk configuration behavior, compatibility,
+  parser, external plugin, performance, security, patent, or FTO claim.


### PR DESCRIPTION
Refs #15. T-0012/S03 adds a private, dependency-free original Rust raw-scalar resolver and internal contract tests under ADR-0006.\n\nIndependent acceptance at `8432391` passed fmt, workspace Clippy with warnings denied, core tests (8), workspace tests (8 core/0 CLI), and diff check. Named read-only Tester reproduction is pending.\n\nThis is Unit/Contract evidence only. It is not a parser, public API, Embulk differential result, compatibility claim, or approval of lexical/decimal conversion.