### PR TITLE
feat(core): preserve ordered logical schemas with live comparison

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -154,3 +154,6 @@ live comparison of S05's three actual outcomes. ADR-0007 and its
 [packet](docs/provenance/T-0012-ordered-schema-differential.md) exclude lookup,
 nullability, values, Arrow, public APIs and plugin traits. No parent re-estimate
 or completion follows from activation.
+Primary and independent Tester acceptance passed at `c7c7872`: three live schema
+outcomes, S04 regression, strict checks and 14 offline tests with two intentional
+live ignores. Integration remains pending.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0021` and `T-0012/S05` are `In Progress`, and every other item is
+`T-0021` and `T-0012/S06` are `In Progress`, and every other item is
 `Backlog`. No item is `Blocked`. This is the two-item WIP limit.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -34,7 +34,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S05: schema observation; S01–S04 integrated) | In Progress | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S06: ordered schema differential; S01–S05 integrated) | In Progress | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics | Backlog | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -146,5 +146,11 @@ construction/handoff cases through the pinned executable before choosing a
 Rust schema representation. See its [packet](docs/provenance/T-0012-schema-boundary-probe.md).
 This is existing T-0012 scope and does not trigger another parent re-estimate.
 Primary and independent Tester acceptance passed at `cc24730`, including all
-three schema cases, validator controls and S01/S02/S04 regressions. Integration
-is pending; parent completion and schema support are not claimed.
+three schema cases, validator controls and S01/S02/S04 regressions. PR #68
+integrated as `68559dc`; parent completion and schema support are not claimed.
+
+S06 (3 SP within Current SP 8) adds only a private ordered schema plus a bounded
+live comparison of S05's three actual outcomes. ADR-0007 and its
+[packet](docs/provenance/T-0012-ordered-schema-differential.md) exclude lookup,
+nullability, values, Arrow, public APIs and plugin traits. No parent re-estimate
+or completion follows from activation.

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -7,6 +7,13 @@
 )]
 mod scalar_resolution;
 
+// This is deliberately private until a later packet authorizes an API consumer.
+#[allow(
+    dead_code,
+    reason = "T-0012/S06 is an internal ordered schema without a public consumer"
+)]
+mod logical_schema;
+
 pub const DEVELOPMENT_STATUS: &str =
     "emburk: development environment ready (data transfer not implemented yet)";
 

--- a/crates/emburk-core/src/logical_schema.rs
+++ b/crates/emburk-core/src/logical_schema.rs
@@ -1,0 +1,304 @@
+//! Private, ordered logical schema storage with no physical encoding policy.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LogicalType {
+    Boolean,
+    Signed64,
+    Float64,
+    Text,
+    Timestamp,
+    Json,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LogicalColumn {
+    name: String,
+    logical_type: LogicalType,
+}
+
+impl LogicalColumn {
+    fn new(name: impl Into<String>, logical_type: LogicalType) -> Self {
+        Self {
+            name: name.into(),
+            logical_type,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LogicalSchema {
+    columns: Vec<LogicalColumn>,
+}
+
+impl LogicalSchema {
+    fn new(columns: Vec<LogicalColumn>) -> Self {
+        Self { columns }
+    }
+
+    fn columns(&self) -> impl ExactSizeIterator<Item = &LogicalColumn> {
+        self.columns.iter()
+    }
+}
+
+// The bridge is deliberately test-only. Its driver obtains actual schema rows
+// from S05, while this module supplies only the private representation.
+#[cfg(test)]
+fn assert_live_tsv(tsv: &str) -> Result<(), String> {
+    const CASES: [&str; 3] = ["empty", "ordered6types", "duplicate-name-differing-types"];
+    let mut lines = tsv.lines();
+    if lines.next() != Some("T0012-S06\t1") {
+        return Err("unsupported TSV header".into());
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    while let Some(case_line) = lines.next() {
+        let fields: Vec<_> = case_line.split('\t').collect();
+        if fields.len() != 3 || fields[0] != "CASE" {
+            return Err("missing case boundary".into());
+        }
+        let case = fields[1];
+        if !CASES.contains(&case) || !seen.insert(case.to_owned()) {
+            return Err("unknown or duplicate case".into());
+        }
+        let count: usize = fields[2].parse().map_err(|_| "malformed case count")?;
+        if count > lines.clone().count() {
+            return Err("case count exceeds remaining rows".into());
+        }
+        let mut input = Vec::with_capacity(count);
+        let mut expected = Vec::with_capacity(count);
+        for index in 0..count {
+            let row = lines.next().ok_or("truncated case rows")?;
+            let row: Vec<_> = row.split('\t').collect();
+            if row.len() != 6 || row[0] != "FIELD" || row[1] != index.to_string() {
+                return Err("malformed field row".into());
+            }
+            input.push(LogicalColumn::new(
+                decode_hex_string(row[2])?,
+                parse_type(row[3])?,
+            ));
+            expected.push(LogicalColumn::new(
+                decode_hex_string(row[4])?,
+                parse_type(row[5])?,
+            ));
+        }
+        let schema = LogicalSchema::new(input.clone());
+        let actual: Vec<_> = schema.columns().cloned().collect();
+        if actual != input {
+            return Err("private schema did not preserve input columns".into());
+        }
+        if actual != expected {
+            return Err(format!("oracle differs from private schema for {case}"));
+        }
+    }
+    if seen.len() != CASES.len() || !CASES.iter().all(|case| seen.contains(*case)) {
+        return Err("TSV case manifest is not exact".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn parse_type(value: &str) -> Result<LogicalType, String> {
+    match value {
+        "boolean" => Ok(LogicalType::Boolean),
+        "signed64" => Ok(LogicalType::Signed64),
+        "float64" => Ok(LogicalType::Float64),
+        "text" => Ok(LogicalType::Text),
+        "timestamp" => Ok(LogicalType::Timestamp),
+        "json" => Ok(LogicalType::Json),
+        _ => Err("unknown logical type".into()),
+    }
+}
+
+#[cfg(test)]
+fn decode_hex_string(value: &str) -> Result<String, String> {
+    let bytes = value.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return Err("malformed hex".into());
+    }
+    let (pairs, remainder) = bytes.as_chunks::<2>();
+    debug_assert!(remainder.is_empty());
+    let mut decoded = Vec::with_capacity(pairs.len());
+    for pair in pairs {
+        decoded.push(hex_nibble(pair[0])? << 4 | hex_nibble(pair[1])?);
+    }
+    String::from_utf8(decoded).map_err(|_| "non-UTF-8 hex string".into())
+}
+
+#[cfg(test)]
+fn hex_nibble(value: u8) -> Result<u8, String> {
+    match value {
+        b'0'..=b'9' => Ok(value - b'0'),
+        b'a'..=b'f' => Ok(value - b'a' + 10),
+        b'A'..=b'F' => Ok(value - b'A' + 10),
+        _ => Err("malformed hex".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogicalColumn, LogicalSchema, LogicalType};
+
+    #[test]
+    fn preserves_empty_schema() {
+        assert_eq!(LogicalSchema::new(vec![]).columns().len(), 0);
+    }
+
+    #[test]
+    fn preserves_six_ordered_logical_types() {
+        let columns = vec![
+            LogicalColumn::new("boolean_column", LogicalType::Boolean),
+            LogicalColumn::new("long_column", LogicalType::Signed64),
+            LogicalColumn::new("double_column", LogicalType::Float64),
+            LogicalColumn::new("string_column", LogicalType::Text),
+            LogicalColumn::new("timestamp_column", LogicalType::Timestamp),
+            LogicalColumn::new("json_column", LogicalType::Json),
+        ];
+        assert_eq!(
+            LogicalSchema::new(columns.clone())
+                .columns()
+                .cloned()
+                .collect::<Vec<_>>(),
+            columns
+        );
+    }
+
+    #[test]
+    fn preserves_duplicate_names_at_distinct_positions() {
+        let columns = vec![
+            LogicalColumn::new("duplicate", LogicalType::Boolean),
+            LogicalColumn::new("duplicate", LogicalType::Text),
+        ];
+        assert_eq!(
+            LogicalSchema::new(columns.clone())
+                .columns()
+                .cloned()
+                .collect::<Vec<_>>(),
+            columns
+        );
+    }
+
+    #[test]
+    fn owns_arbitrary_utf8_names() {
+        let mut name = String::from("crab 🦀\n");
+        let schema = LogicalSchema::new(vec![LogicalColumn::new(name.clone(), LogicalType::Json)]);
+        name.push_str("changed outside schema");
+        assert_eq!(schema.columns().next().unwrap().name, "crab 🦀\n");
+    }
+
+    fn field(
+        index: usize,
+        input_name: &str,
+        input_type: &str,
+        expected_name: &str,
+        expected_type: &str,
+    ) -> String {
+        format!(
+            "FIELD\t{index}\t{}\t{input_type}\t{}\t{expected_type}",
+            input_name
+                .as_bytes()
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>(),
+            expected_name
+                .as_bytes()
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>()
+        )
+    }
+
+    fn valid_tsv() -> String {
+        let empty = "CASE\tempty\t0".to_owned();
+        let ordered = [
+            ("boolean_column", "boolean"),
+            ("long_column", "signed64"),
+            ("double_column", "float64"),
+            ("string_column", "text"),
+            ("timestamp_column", "timestamp"),
+            ("json_column", "json"),
+        ];
+        let duplicate = [("duplicate", "boolean"), ("duplicate", "text")];
+        let ordered_rows = ordered
+            .iter()
+            .enumerate()
+            .map(|(i, (name, kind))| field(i, name, kind, name, kind))
+            .collect::<Vec<_>>();
+        let duplicate_rows = duplicate
+            .iter()
+            .enumerate()
+            .map(|(i, (name, kind))| field(i, name, kind, name, kind))
+            .collect::<Vec<_>>();
+        format!(
+            "T0012-S06\t1\n{empty}\nCASE\tordered6types\t6\n{}\nCASE\tduplicate-name-differing-types\t2\n{}\n",
+            ordered_rows.join("\n"),
+            duplicate_rows.join("\n")
+        )
+    }
+
+    #[test]
+    fn live_tsv_bridge_rejects_invalid_or_mutated_evidence() {
+        let valid = valid_tsv();
+        assert!(super::assert_live_tsv(&valid).is_ok());
+        for bad in [
+            valid.replacen("CASE\tempty\t0", "CASE\tempty\t1", 1),
+            valid.replacen("CASE\tempty\t0", "CASE\tunknown\t0", 1),
+            valid.replacen(
+                "\tboolean\t626f6f6c65616e5f636f6c756d6e\tboolean",
+                "\tunknown\t626f6f6c65616e5f636f6c756d6e\tboolean",
+                1,
+            ),
+            valid.replacen("626f6f6c65616e5f636f6c756d6e", "zz", 1),
+            valid.replacen("FIELD\t0", "FIELD\t1", 1),
+            valid.replacen("CASE\tempty\t0\n", "", 1),
+            valid.replacen("CASE\tordered6types\t6", "CASE\tordered6types\t5", 1),
+            valid.replacen("CASE\tempty\t0", "CASE\tempty\t999999999", 1),
+            format!("{valid}CASE\tempty\t0\n"),
+            valid.replacen("626f6f6c65616e5f636f6c756d6e", "ff", 1),
+            valid.replacen(
+                "\t626f6f6c65616e5f636f6c756d6e\tboolean\n",
+                "\t626f6f6c65616e5f636f6c756d6e\tunknown\n",
+                1,
+            ),
+        ] {
+            assert!(super::assert_live_tsv(&bad).is_err(), "{bad}");
+        }
+        let original_field = valid
+            .lines()
+            .find(|line| line.starts_with("FIELD\t0\t"))
+            .unwrap();
+        let original_parts: Vec<_> = original_field.split('\t').collect();
+        let input_before = (original_parts[2], original_parts[3]);
+        let mutated_expected = valid
+            .lines()
+            .map(|line| {
+                if line == original_field {
+                    let mut parts: Vec<_> = line.split('\t').collect();
+                    parts[4] = "6368616e676564";
+                    parts.join("\t")
+                } else {
+                    line.to_owned()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        let mutated_field = mutated_expected
+            .lines()
+            .find(|line| line.starts_with("FIELD\t0\t"))
+            .unwrap();
+        let mutated_parts: Vec<_> = mutated_field.split('\t').collect();
+        assert_eq!(input_before, (mutated_parts[2], mutated_parts[3]));
+        assert!(super::assert_live_tsv(&mutated_expected).is_err());
+        assert!(
+            super::assert_live_tsv(&valid).is_ok(),
+            "expected-only mutation changed input state"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires the external T-0012/S05 oracle driver"]
+    fn live_schema_differential() {
+        let path = std::env::var("T0012_S06_TSV").expect("T0012_S06_TSV must name driver output");
+        let tsv = std::fs::read_to_string(path).expect("read driver TSV");
+        super::assert_live_tsv(&tsv).expect("validate and compare live schema TSV");
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,8 +30,10 @@ a YAML loader nor a stable public API. Creating crate directories does not make
 their eventual Rust API stable.
 
 ADR-0007 permits a private ordered logical schema before any physical encoding
-or public exposure. Its S06 implementation and live comparison are pending;
-logical type tags alone do not establish value or Arrow representations.
+or public exposure. S06 implements it as an owned ordered vector in the core,
+with no name lookup or deduplication. Its three-case live comparison passed
+primary and independent Tester acceptance; integration remains pending.
+Logical type tags alone do not establish value or Arrow representations.
 
 T-0012 reference probes and S04's ignored live comparison are test-only tools
 outside the Emburk runtime. Their local executable retrieval and generated probe

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,6 +29,10 @@ private, dependency-free raw-scalar resolver inside `emburk-core`; it is neither
 a YAML loader nor a stable public API. Creating crate directories does not make
 their eventual Rust API stable.
 
+ADR-0007 permits a private ordered logical schema before any physical encoding
+or public exposure. Its S06 implementation and live comparison are pending;
+logical type tags alone do not establish value or Arrow representations.
+
 T-0012 reference probes and S04's ignored live comparison are test-only tools
 outside the Emburk runtime. Their local executable retrieval and generated probe
 plugin do not create an Emburk Java host, admitted plugin, runtime dependency,

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -60,6 +60,14 @@ columns constructed and reached the run callback without changing their
 ordered fingerprints. This does not add Native or Verified schema support,
 name lookup, nullability, Page/value encoding, or a lifecycle contract.
 
+The private ordered logical schema is Partial/internal. Primary and independent
+[S06 acceptance](provenance/T-0012-ordered-schema-differential.md) compares the
+same three selected cases against actual S05 run-phase data and preserves
+the duplicate-name pair as two ordered positions. Internal tests also cover
+owned-name storage and malformed evidence. This is not a full schema API,
+validation policy, arbitrary-name compatibility, lookup, nullability, values,
+Page/Arrow encoding or lifecycle claim. Integration is pending.
+
 ## Adding an Entry
 
 Each entry must identify the Embulk version, exact plugin artifact, configuration fixture, expected evidence, source/provenance record, and known deviations. Claims enter this document only after review evidence exists.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,8 +37,9 @@ that limited matrix does not satisfy the full configuration/schema/value or
 lifecycle gate.
 
 S05 primary schema observations at `cc24730` preserve ordered columns and
-duplicate names across handoff. Independent acceptance passed; integration is
-pending. They inform a future private schema representation, not Arrow/value
+duplicate names across handoff. Independent acceptance passed and PR #68
+integrated as `68559dc`. S06 adds a private ordered representation and bounded
+live comparison under ADR-0007, not Arrow/value
 encoding or completion of the Phase 0 contract gate.
 
 ## Phase 1: Native File-to-File MVP

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,6 +42,11 @@ integrated as `68559dc`. S06 adds a private ordered representation and bounded
 live comparison under ADR-0007, not Arrow/value
 encoding or completion of the Phase 0 contract gate.
 
+S06 primary acceptance at `c7c7872` matches three ordered schema outcomes with
+the private Rust model. The bounded result advances the logical-contract
+foundation but does not satisfy the full schema/value or lifecycle exit gate;
+independent acceptance passed and integration is pending.
+
 ## Phase 1: Native File-to-File MVP
 
 - Build the compact execution core and MVP CLI.

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -92,6 +92,11 @@ representation; a name-keyed map alone would lose the observed duplicate case.
 They do not settle lookup, renaming, null handling, mismatch timing or physical
 value encodings, and do not establish a Rust schema API.
 
+S06 now implements the private ordered-vector boundary under ADR-0007. Its
+three-case live comparison has primary and independent acceptance; integration
+is pending. This storage-only model does not resolve the remaining
+worksheet cells or authorize physical encoding/public API choices.
+
 ## Logical records and physical batches
 
 Keep the logical compatibility contract independent of physical Arrow storage.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -26,7 +26,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021 (`In Progress`) and T-0012/S05 (`In Progress`) are the only active work
+T-0021 (`In Progress`) and T-0012/S06 (`In Progress`) are the only active work
 items. The combined WIP is two of two; no item is `Ready` or `Blocked`.
 
 | Item | State | Purpose |
@@ -35,7 +35,7 @@ items. The combined WIP is two of two; no item is `Ready` or `Blocked`.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S05 | In Progress | Schema-boundary reference observations; S01–S04 integrated |
+| T-0012/S06 | In Progress | Private ordered schema and live comparison; S01–S05 integrated |
 | T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
@@ -122,6 +122,10 @@ S05 primary acceptance at `cc24730` recorded three schema construction/handoff
 successes: zero columns, six ordered logical types, and two same-name columns
 with distinct types. Actual transaction/run fingerprints matched. Its strict
 evidence validator and mutated-copy controls passed the exact Demo. Independent
-Tester reproduced it and S01/S02/S04 regressions; integration remains pending.
+Tester reproduced it and S01/S02/S04 regressions; PR #68 integrated as `68559dc`.
 This is Reference Observation /
 Integration only; no Rust schema, values or batches are added.
+
+S06 is implementing the private ordered schema permitted by ADR-0007 and a
+three-case live comparator. Its acceptance is pending; no schema support or
+physical encoding claim follows from the packet.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -16,6 +16,9 @@ Development state: `bootstrap`
 - Thirteen selected private raw-scalar outcomes match the pinned Embulk
   executable in a live differential test. No full configuration, plugin,
   data-transfer, or performance claim has passed its evidence gate.
+- A private ordered logical schema preserves owned names, type tags, order and
+  duplicates. Its live comparison matches three selected schema outcomes;
+  values, nullability, lookup and physical encoding remain unimplemented.
 - The product strategy selects a compact Rust execution core, optional
   out-of-process compatibility hosts, explicit versioned compatibility, and a
   native File-to-File vertical slice as the first runtime milestone.
@@ -126,6 +129,11 @@ Tester reproduced it and S01/S02/S04 regressions; PR #68 integrated as `68559dc`
 This is Reference Observation /
 Integration only; no Rust schema, values or batches are added.
 
-S06 is implementing the private ordered schema permitted by ADR-0007 and a
-three-case live comparator. Its acceptance is pending; no schema support or
-physical encoding claim follows from the packet.
+S06 implements the private ordered schema permitted by ADR-0007 and a
+three-case live comparator. Primary acceptance at `c7c7872` passed all three
+live outcomes and negative controls; workspace tests passed 14 with two
+explicitly ignored live tests, plus format and strict Clippy. Independent
+Tester reproduced S06 and S04 live regression; integration remains pending.
+Its evidence is Unit/Contract plus
+Differential for the three selected ordered outcomes only; no public schema
+support or physical encoding claim follows.

--- a/docs/decisions/ADR-0007-private-ordered-logical-schema.md
+++ b/docs/decisions/ADR-0007-private-ordered-logical-schema.md
@@ -1,0 +1,35 @@
+# ADR-0007: Private Ordered Logical Schema Before Physical Encoding
+
+- Status: Accepted
+- Date: 2026-09-06
+
+## Context
+
+T-0012/S05 observed empty, six-type ordered and duplicate-name schemas against
+the pinned Embulk executable. Each reached run with the same ordered columns.
+Names alone cannot identify a column: the duplicate fixture retains two
+different positions and types. No name lookup, nullability or Page/value
+encoding behavior was established.
+
+## Decision
+
+Permit T-0012/S06 to add a private, dependency-free ordered schema in
+`emburk-core`. Store owned names and an original six-variant logical type tag in
+an ordered vector. Construction and read-only iteration preserve supplied
+order, names and duplicates. Position is the sequence index, not a name-keyed
+identity. Do not add uniqueness checks, name lookup or deduplication.
+
+The logical tags represent Boolean, signed 64-bit, 64-bit float, text, timestamp
+and JSON categories only. They do not choose representations for values,
+precision, encoding, nullability or Arrow. No new crate, public API, parser,
+plugin trait or serialization is authorized. A test-only live comparator must
+compare the three supported outcomes with actual S05 oracle data.
+
+## Consequences
+
+This preserves the observed duplicate/order cases without prematurely binding
+the logical model to Arrow or a plugin interface. ADR-0004 remains a target
+direction; physical batch representation still needs separate value round-trip
+evidence. Arbitrary owned-name preservation is an internal storage invariant,
+not a claim that all possible names passed Embulk validation. Public exposure,
+schema transformations and unsupported semantics require another packet.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -10,3 +10,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0004](ADR-0004-arrow-compatible-logical-batches.md) | Arrow-compatible logical batches | Accepted |
 | [ADR-0005](ADR-0005-traceable-license-aware-reimplementation.md) | Traceable, license-aware reimplementation | Accepted |
 | [ADR-0006](ADR-0006-private-raw-scalar-resolution-before-parser.md) | Private raw scalar resolution before parser adoption | Accepted |
+| [ADR-0007](ADR-0007-private-ordered-logical-schema.md) | Private ordered logical schema before physical encoding | Accepted |

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -33,4 +33,8 @@
   Empty, ordered six-type and duplicate-name schemas reached run unchanged;
   independent Tester reproduced the exact Demo and S01/S02/S04 regressions,
   all with final exit 0. Format, strict Clippy, syntax and offline tests passed.
-  Integration is pending; evidence remains Reference Observation / Integration.
+  Final-head Demo at `cc40f0f` passed and PR #68 integrated as `68559dc`;
+  evidence remains Reference Observation / Integration, with parent #15 open.
+- Accepted ADR-0007 and activated S06 after S05 integration: private ordered
+  schema and three-case live comparison, preserving duplicate names and order.
+  Its 3 SP is within Current SP 8; values, lookup, Arrow and APIs stay deferred.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -38,3 +38,8 @@
 - Accepted ADR-0007 and activated S06 after S05 integration: private ordered
   schema and three-case live comparison, preserving duplicate names and order.
   Its 3 SP is within Current SP 8; values, lookup, Arrow and APIs stay deferred.
+- S06 primary acceptance passed at `c7c7872`: three actual schema outcomes
+  matched, negative controls passed, and 14 offline tests passed with two live
+  tests intentionally ignored. Review removed fixed outcome-hash gates and
+  corrected expected-only mutation coverage. Independent Tester reproduced S06,
+  S04 regression and offline/static checks. Integration is pending.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -12,4 +12,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S03 internal scalar resolution](T-0012-scalar-resolution.md) | Done (Unit/Contract; PR #66) |
 | [T-0012/S04 live scalar differential](T-0012-live-scalar-differential.md) | Done (selected typed Differential; PR #67) |
 | [T-0012/S05 schema-boundary observation](T-0012-schema-boundary-probe.md) | Done (Reference Observation / Integration; PR #68) |
-| [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | In Progress (acceptance pending) |
+| [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | In Progress (independent acceptance passed; integration pending) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -11,4 +11,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S02 configuration-conversion reference probe](T-0012-config-conversion-probe.md) | Done (Reference Observation / Integration) |
 | [T-0012/S03 internal scalar resolution](T-0012-scalar-resolution.md) | Done (Unit/Contract; PR #66) |
 | [T-0012/S04 live scalar differential](T-0012-live-scalar-differential.md) | Done (selected typed Differential; PR #67) |
-| [T-0012/S05 schema-boundary observation](T-0012-schema-boundary-probe.md) | In Progress (independent acceptance passed; integration pending) |
+| [T-0012/S05 schema-boundary observation](T-0012-schema-boundary-probe.md) | Done (Reference Observation / Integration; PR #68) |
+| [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | In Progress (acceptance pending) |

--- a/docs/provenance/T-0012-ordered-schema-differential.md
+++ b/docs/provenance/T-0012-ordered-schema-differential.md
@@ -2,7 +2,7 @@
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
 - Branch: `feat/t-0012-ordered-logical-schema`
-- State: In Progress; acceptance pending
+- State: In Progress; independent acceptance passed, integration pending
 - Owner: Rust Core Implementer; canonical records/integration: Project Manager
 - Dependencies: T-0011 and S05, integrated through PR #68 as
   `68559dc8b81d45c2b236db3d1e5266f70ab589a9`
@@ -26,7 +26,8 @@ Implementer owns exactly:
 Do not change S05's runner, Java probe or tests, the scalar resolver, Cargo
 manifests, production dependencies or public APIs. PM separately owns STATUS,
 TODO, ROADMAP, ARCHITECTURE, COMPATIBILITY, relevant ADRs, provenance/index and
-the dated log. Implementation and canonical records remain disjoint.
+the dated log; RUST_RUNTIME_DESIGN may be reconciled to accepted observations.
+Implementation and canonical records remain disjoint.
 
 Use a private LogicalSchema containing ordered LogicalColumns, each with owned
 UTF-8 name and logical type (Boolean, Signed64, Float64, Text, Timestamp, Json).
@@ -87,3 +88,46 @@ expansion for unknown semantic mappings, new dependencies/APIs/encodings,
 source translation, redistribution or material IP/security uncertainty. If the
 accepted oracle format cannot be consumed without changing S05, repacket rather
 than modifying its files silently.
+
+## Primary acceptance
+
+At source revision `c7c7872`, the primary agent ran the exact Demo by absolute
+path from `/private/tmp`: exit 0, three live schema comparisons in exactly one
+selected ignored Rust test (one passed, zero ignored). The new negative-control
+test also selected exactly one test. Offline workspace tests passed 14 with two
+intentional live-test ignores; format, strict workspace/all-target Clippy and
+diff checks exited 0.
+
+External evidence: `${TMPDIR}/t0012-s06.J9p9ak`. Its `live.tsv` has 12 lines:
+one version header, three CASE rows and eight ordered FIELD rows. SHA-256:
+`053c68f737661786f709e488a57ef9075092294fa6c0ca673a2ae5651293a66b`.
+Recorded actual raw evidence hashes are the S05 hashes; they are computed
+observations, not hardcoded outcome acceptance gates. The manifest retains the
+live oracle evidence directory before normalization.
+
+Review removed a draft outcome-hash gate and corrected an initially input-side
+mutation into an explicitly verified expected-only mutation. Driver negative
+controls re-fingerprint mutated phases so unknown-type and phase-mismatch tests
+exercise their intended rejection paths rather than merely checksum rejection.
+A positive synthetic test preserves changed actual output through TSV while
+leaving the test-owned input unchanged. Huge row counts reject before capacity
+allocation. None of these synthetic checks adds an upstream observation.
+
+Evidence: Unit/Contract internal storage plus Differential for the three selected
+ordered schema outcomes. Primary scalar live regression also passed 13 cases
+with exit 0 (`${TMPDIR}/t0012-s04.dNquvT`).
+
+Independent Tester reproduced the exact S06 Demo and S04 regression at full
+revision `c7c787202ce3c5321191773f94a2680617cba705`, each with final exit 0.
+Normal and `PYTHONOPTIMIZE=1` driver self-tests passed; format, strict Clippy,
+offline workspace tests (14 passed, 2 intentional live ignores) and diff checks
+passed. No implementation or acceptance finding remains open.
+
+Tester logs: `/private/tmp/emburk-t0012-s06-acceptance-20260906T011105/`.
+`s06-demo.log` SHA-256:
+`3dae1763ddd9195f3ce447bee56c7ac16283feb89cd85a4bfa61fc56229851d6`.
+Tester live evidence `${TMPDIR}/t0012-s06.dpJVxD` has the same TSV hash as primary
+acceptance. Its raw-record hash file SHA-256 is
+`9946b294746847657f31dca792953d09163d923f2fb9a3bb96f1c52bc5428476`.
+Platform: macOS 26.5.1 arm64, Bash 3.2.57, Python 3.14.6, Rust/Cargo 1.98.1,
+Temurin JDK 17.0.20. PR integration remains pending; parent T-0012 is not complete.

--- a/docs/provenance/T-0012-ordered-schema-differential.md
+++ b/docs/provenance/T-0012-ordered-schema-differential.md
@@ -1,0 +1,89 @@
+# T-0012/S06 private ordered schema and live comparison
+
+- Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
+- Branch: `feat/t-0012-ordered-logical-schema`
+- State: In Progress; acceptance pending
+- Owner: Rust Core Implementer; canonical records/integration: Project Manager
+- Dependencies: T-0011 and S05, integrated through PR #68 as
+  `68559dc8b81d45c2b236db3d1e5266f70ab589a9`
+- Authority: owner implementation request and accepted ADR-0007
+- Estimate: 3 SP within unchanged Current SP 8 / Initial SP 5. Raw score:
+  implementation 1, uncertainty 0 (bounded accepted observations), verification
+  2 (live plus negative comparison), environment 1 (established Java route).
+  No parent completion, additional estimate or duplicate velocity is implied.
+
+## Mutation packet
+
+Implementer owns exactly:
+
+- `crates/emburk-core/src/lib.rs`: private module declaration and narrowly
+  scoped unused-code rationale only;
+- `crates/emburk-core/src/logical_schema.rs`: original ordered representation,
+  unit tests and test-only live transport bridge;
+- `tools/t0012-schema-differential`: new Python-standard-library driver;
+- `tests/t0012_schema_differential_test.sh`: new Demo and negative checks.
+
+Do not change S05's runner, Java probe or tests, the scalar resolver, Cargo
+manifests, production dependencies or public APIs. PM separately owns STATUS,
+TODO, ROADMAP, ARCHITECTURE, COMPATIBILITY, relevant ADRs, provenance/index and
+the dated log. Implementation and canonical records remain disjoint.
+
+Use a private LogicalSchema containing ordered LogicalColumns, each with owned
+UTF-8 name and logical type (Boolean, Signed64, Float64, Text, Timestamp, Json).
+Construction and ordered iteration preserve the supplied vector exactly;
+duplicate names remain separate positions. No name lookup, uniqueness policy,
+renaming, nullability, concrete values, Pages, Arrow or serialization is added.
+Unit tests include empty, six ordered types and same-name/different-type pairs;
+additional arbitrary-name tests establish only internal storage invariants.
+
+## Live comparison and acceptance
+
+The new driver invokes the unchanged S05 schema mode. Retain its actual raw
+evidence paths and results before normalization; retrieval or missing evidence
+cannot become an offline skip. Independently check the exact three-case set,
+canonical Base64/UTF-8 fields, unique contiguous indices, count/fingerprints,
+phase equality, known type names and successful actual run outcomes. Never
+select outputs by fixture ID; IDs constrain membership/count only. Input columns
+are test-owned, while expected columns come from actual oracle run-phase rows.
+Reject unknown output types rather than guessing a fallback.
+
+Transport is a versioned UTF-8 TSV with explicit case boundaries/counts and
+hex-encoded names, preserving empty schemas, names and duplicate positions.
+The Rust bridge is test-only and invokes the real private representation. Do
+not embed upstream expected columns as a live fallback. Test missing/duplicate/
+truncated/malformed evidence, unknown types, broken encodings, phase mismatch
+and expected-only mutation; the latter must leave input columns unchanged.
+
+Demo Command: `tests/t0012_schema_differential_test.sh`. It runs offline negative
+checks, the actual S05 oracle and exactly one fully qualified ignored Rust test
+covering all three live cases. Prove the selected test ran (zero filtered matches
+must fail); normal offline tests explicitly ignore live tests. Run workspace
+format, strict Clippy, tests and diff checks, plus S04 live regression. Independent
+Tester reproduction at a frozen revision and record reconciliation precede PR
+integration. Retain all raw artifacts/logs outside the repository.
+
+Evidence target: Unit/Contract for internal storage, Differential for exactly
+three selected ordered schema outcomes. No full schema/API, name lookup,
+nullability, values, Arrow, lifecycle, plugin, transfer or general compatibility
+claim; parent T-0012 remains open.
+
+## Provenance and stop boundary
+
+Access date: 2026-09-06. Only S05's accepted runtime observations influence this
+slice; see its [exact reference and license record](T-0012-schema-boundary-probe.md).
+Official Embulk 0.11.5 executable SHA-256:
+`e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`;
+core commit `c5ac2d471edac465b45088669d376a7e2a525f8f`, SPI 0.11 commit
+`576e98033a14ba8ac994ed581d3c9d8fcdda2749`. S05's six observed type-name strings
+map only to the corresponding internal category; observed names are data, not
+reused upstream implementation. No new source or tests are inspected, copied
+or translated. Apache-2.0 source classification is not patent/FTO clearance.
+Executable LICENSE/NOTICE stay in external oracle evidence; no JAR, dependency
+or plugin is newly admitted or redistributed. SBOM, redistribution, patent,
+standards and freedom-to-operate review remain unreviewed.
+
+Repair ordinary harness/build/retrieval problems within this packet. Stop scope
+expansion for unknown semantic mappings, new dependencies/APIs/encodings,
+source translation, redistribution or material IP/security uncertainty. If the
+accepted oracle format cannot be consumed without changing S05, repacket rather
+than modifying its files silently.

--- a/docs/provenance/T-0012-schema-boundary-probe.md
+++ b/docs/provenance/T-0012-schema-boundary-probe.md
@@ -2,7 +2,8 @@
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
 - Branch: `research/t-0012-schema-boundary`
-- State: In Progress; independent acceptance passed, integration pending
+- State: Done as a slice; integrated through PR #68 as
+  `68559dc8b81d45c2b236db3d1e5266f70ab589a9`; parent remains open
 - Owner: Compatibility Host Implementer; records/integration: Project Manager
 - Slice estimate: 3 SP within Current SP 8; Initial SP remains 5. Do not sum
   parent and slice delivery or award parent completion.
@@ -128,4 +129,6 @@ Tester schema evidence `run.AgBYWy/evidence` has the same two raw-record hashes
 as primary acceptance above. Platform: macOS 26.5.1 arm64, Bash 3.2.57,
 Rust/Cargo 1.98.1, Python 3.14.6, Temurin JDK 17.0.20. No new source or runtime
 artifact is redistributed. Evidence remains Reference Observation / Integration
-only. PR integration remains pending; parent T-0012 is not complete.
+only. Final-head primary Demo at `cc40f0fae1730075271b37d348eeab34769e5158`
+exited 0 with evidence `run.r71A1u/evidence`. PR #68 integrated the slice;
+parent T-0012 is not complete.

--- a/tests/t0012_schema_differential_test.sh
+++ b/tests/t0012_schema_differential_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+evidence_dir=${T0012_S06_EVIDENCE_DIR:-$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-s06.XXXXXX")}
+mkdir -p -- "$evidence_dir"
+printf 'T0012_S06_EVIDENCE_DIR=%s\n' "$evidence_dir"
+
+"$root/tools/t0012-schema-differential" --self-test > "$evidence_dir/python-self-test.log" 2>&1
+cargo test --manifest-path "$root/Cargo.toml" -p emburk-core logical_schema::tests::live_tsv_bridge_rejects_invalid_or_mutated_evidence -- --exact > "$evidence_dir/rust-negative-controls.log" 2>&1
+grep -Fqx 'test logical_schema::tests::live_tsv_bridge_rejects_invalid_or_mutated_evidence ... ok' "$evidence_dir/rust-negative-controls.log"
+grep -Eq '^test result: ok\. 1 passed; 0 failed; 0 ignored; .* filtered out;' "$evidence_dir/rust-negative-controls.log"
+
+"$root/tools/t0012-schema-differential" --tsv "$evidence_dir/live.tsv" --evidence-manifest "$evidence_dir/oracle-evidence-directories.txt" --raw-hashes "$evidence_dir/raw-evidence-hashes.txt" > "$evidence_dir/driver.log" 2>&1
+[[ $(wc -l < "$evidence_dir/live.tsv" | tr -d ' ') == 12 ]]
+grep -Eq '^schema-cases\.raw=[0-9a-f]{64}$' "$evidence_dir/raw-evidence-hashes.txt"
+grep -Eq '^schema-results\.raw=[0-9a-f]{64}$' "$evidence_dir/raw-evidence-hashes.txt"
+
+T0012_S06_TSV="$evidence_dir/live.tsv" cargo test --manifest-path "$root/Cargo.toml" -p emburk-core logical_schema::tests::live_schema_differential -- --ignored --exact > "$evidence_dir/live-rust-test.log" 2>&1
+grep -Fqx 'test logical_schema::tests::live_schema_differential ... ok' "$evidence_dir/live-rust-test.log"
+grep -Eq '^test result: ok\. 1 passed; 0 failed; 0 ignored; .* filtered out;' "$evidence_dir/live-rust-test.log"
+printf '%s\n' 'T0012/S06: compared exactly 3 live ordered schema outcomes; negative controls passed'

--- a/tools/t0012-schema-differential
+++ b/tools/t0012-schema-differential
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Validate S05 raw schema evidence and bridge it to the private Rust test."""
+import argparse
+import base64
+import binascii
+import hashlib
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "tools/t0012-config-presence/run.sh"
+CASES = ("empty", "ordered6types", "duplicate-name-differing-types")
+INPUT = {
+    "empty": (),
+    "ordered6types": (("boolean_column", "boolean"), ("long_column", "signed64"), ("double_column", "float64"), ("string_column", "text"), ("timestamp_column", "timestamp"), ("json_column", "json")),
+    "duplicate-name-differing-types": (("duplicate", "boolean"), ("duplicate", "text")),
+}
+TYPE_MAP = {"boolean": "boolean", "long": "signed64", "double": "float64", "string": "text", "timestamp": "timestamp", "json": "json"}
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+def b64(value):
+    try:
+        decoded = base64.b64decode(value, validate=True)
+        decoded.decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError) as error:
+        raise ValueError("malformed base64/UTF-8 field") from error
+    require(base64.b64encode(decoded).decode("ascii") == value, "non-canonical base64 field")
+    return decoded.decode("utf-8")
+
+def invoke(manifest):
+    completed = subprocess.run([str(RUNNER)], env={**os.environ, "T0012_MODE": "schema"}, text=True, capture_output=True, check=False)
+    paths = [line.split("=", 1)[1] for line in completed.stdout.splitlines() if line.startswith("T0012_EVIDENCE_DIR=")]
+    require(len(paths) == 1, "schema oracle did not report exactly one evidence directory")
+    path = pathlib.Path(paths[0])
+    manifest.write_text(f"schema={path}\n", encoding="utf-8")
+    if completed.returncode:
+        sys.stderr.write(completed.stderr)
+        raise ValueError(f"schema oracle exited {completed.returncode}; evidence={path}")
+    return path
+
+def raw_hashes(evidence):
+    hashes = {}
+    for filename in ("schema-cases.raw", "schema-results.raw"):
+        payload = (evidence / filename).read_bytes()
+        require(payload, f"missing raw evidence: {filename}")
+        hashes[filename] = hashlib.sha256(payload).hexdigest()
+    return hashes
+
+def parse(evidence):
+    cases = {}
+    for line in (evidence / "schema-cases.raw").read_text(encoding="utf-8").splitlines():
+        fields = line.split("|")
+        require(len(fields) == 5 and fields[0] == "SCHEMA_CASE", "malformed schema case")
+        _, fixture, code, outcome, entered = fields
+        require(fixture in CASES and fixture not in cases, "unknown or duplicate schema case")
+        require(code == "0" and outcome == "SUCCESS" and entered == "1", "schema case did not reach successful run")
+        cases[fixture] = True
+    require(tuple(cases) == CASES, "schema case manifest is not exact")
+    data = {case: {"fields": {"transaction": [], "run": []}, "phases": {}, "entered": 0} for case in CASES}
+    for line in (evidence / "schema-results.raw").read_text(encoding="utf-8").splitlines():
+        fields = line.split("|")
+        require(len(fields) >= 2 and fields[1] in data, "unknown schema result fixture")
+        if fields[0] == "SCHEMA_FIELD":
+            require(len(fields) == 6, "malformed schema field")
+            _, fixture, phase, index, name, type_name = fields
+            require(phase in {"transaction", "run"} and index.isdigit(), "malformed schema field position")
+            data[fixture]["fields"][phase].append((int(index), b64(name), b64(type_name)))
+        elif fields[0] == "SCHEMA_PHASE":
+            require(len(fields) == 5, "malformed schema phase")
+            _, fixture, phase, count, fingerprint = fields
+            require(phase in {"transaction", "run"} and count.isdigit() and phase not in data[fixture]["phases"], "malformed schema phase")
+            require(len(fingerprint) == 64 and all(char in "0123456789abcdef" for char in fingerprint), "malformed schema fingerprint")
+            data[fixture]["phases"][phase] = (int(count), fingerprint)
+        elif fields[0] == "CONTROL_RUN_ENTERED":
+            require(len(fields) == 2, "malformed run entry")
+            data[fixture]["entered"] += 1
+        else:
+            raise ValueError("unexpected schema result row")
+    expected = {}
+    for fixture, entry in data.items():
+        require(entry["entered"] == 1, "schema case did not enter run exactly once")
+        require(set(entry["phases"]) == {"transaction", "run"}, "missing schema phase")
+        for phase, (count, fingerprint) in entry["phases"].items():
+            rows = entry["fields"][phase]
+            require(count == len(rows), "schema phase count does not match fields")
+            require([row[0] for row in rows] == list(range(count)), "schema indices are not contiguous")
+            material = "".join(f"{index}|{base64.b64encode(name.encode()).decode()}|{base64.b64encode(type_name.encode()).decode()}\n" for index, name, type_name in rows)
+            require(hashlib.sha256(material.encode()).hexdigest() == fingerprint, "schema fingerprint mismatch")
+        require(entry["phases"]["transaction"] == entry["phases"]["run"], "transaction/run phase mismatch")
+        columns = []
+        for _, name, type_name in entry["fields"]["run"]:
+            try:
+                columns.append((name, TYPE_MAP[type_name]))
+            except KeyError as error:
+                raise ValueError("unknown output type") from error
+        expected[fixture] = tuple(columns)
+    return expected
+
+def write_tsv(expected, output):
+    rows = ["T0012-S06\t1"]
+    for fixture in CASES:
+        input_columns = INPUT[fixture]
+        oracle_columns = expected[fixture]
+        require(len(input_columns) == len(oracle_columns), "oracle count differs from test-owned input")
+        rows.append(f"CASE\t{fixture}\t{len(input_columns)}")
+        for index, ((input_name, input_type), (expected_name, expected_type)) in enumerate(zip(input_columns, oracle_columns, strict=True)):
+            rows.append("\t".join(("FIELD", str(index), input_name.encode().hex(), input_type, expected_name.encode().hex(), expected_type)))
+    output.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+def self_test():
+    require(b64("Ym9vbGVhbl9jb2x1bW4=") == "boolean_column", "base64 decode failed")
+    for bad in ("!", "YQ", "//8="):
+        try: b64(bad)
+        except ValueError: pass
+        else: raise ValueError("broken encoding accepted")
+    with tempfile.TemporaryDirectory() as temporary:
+        root = pathlib.Path(temporary)
+        fields = {
+            "empty": (),
+            "ordered6types": (("boolean_column", "boolean"), ("long_column", "long"), ("double_column", "double"), ("string_column", "string"), ("timestamp_column", "timestamp"), ("json_column", "json")),
+            "duplicate-name-differing-types": (("duplicate", "boolean"), ("duplicate", "string")),
+        }
+        cases = []
+        results = []
+        for fixture in CASES:
+            rows = []
+            for phase in ("transaction", "run"):
+                phase_rows = []
+                for index, (name, kind) in enumerate(fields[fixture]):
+                    encoded_name = base64.b64encode(name.encode()).decode()
+                    encoded_kind = base64.b64encode(kind.encode()).decode()
+                    results.append(f"SCHEMA_FIELD|{fixture}|{phase}|{index}|{encoded_name}|{encoded_kind}")
+                    phase_rows.append(f"{index}|{encoded_name}|{encoded_kind}\n")
+                results.append(f"SCHEMA_PHASE|{fixture}|{phase}|{len(phase_rows)}|{hashlib.sha256(''.join(phase_rows).encode()).hexdigest()}")
+            results.append(f"CONTROL_RUN_ENTERED|{fixture}")
+            cases.append(f"SCHEMA_CASE|{fixture}|0|SUCCESS|1")
+        root.joinpath("schema-cases.raw").write_text("\n".join(cases) + "\n", encoding="utf-8")
+        root.joinpath("schema-results.raw").write_text("\n".join(results) + "\n", encoding="utf-8")
+        parsed = parse(root)
+        require(parsed["ordered6types"][0] == ("boolean_column", "boolean"), "valid fixture parse failed")
+        original_input = INPUT["ordered6types"]
+        changed = results.copy()
+        position = next(i for i, row in enumerate(changed) if row.startswith("SCHEMA_FIELD|ordered6types|transaction|0|"))
+        changed[position] = changed[position].replace("Ym9vbGVhbl9jb2x1bW4=", "Y2hhbmdlZF9jb2x1bW4=")
+        position = next(i for i, row in enumerate(changed) if row.startswith("SCHEMA_FIELD|ordered6types|run|0|"))
+        changed[position] = changed[position].replace("Ym9vbGVhbl9jb2x1bW4=", "Y2hhbmdlZF9jb2x1bW4=")
+        for phase in ("transaction", "run"):
+            start = [i for i, row in enumerate(changed) if row.startswith(f"SCHEMA_FIELD|ordered6types|{phase}|")]
+            material = "".join("|".join(changed[i].split("|")[3:]) + "\n" for i in start)
+            phase_index = next(i for i, row in enumerate(changed) if row.startswith(f"SCHEMA_PHASE|ordered6types|{phase}|"))
+            changed[phase_index] = f"SCHEMA_PHASE|ordered6types|{phase}|6|{hashlib.sha256(material.encode()).hexdigest()}"
+        root.joinpath("schema-results.raw").write_text("\n".join(changed) + "\n", encoding="utf-8")
+        require(parse(root)["ordered6types"][0][0] == "changed_column", "changed actual was not preserved")
+        require(INPUT["ordered6types"] == original_input, "actual mutation changed test-owned input")
+        write_tsv(parse(root), root / "changed.tsv")
+        changed_field = next(line.split("\t") for line in (root / "changed.tsv").read_text(encoding="utf-8").splitlines() if line.startswith("FIELD\t0\t") and "changed_column".encode().hex() in line)
+        require(changed_field[2] == "boolean_column".encode().hex() and changed_field[4] == "changed_column".encode().hex(), "TSV did not keep input and expected columns separate")
+        failures = {
+            "missing": None,
+            "duplicate": None,
+            "truncated": None,
+            "unknown-type": "unknown output type",
+            "bad-b64": None,
+            "phase-mismatch": "transaction/run phase mismatch",
+        }
+        for action, expected_failure in failures.items():
+            root.joinpath("schema-cases.raw").write_text("\n".join(cases) + "\n", encoding="utf-8")
+            mutated = results.copy()
+            if action == "missing":
+                mutated.pop(0)
+            elif action == "duplicate":
+                mutated.append(mutated[0])
+            elif action == "truncated":
+                index = next(i for i, row in enumerate(mutated) if row.startswith("SCHEMA_FIELD|ordered6types|transaction|0|"))
+                mutated[index] = "SCHEMA_FIELD"
+            else:
+                index = next(i for i, row in enumerate(mutated) if row.startswith("SCHEMA_FIELD|ordered6types|transaction|0|"))
+                if action == "unknown-type":
+                    mutated[index] = mutated[index].rsplit("|", 1)[0] + "|dW5rbm93bg=="
+                    run_index = next(i for i, row in enumerate(mutated) if row.startswith("SCHEMA_FIELD|ordered6types|run|0|"))
+                    mutated[run_index] = mutated[run_index].rsplit("|", 1)[0] + "|dW5rbm93bg=="
+                elif action == "bad-b64":
+                    mutated[index] = mutated[index].replace("Ym9vbGVhbl9jb2x1bW4=", "!")
+                else:
+                    run_index = next(i for i, row in enumerate(mutated) if row.startswith("SCHEMA_FIELD|ordered6types|run|0|"))
+                    mutated[run_index] = mutated[run_index].replace("Ym9vbGVhbl9jb2x1bW4=", "Y2hhbmdlZA==")
+                if action in {"unknown-type", "phase-mismatch"}:
+                    phases = ("transaction", "run") if action == "unknown-type" else ("run",)
+                    for phase in phases:
+                        field_indices = [i for i, row in enumerate(mutated) if row.startswith(f"SCHEMA_FIELD|ordered6types|{phase}|")]
+                        material = "".join("|".join(mutated[i].split("|")[3:]) + "\n" for i in field_indices)
+                        phase_index = next(i for i, row in enumerate(mutated) if row.startswith(f"SCHEMA_PHASE|ordered6types|{phase}|"))
+                        mutated[phase_index] = f"SCHEMA_PHASE|ordered6types|{phase}|6|{hashlib.sha256(material.encode()).hexdigest()}"
+            root.joinpath("schema-results.raw").write_text("\n".join(mutated) + "\n", encoding="utf-8")
+            try: parse(root)
+            except ValueError as error:
+                if expected_failure is not None:
+                    require(str(error) == expected_failure, f"{action} used the wrong rejection path")
+            else: raise ValueError(f"{action} evidence accepted")
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tsv", type=pathlib.Path)
+    parser.add_argument("--evidence-manifest", type=pathlib.Path)
+    parser.add_argument("--raw-hashes", type=pathlib.Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.self_test:
+            self_test(); return 0
+        require(args.tsv and args.evidence_manifest and args.raw_hashes, "--tsv, --evidence-manifest, and --raw-hashes are required")
+        evidence = invoke(args.evidence_manifest)
+        raw = raw_hashes(evidence)
+        args.raw_hashes.write_text("".join(f"{name}={digest}\n" for name, digest in raw.items()), encoding="utf-8")
+        expected = parse(evidence)
+        write_tsv(expected, args.tsv)
+    except (OSError, ValueError) as error:
+        print(f"T0012/S06 driver rejected oracle: {error}", file=sys.stderr)
+        return 4
+    return 0
+
+if __name__ == "__main__": sys.exit(main())


### PR DESCRIPTION
## Scope
Refs #15 — T-0012/S06 only, parent remains open.

Private dependency-free ordered schema stores owned names and six logical type tags without dropping order or duplicate names. Original live comparator consumes unchanged S05 actual run-phase evidence. No lookup, uniqueness policy, nullability, concrete values, Arrow, public API or plugin traits.

## Acceptance
Primary and independent Tester reproduced the exact schema Demo at c7c7872: three selected outcomes matched, exactly one live test executed. S04 regression matched all 13 scalar outcomes. Offline workspace tests: 14 passed, 2 intentional live ignores. Format, strict Clippy, per-script shell syntax, normal/optimized Python self-tests and diff checks passed. Expected-only mutations preserve input columns; unknown-type and phase mismatch tests recompute digests to prove intended rejection paths. Raw output hashes are recorded, not acceptance snapshot gates.

1b13016 updates records only. Evidence hashes and non-claims: docs/provenance/T-0012-ordered-schema-differential.md. ADR-0007 scopes the private boundary.

Evidence Unit/Contract plus Differential for three selected schemas only. No full schema, lifecycle, transfer or parent-completion claim. 3-SP slice within Current SP 8, Initial SP 5 unchanged.