### PR TITLE
test(t-0013): observe zero and one task input lifecycle

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S01` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
+`T-0013/S01` is `Review`; `T-0012`, `T-0021` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01: input callback observations) | In Progress | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01: input callback observations) | Review | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -165,3 +165,9 @@ retry, resume, production traits and delivery guarantees. T-0012 and T-0021
 return to Backlog, not Done or Blocked, so this missing lifecycle evidence can
 advance the core-trait dependency. Accepted slices remain accepted; no parent
 velocity is awarded.
+
+S01 primary acceptance at `b3f9c68` passed the two live input fixtures and all
+artifact/trace controls. Independent Tester reproduced the complete Demo;
+integration remains pending.
+The next lifecycle decision needs direct output-side observations before
+assigning commit, abort or close responsibilities to private Rust traits.

--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,8 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0021` and `T-0012/S06` are `In Progress`, and every other item is
-`Backlog`. No item is `Blocked`. This is the two-item WIP limit.
+`T-0013/S01` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
+are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -34,8 +34,8 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S06: ordered schema differential; S01–S05 integrated) | In Progress | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics | Backlog | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01: input callback observations) | In Progress | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -43,7 +43,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
-| T-0021 | Define workspace boundaries and core traits | In Progress | P1 | 5 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
+| T-0021 | Define workspace boundaries and core traits | Backlog | P1 | 5 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
@@ -139,7 +139,7 @@ integrated as `79cbcb9`. T-0012's current estimate increased from 5 to 8 SP; Ini
 5. The refinement accounts for the explicit oracle adapter, private test bridge,
 and negative evidence validation omitted from the initial estimate. It does
 not award parent completion or change the remaining configuration/schema/value
-scope. T-0021 and T-0012 occupy the combined WIP limit of two.
+scope. T-0021 and T-0012 previously occupied the combined WIP limit of two.
 
 S05 (3 SP within Current SP 8, not additional points) observes three schema
 construction/handoff cases through the pinned executable before choosing a
@@ -156,4 +156,12 @@ nullability, values, Arrow, public APIs and plugin traits. No parent re-estimate
 or completion follows from activation.
 Primary and independent Tester acceptance passed at `c7c7872`: three live schema
 outcomes, S04 regression, strict checks and 14 offline tests with two intentional
-live ignores. Integration remains pending.
+live ignores. PR #69 integrated as `5de35b7`.
+
+T-0013/S01 (3 SP within unchanged Current/Initial SP 8) observes zero-task and
+one-task input callback traces using a separate pinned-runtime probe. Its
+[packet](docs/provenance/T-0013-input-lifecycle-probe.md) excludes fault injection,
+retry, resume, production traits and delivery guarantees. T-0012 and T-0021
+return to Backlog, not Done or Blocked, so this missing lifecycle evidence can
+advance the core-trait dependency. Accepted slices remain accepted; no parent
+velocity is awarded.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ their eventual Rust API stable.
 ADR-0007 permits a private ordered logical schema before any physical encoding
 or public exposure. S06 implements it as an owned ordered vector in the core,
 with no name lookup or deduplication. Its three-case live comparison passed
-primary and independent Tester acceptance; integration remains pending.
+primary and independent Tester acceptance and integrated through PR #69.
 Logical type tags alone do not establish value or Arrow representations.
 
 T-0012 reference probes and S04's ignored live comparison are test-only tools

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -68,6 +68,14 @@ owned-name storage and malformed evidence. This is not a full schema API,
 validation policy, arbitrary-name compatibility, lookup, nullability, values,
 Page/Arrow encoding or lifecycle claim. PR #69 integrated the slice as `5de35b7`.
 
+[T-0013/S01](provenance/T-0013-input-lifecycle-probe.md) records a bounded
+input-side reference observation: zero and one empty task processes exited 0,
+with six and ten probe markers respectively, including cleanup. The one-task
+probe's call to `PageOutput.finish()` returned normally. No resume or guess
+marker occurred. This does not establish output callback ordering, delivery,
+cleanup guarantees, failure/retry behavior or Native/Verified lifecycle support.
+Primary and independent acceptance passed; integration is pending.
+
 ## Adding an Entry
 
 Each entry must identify the Embulk version, exact plugin artifact, configuration fixture, expected evidence, source/provenance record, and known deviations. Claims enter this document only after review evidence exists.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -66,7 +66,7 @@ same three selected cases against actual S05 run-phase data and preserves
 the duplicate-name pair as two ordered positions. Internal tests also cover
 owned-name storage and malformed evidence. This is not a full schema API,
 validation policy, arbitrary-name compatibility, lookup, nullability, values,
-Page/Arrow encoding or lifecycle claim. Integration is pending.
+Page/Arrow encoding or lifecycle claim. PR #69 integrated the slice as `5de35b7`.
 
 ## Adding an Entry
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,7 +45,12 @@ encoding or completion of the Phase 0 contract gate.
 S06 primary acceptance at `c7c7872` matches three ordered schema outcomes with
 the private Rust model. The bounded result advances the logical-contract
 foundation but does not satisfy the full schema/value or lifecycle exit gate;
-independent acceptance passed and integration is pending.
+independent acceptance passed and PR #69 integrated as `5de35b7`.
+
+T-0013/S01 now supplies a separate input lifecycle observation lane for zero
+and one empty task. T-0012 and T-0021 are requeued after their accepted slices
+to address this still-missing prerequisite. This is not parent completion or a
+blocker; callback traits, cleanup guarantees and resume remain unverified.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,6 +51,9 @@ T-0013/S01 now supplies a separate input lifecycle observation lane for zero
 and one empty task. T-0012 and T-0021 are requeued after their accepted slices
 to address this still-missing prerequisite. This is not parent completion or a
 blocker; callback traits, cleanup guarantees and resume remain unverified.
+Primary acceptance records successful zero/one empty task executions and strict
+trace controls. This reference observation cannot satisfy the lifecycle exit
+gate; direct output-side and failure/recovery evidence are still missing.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -129,6 +129,12 @@ The following sequence is an Emburk orchestration proposal. Exact upstream
 callbacks, nesting, retry rules and call counts are unverified until T-0013.
 No public trait signatures should be frozen from this sequence alone.
 
+T-0013/S01's bounded input probe now records successful zero/one empty task
+executions, including input cleanup and the normal return of the one-task
+probe's `PageOutput.finish()` call. This is reference observation only. It does
+not reveal output commit/abort/close behavior; observe that boundary directly
+before making those responsibilities part of the private Rust execution model.
+
 | Phase | Coordinator responsibility | Plugin/adapter responsibility | Trace evidence required |
 |---|---|---|---|
 | Resolve and validate | Select pinned factories, resolve configuration | Validate plugin options at the compatible stage | First error, defaults applied, side effects before failure |

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -93,8 +93,8 @@ They do not settle lookup, renaming, null handling, mismatch timing or physical
 value encodings, and do not establish a Rust schema API.
 
 S06 now implements the private ordered-vector boundary under ADR-0007. Its
-three-case live comparison has primary and independent acceptance; integration
-is pending. This storage-only model does not resolve the remaining
+three-case live comparison has primary and independent acceptance and integrated
+through PR #69. This storage-only model does not resolve the remaining
 worksheet cells or authorize physical encoding/public API choices.
 
 ## Logical records and physical batches

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -29,8 +29,9 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021 (`In Progress`) and T-0012/S06 (`In Progress`) are the only active work
-items. The combined WIP is two of two; no item is `Ready` or `Blocked`.
+T-0013/S01 (`In Progress`) is the only active work item. Combined WIP is one of
+two; no item is `Ready` or `Blocked`. T-0012 and T-0021 return to Backlog after
+their accepted slices; their remaining contracts/dependencies are not complete.
 
 | Item | State | Purpose |
 |---|---|---|
@@ -38,8 +39,9 @@ items. The combined WIP is two of two; no item is `Ready` or `Blocked`.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S06 | In Progress | Private ordered schema and live comparison; S01–S05 integrated |
-| T-0021 | In Progress | Workspace skeleton (S01, PR #58) and runtime design proposal (S02) |
+| T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
+| T-0021 | Backlog | S01/S02 integrated; core traits await T-0012/T-0013 contracts |
+| T-0013/S01 | In Progress | Observe zero-task and one-task input lifecycle traces |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -133,7 +135,11 @@ S06 implements the private ordered schema permitted by ADR-0007 and a
 three-case live comparator. Primary acceptance at `c7c7872` passed all three
 live outcomes and negative controls; workspace tests passed 14 with two
 explicitly ignored live tests, plus format and strict Clippy. Independent
-Tester reproduced S06 and S04 live regression; integration remains pending.
+Tester reproduced S06 and S04 live regression; PR #69 integrated as `5de35b7`.
 Its evidence is Unit/Contract plus
 Differential for the three selected ordered outcomes only; no public schema
 support or physical encoding claim follows.
+
+T-0013/S01 now observes actual input callback traces before Rust lifecycle
+traits are chosen. Acceptance is pending; no callback, cleanup or resume
+contract is implemented or verified.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -29,7 +29,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S01 (`In Progress`) is the only active work item. Combined WIP is one of
+T-0013/S01 (`Review`) is the only active work item. Combined WIP is one of
 two; no item is `Ready` or `Blocked`. T-0012 and T-0021 return to Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -41,7 +41,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
 | T-0021 | Backlog | S01/S02 integrated; core traits await T-0012/T-0013 contracts |
-| T-0013/S01 | In Progress | Observe zero-task and one-task input lifecycle traces |
+| T-0013/S01 | Review | Accept zero-task and one-task input lifecycle traces |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -141,5 +141,9 @@ Differential for the three selected ordered outcomes only; no public schema
 support or physical encoding claim follows.
 
 T-0013/S01 now observes actual input callback traces before Rust lifecycle
-traits are chosen. Acceptance is pending; no callback, cleanup or resume
-contract is implemented or verified.
+traits are chosen. Primary acceptance at `b3f9c68` passed the exact Demo:
+zero/one empty task processes exited 0 with six/ten input probe markers,
+respectively, plus artifact and malformed-evidence controls. Independent
+Tester reproduced the complete Demo; integration is pending. No callback, cleanup or resume
+contract is implemented or verified. See the
+[S01 evidence record](provenance/T-0013-input-lifecycle-probe.md).

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -42,4 +42,10 @@
   matched, negative controls passed, and 14 offline tests passed with two live
   tests intentionally ignored. Review removed fixed outcome-hash gates and
   corrected expected-only mutation coverage. Independent Tester reproduced S06,
-  S04 regression and offline/static checks. Integration is pending.
+  S04 regression and offline/static checks. Final-head Demo at `1b13016` passed;
+  PR #69 integrated as `5de35b7`, with parent #15 open.
+- Requeued T-0012 and T-0021 after their accepted slices and activated
+  T-0013/S01's separate zero/one-task input callback observation packet.
+  Combined WIP becomes one of two; this is prioritization, not a blocker or
+  parent completion. Librarian public-interface triage passed for the pinned
+  executable; no Rust lifecycle or new artifact is admitted.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -49,3 +49,9 @@
   Combined WIP becomes one of two; this is prioritization, not a blocker or
   parent completion. Librarian public-interface triage passed for the pinned
   executable; no Rust lifecycle or new artifact is admitted.
+- T-0013/S01 primary acceptance at `b3f9c68` passed zero/one empty task
+  observations, artifact controls, 17 malformed/contradictory evidence controls
+  and two synthetic exception-message transport controls. Review tightened
+  nonzero zero-task evidence to require a transaction exception. Independent
+  Tester reproduced the complete Demo at `b3f9c68`; integration is pending.
+  No Rust lifecycle policy follows.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -12,4 +12,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S03 internal scalar resolution](T-0012-scalar-resolution.md) | Done (Unit/Contract; PR #66) |
 | [T-0012/S04 live scalar differential](T-0012-live-scalar-differential.md) | Done (selected typed Differential; PR #67) |
 | [T-0012/S05 schema-boundary observation](T-0012-schema-boundary-probe.md) | Done (Reference Observation / Integration; PR #68) |
-| [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | In Progress (independent acceptance passed; integration pending) |
+| [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | Done (selected schema Differential; PR #69) |
+| [T-0013/S01 input lifecycle observation](T-0013-input-lifecycle-probe.md) | In Progress (acceptance pending) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -13,4 +13,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S04 live scalar differential](T-0012-live-scalar-differential.md) | Done (selected typed Differential; PR #67) |
 | [T-0012/S05 schema-boundary observation](T-0012-schema-boundary-probe.md) | Done (Reference Observation / Integration; PR #68) |
 | [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | Done (selected schema Differential; PR #69) |
-| [T-0013/S01 input lifecycle observation](T-0013-input-lifecycle-probe.md) | In Progress (acceptance pending) |
+| [T-0013/S01 input lifecycle observation](T-0013-input-lifecycle-probe.md) | Review (Reference Observation / Integration; integration pending) |

--- a/docs/provenance/T-0012-ordered-schema-differential.md
+++ b/docs/provenance/T-0012-ordered-schema-differential.md
@@ -2,7 +2,8 @@
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
 - Branch: `feat/t-0012-ordered-logical-schema`
-- State: In Progress; independent acceptance passed, integration pending
+- State: Done as a slice; integrated through PR #69 as
+  `5de35b790f717175668eb660852e2d7aef11f2dd`; parent remains open
 - Owner: Rust Core Implementer; canonical records/integration: Project Manager
 - Dependencies: T-0011 and S05, integrated through PR #68 as
   `68559dc8b81d45c2b236db3d1e5266f70ab589a9`
@@ -130,4 +131,7 @@ Tester live evidence `${TMPDIR}/t0012-s06.dpJVxD` has the same TSV hash as prima
 acceptance. Its raw-record hash file SHA-256 is
 `9946b294746847657f31dca792953d09163d923f2fb9a3bb96f1c52bc5428476`.
 Platform: macOS 26.5.1 arm64, Bash 3.2.57, Python 3.14.6, Rust/Cargo 1.98.1,
-Temurin JDK 17.0.20. PR integration remains pending; parent T-0012 is not complete.
+Temurin JDK 17.0.20. Each shell script was also syntax-checked individually.
+Final-head primary Demo at `1b1301623a157614ba2c94118daffcd49eae3e2c` passed
+with evidence `${TMPDIR}/t0012-s06.weWGJE`. PR #69 integrated the slice;
+parent T-0012 is not complete.

--- a/docs/provenance/T-0013-input-lifecycle-probe.md
+++ b/docs/provenance/T-0013-input-lifecycle-probe.md
@@ -1,7 +1,7 @@
 # T-0013/S01 input lifecycle reference observation
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: In Progress; acceptance pending
+- State: Review; primary and independent acceptance passed, integration pending
 - Parent: T-0010; priority P0
 - Slice estimate: 3 SP within unchanged parent Current/Initial SP 8
 - Refinement: implementation 1, uncertainty 1, verification 1, environment 1;
@@ -134,6 +134,60 @@ packet. Stop expansion for injected failure/retry/resume scenarios, new upstream
 implementation inspection, new artifacts, production traits, redistribution or
 material IP/security uncertainty requiring PM/legal review. Do not hide an
 unexpected trace; retain it and obtain PM interpretation before policy work.
+
+## Acceptance evidence (2026-09-06)
+
+Primary acceptance at source `b3f9c68bfd9da7255198cbb0790af11ffe80a6ba`
+ran the exact Demo from `/private/tmp`, exit 0. Per-file `bash -n` for the runner
+and test and `git diff --check` also passed. No Rust source changed, so this
+slice does not claim a new Rust regression run.
+
+Primary live evidence is retained outside the repository at
+`${TMPDIR}/t0013-input-lifecycle.qv38QN/evidence`. The two actual processes
+exited 0. Observed marker sequences were:
+
+- Zero tasks: transaction entry, control before/normal return, transaction
+  normal return, cleanup entry/normal return (six events).
+- One empty task: transaction entry, control before, run entry, finish
+  before/normal return, run normal return, control normal return, transaction
+  normal return, cleanup entry/normal return (ten events).
+
+The one-task index was 0; cleanup received zero and one reports respectively.
+No resume or guess marker occurred. These are observations of the original
+local probe under the pinned executable, not general callback guarantees or
+observations of the bundled output's internal callbacks.
+
+Evidence SHA-256:
+
+- `cases.raw`: `cc17f151d0def47f65d40ad6660396526b8dd5544d201ae51f069791e7ff8c9b`
+- `traces.raw`: `fc7d8b815e87a75eeec1ae87bbb01a44300c1469ca94f5cef26d9819b6c0d6b9`
+- Zero trace: `f0977282bd44bdd8a2dac41e6b3ba15dd0562b04c7622aa9491ae31d5df0a418`
+- One trace: `e3c7d993ecc6b59405516877d242368b5f59e8c3a35d7e7a97c5671f7dc30bc8`
+
+Actual corrupt-copy rejection exited 3 (`t0013-input-lifecycle.WUL1WR`), and
+the unavailable asset control exited 56 (`t0013-input-lifecycle.Ldvnrm`).
+Seventeen malformed/contradictory evidence controls each reached their intended
+diagnostic. Two synthetic transaction-exception messages (null and empty) were
+accepted as transport representations, not live fault observations. Review
+specifically required a transaction exception before accepting a nonzero
+zero-task rejection; an unrelated callback exception cannot substitute for it.
+Mutated copies update hashes and copied raw logs where necessary, so semantic
+controls do not merely fail a stale checksum. No outcome hash is an acceptance
+constant.
+
+The platform is macOS arm64 with Java Temurin 17.0.20, Python 3.14.6 and Bash
+3.2.57. Executable identity, Java settings, plugin source/JAR hashes and notices
+are retained per run. The known executable ZIP-prefix warning is not a changed
+artifact identity.
+
+Independent Tester acceptance reproduced the exact Demo at `b3f9c68`, exit 0,
+with identical case/trace hashes and all controls passing. Evidence:
+`${TMPDIR}/t0013-input-lifecycle.C1Wl7R/evidence`; complete run log
+`/private/tmp/t0013-independent-full-probe-network.log`, SHA-256
+`71751109dcc4d5b53a6ad49155c1e96bba337e850d1a314f80d366c45609b4c6`.
+The initial sandbox-only attempt could not resolve GitHub; the authorized
+network rerun succeeded without changing source or artifact. No acceptance
+findings remain. PR integration is pending; parent #16 stays open.
 
 ## Non-claims
 

--- a/docs/provenance/T-0013-input-lifecycle-probe.md
+++ b/docs/provenance/T-0013-input-lifecycle-probe.md
@@ -1,0 +1,144 @@
+# T-0013/S01 input lifecycle reference observation
+
+- Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
+- State: In Progress; acceptance pending
+- Parent: T-0010; priority P0
+- Slice estimate: 3 SP within unchanged parent Current/Initial SP 8
+- Refinement: implementation 1, uncertainty 1, verification 1, environment 1;
+  raw 4 maps to 3 SP. No parent completion or duplicate velocity is implied.
+
+## Authority
+
+Repository owner retains final authority. Lifecycle owner: Project Manager;
+mutation owner: Compatibility Host Implementer. Required reviewers: Librarian
+(public-interface/provenance gate), Tester (independent reproduction), PM
+(scope and acceptance). Standing owner authorization permits implementation
+and integration after acceptance; ordinary build/retrieval problems are not
+incidents or grounds to abandon unaffected work.
+
+## Dependencies
+
+T-0011's pinned reference inventory and the established T-0012 official
+executable/local input-plugin route. No T-0012 source file changes are needed.
+T-0012/S01–S06 and T-0021/S01–S02 are integrated; their still-incomplete parent
+tasks return to Backlog while this dependency-clearing lifecycle slice runs.
+This is reprioritization, not a Blocked or Done transition. WIP becomes one.
+
+## Branch and allowlist
+
+Branch: `research/t-0013-input-lifecycle`.
+Implementer owns exactly three new files:
+
+- `tools/t0013-input-lifecycle/run.sh`
+- `tools/t0013-input-lifecycle/src/T0013InputPlugin.java`
+- `tests/t0013_input_lifecycle_probe_test.sh`
+
+No changes to T-0012 probes/comparators, Rust code, Cargo manifests, production
+dependencies, credentials, plugin APIs or public traits. PM separately owns
+STATUS, TODO, ROADMAP, COMPATIBILITY, ARCHITECTURE, RUST_RUNTIME_DESIGN,
+provenance/index and the dated log. Records and implementation remain serial
+or disjoint.
+
+## Artifacts
+
+Independently author a local-only input plugin and runner for exactly two
+isolated fixtures: requested task count zero and one, both with empty schema,
+no input records, no Page creation/addition and the bundled null output.
+Use the established official executable route with a distinct local plugin
+coordinate and isolated external runtime directories.
+
+Emit actual entry/normal-return markers in input transaction, run and cleanup;
+also instrument resume/guess if invoked, without requiring that they occur.
+Emit markers immediately before Control.run and after its normal return. In
+the positive-control run callback, emit markers immediately before
+PageOutput.finish() and after its normal return, then return a new TaskReport.
+These are probe markers, not direct observations of OutputPlugin callbacks or
+delivery guarantees. Include actual task index/count where available.
+
+Use an unambiguous trace envelope with fixture ID, monotonically recorded
+sequence, event and encoded fields. Preserve raw exception class/message with
+null distinct from empty and rethrow observed RuntimeExceptions so the original
+process failure remains visible. Do not catch linkage/setup Errors as semantic
+outcomes. Keep observation I/O outside the caught operation; I/O failure is not
+a lifecycle result. Do not fabricate uncalled callbacks, sort away event order,
+deduplicate repeats or infer cleanup from object destruction.
+
+Retain each requested task count, raw process log, extracted event sequence,
+process exit, event count/digest and pinned executable/plugin/source hashes in
+external evidence. Record actual outcomes, not expected traces keyed by ID.
+
+## Acceptance criteria
+
+One-task positive control must reach transaction, Control.run and an actual run
+callback with normal finish/run/transaction return and process exit 0. Record
+the zero-task result without presupposing success or rejection; a rejection is
+acceptable observation only after reaching the instrumented transaction/control
+operation, with raw exception and nonzero process exit. Setup failure is never
+an accepted fixture. Any surprising callbacks remain evidence for PM review,
+not permission to infer a Rust lifecycle policy.
+
+Validate exactly two complete fixture envelopes, sequence/field grammar,
+required positive-control markers and consistency of raw traces, counts,
+digests and process exits. Reject unknown/truncated/missing/duplicate records;
+test corrupted copies, not just static source structure. No output snapshot
+hash is a hardcoded acceptance gate. Preserve errors and evidence paths.
+
+Require actual corrupt-executable-copy rejection (exit 3) and unavailable
+official asset rejection (exit 56) before observations. Never skip an unavailable
+runtime or substitute a different version. The independent Tester must reproduce
+the full Demo at a frozen source revision before integration.
+
+## Demo Command
+
+`tests/t0013_input_lifecycle_probe_test.sh`
+
+It must execute both live fixtures, negative artifact controls and malformed
+trace tests; final exit 0 proves the whole script completed, not merely that
+some live rows were printed. Run per-file shell syntax and `git diff --check`.
+New Java must compile/run against the same pinned Java 17/executable route.
+
+## Evidence class
+
+Reference Observation / Integration only. A future independently implemented
+Rust lifecycle comparator is needed for the parent Differential (Embulk) gate.
+
+## Reference and reuse record
+
+Access/review date: 2026-09-06. Librarian read-only gate used `javap -public`
+against the already admitted official
+[Embulk 0.11.5 executable](https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar),
+SHA-256 `e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`.
+Core pin `c5ac2d471edac465b45088669d376a7e2a525f8f`; SPI 0.11 pin
+`576e98033a14ba8ac994ed581d3c9d8fcdda2749`.
+Artifact API locators: `org/embulk/spi/InputPlugin.class`,
+`InputPlugin$Control.class`, `Exec.class`, `PageOutput.class`, and
+`org/embulk/config/TaskSource.class`, `TaskReport.class`.
+Public signatures establish available calls only, not callback semantics.
+PageOutput.finish(): void permits an original empty positive-control call;
+the marker around it is not an output-delivery observation.
+
+Core/SPI source license classification is Apache-2.0; exact LICENSE and core
+NOTICE-executable locators remain in [T-0011](T-0011-embulk-reference-inventory.md).
+The runner retains executable `META-INF/LICENSE` and `META-INF/NOTICE` externally.
+No upstream implementation, test, fixture or text is copied/translated. Reusing
+project-owned test-runner boilerplate is not new upstream adoption. Original
+test source is published, while executable and generated probe JARs remain
+local-only. No new plugin or dependency is admitted. Runtime SBOM/transitives,
+redistribution, patent/standards/trademark, jurisdiction and freedom-to-operate
+review remain unreviewed; this interface triage is not legal clearance.
+
+## Stop rule
+
+Repair ordinary compile, harness and authorized retrieval failures within this
+packet. Stop expansion for injected failure/retry/resume scenarios, new upstream
+implementation inspection, new artifacts, production traits, redistribution or
+material IP/security uncertainty requiring PM/legal review. Do not hide an
+unexpected trace; retain it and obtain PM interpretation before policy work.
+
+## Non-claims
+
+No Rust lifecycle, full callback-order/count contract, output callback/delivery,
+cleanup guarantee, retry, resume, task-report semantics, transaction atomicity,
+exactly-once, plugin compatibility, performance, security or release claim.
+No fault injection in this slice. Parent T-0013 remains open after bounded
+observation acceptance.

--- a/tests/t0013_input_lifecycle_probe_test.sh
+++ b/tests/t0013_input_lifecycle_probe_test.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+runner="$root/tools/t0013-input-lifecycle/run.sh"
+[[ -x "$runner" ]] || exit 2
+
+run_negative() {
+  local control=$1 expected=$2 label=$3 output status evidence
+  if output=$(T0013_NEGATIVE="$control" "$runner" 2>&1); then
+    exit 1
+  else
+    status=$?
+  fi
+  [[ "$status" == "$expected" ]] || exit 1
+  evidence=$(printf '%s\n' "$output" | sed -n 's/^T0013_EVIDENCE_DIR=//p' | tail -1)
+  [[ -n "$evidence" && -d "$evidence" ]] || exit 1
+  grep -Fqx "$label" "$evidence/negative-control.txt" || exit 1
+  printf 'T0013_NEGATIVE_CONTROL=%s|exit=%s|evidence=%s\n' "$control" "$status" "$evidence"
+}
+
+run_negative corrupt-copy 3 corrupt-copy-injected
+run_negative unavailable-asset 56 unavailable-asset-request-failed
+
+output=$("$runner")
+printf '%s\n' "$output"
+evidence=$(printf '%s\n' "$output" | sed -n 's/^T0013_EVIDENCE_DIR=//p' | tail -1)
+[[ -n "$evidence" && -d "$evidence" ]] || exit 1
+for file in executable.sha256 executable-url.txt LICENSE-executable NOTICE-executable java-version.txt \
+  plugin-source.sha256 plugin-jar.sha256 plugin-coordinate.txt cases.raw traces.raw zero.raw.log one.raw.log; do
+  [[ -s "$evidence/$file" ]] || exit 1
+done
+
+validate() {
+  python3 - "$1" <<'PY'
+import base64
+import binascii
+import hashlib
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+
+class InvalidEvidence(Exception):
+    pass
+
+def require(label, condition):
+    if not condition:
+        raise InvalidEvidence(label)
+
+def decimal(label, value):
+    require(label, value.isascii() and value.isdigit())
+    return int(value)
+
+def field(label, value, *, numeric=False, nonempty=False):
+    require(label, value != "-")
+    try:
+        raw = base64.b64decode(value, validate=True)
+        text = raw.decode("utf-8")
+    except (binascii.Error, UnicodeError):
+        raise InvalidEvidence(label)
+    require(label, base64.b64encode(raw).decode("ascii") == value)
+    if nonempty:
+        require(label, text != "")
+    if numeric:
+        decimal(label, text)
+    return text
+
+try:
+    require("cases-readable", root.joinpath("cases.raw").is_file())
+    require("traces-readable", root.joinpath("traces.raw").is_file())
+    cases = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+    traces = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+    require("case-count", len(cases) == 2)
+
+    parsed = {}
+    for row in cases:
+        parts = row.split("|")
+        require("case-arity", len(parts) == 5)
+        tag, fixture, requested, process_exit, summary = parts
+        require("case-tag", tag == "CASE")
+        require("case-fixture", fixture in {"zero", "one"})
+        require("case-duplicate", fixture not in parsed)
+        event_count_text, separator, digest = summary.partition(":")
+        require("case-summary", separator == ":")
+        event_count = decimal("case-event-count", event_count_text)
+        exit_code = decimal("case-process-exit", process_exit)
+        require("case-digest-format", len(digest) == 64 and all(c in "0123456789abcdef" for c in digest))
+        parsed[fixture] = (requested, exit_code, event_count, digest)
+    require("case-fixtures", set(parsed) == {"zero", "one"})
+    require("requested-count", parsed["zero"][0] == "0" and parsed["one"][0] == "1")
+
+    arity = {
+        "transaction-entry": 1,
+        "control-run-before": 1,
+        "control-run-normal-return": 1,
+        "transaction-normal-return": 1,
+        "transaction-runtime-exception": 2,
+        "run-entry": 1,
+        "finish-before": 1,
+        "finish-normal-return": 1,
+        "run-normal-return": 1,
+        "run-runtime-exception": 2,
+        "cleanup-entry": 2,
+        "cleanup-normal-return": 1,
+        "resume-entry": 1,
+        "resume-normal-return": 1,
+        "guess-entry": 0,
+        "guess-normal-return": 0,
+    }
+    count_events = {
+        "transaction-entry", "control-run-before", "control-run-normal-return",
+        "transaction-normal-return", "cleanup-entry", "cleanup-normal-return", "resume-entry",
+        "resume-normal-return",
+    }
+    index_events = {"run-entry", "finish-before", "finish-normal-return", "run-normal-return"}
+    grouped = {"zero": [], "one": []}
+    decoded_events = {"zero": [], "one": []}
+    for row in traces:
+        parts = row.split("|")
+        require("trace-arity-minimum", len(parts) >= 4)
+        tag, fixture, sequence, event = parts[:4]
+        require("trace-tag", tag == "TRACE")
+        require("trace-fixture", fixture in grouped)
+        decimal("trace-sequence", sequence)
+        require("event-known", event in arity)
+        require("event-arity", len(parts) == 4 + arity[event])
+        values = []
+        for index, encoded in enumerate(parts[4:]):
+            if encoded == "-":
+                require("null-field-position", event.endswith("runtime-exception") and index == 1)
+                values.append(None)
+            else:
+                numeric = ((event in count_events and index == 0)
+                           or (event == "cleanup-entry" and index == 1)
+                           or (event in index_events and index == 0))
+                label = "exception-class-field" if event.endswith("runtime-exception") and index == 0 else "canonical-field"
+                values.append(field(label, encoded, numeric=numeric,
+                                    nonempty=event.endswith("runtime-exception") and index == 0))
+        grouped[fixture].append(row)
+        decoded_events[fixture].append((event, values))
+
+    for fixture in ("zero", "one"):
+        requested, exit_code, event_count, digest = parsed[fixture]
+        actual = grouped[fixture]
+        require("case-event-count-match", len(actual) == event_count)
+        material = ("\n".join(actual) + ("\n" if actual else "")).encode("utf-8")
+        require("case-digest-match", hashlib.sha256(material).hexdigest() == digest)
+        raw_log = root / f"{fixture}.raw.log"
+        require("raw-log-required", raw_log.is_file())
+        extracted = [line for line in raw_log.read_text(encoding="utf-8").splitlines() if line.startswith("TRACE|")]
+        require("raw-log-trace-match", extracted == actual)
+        sequences = [decimal("trace-sequence", row.split("|")[2]) for row in actual]
+        require("trace-sequence-contiguous", sequences == list(range(1, event_count + 1)))
+
+        events = [name for name, _ in decoded_events[fixture]]
+        require("transaction-entry-required", "transaction-entry" in events)
+        require("control-entry-required", "control-run-before" in events)
+        for name, values in decoded_events[fixture]:
+            if name in count_events:
+                require("event-requested-count", values[0] == requested)
+
+        transaction_exception = "transaction-runtime-exception" in events
+        run_exception = "run-runtime-exception" in events
+        require("transaction-contradiction", not (transaction_exception and "transaction-normal-return" in events))
+        require("control-contradiction", not (transaction_exception and "control-run-normal-return" in events))
+        require("run-contradiction", not (run_exception and "run-normal-return" in events))
+        require("finish-contradiction", not (run_exception and "finish-normal-return" in events))
+        exceptions = [values for name, values in decoded_events[fixture] if name.endswith("runtime-exception")]
+        require("exception-class", all(values[0] is not None and values[0] != "" for values in exceptions))
+        if exit_code == 0:
+            require("zero-exit-no-exception", not exceptions)
+            require("zero-exit-control-return", "control-run-normal-return" in events)
+            require("zero-exit-transaction-return", "transaction-normal-return" in events)
+        else:
+            require("nonzero-exception", bool(exceptions))
+            if fixture == "zero":
+                require("zero-nonzero-transaction-exception", transaction_exception)
+
+    one_events = [name for name, _ in decoded_events["one"]]
+    require("one-process-success", parsed["one"][1] == 0)
+    required_one = ["run-entry", "finish-before", "finish-normal-return", "run-normal-return",
+                    "control-run-normal-return", "transaction-normal-return"]
+    require("one-positive-markers", all(name in one_events for name in required_one))
+    require("one-positive-order", [one_events.index(name) for name in required_one] == sorted(one_events.index(name) for name in required_one))
+except (InvalidEvidence, OSError, UnicodeError) as failure:
+    label = failure.args[0] if failure.args else "unclassified"
+    print(f"VALIDATION_ERROR|{label}", file=sys.stderr)
+    sys.exit(4)
+PY
+}
+
+validate "$evidence"
+
+mutated_copy() {
+  local mutation=$1 copy
+  copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-trace-validator.XXXXXX")
+  cp "$evidence/cases.raw" "$evidence/traces.raw" "$evidence/zero.raw.log" "$evidence/one.raw.log" "$copy/"
+  python3 - "$mutation" "$copy" <<'PY'
+import base64
+import hashlib
+import pathlib
+import sys
+
+action, directory = sys.argv[1:]
+root = pathlib.Path(directory)
+cases = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+traces = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+
+def next_sequence(fixture):
+    return max(int(row.split("|")[2]) for row in traces if row.startswith(f"TRACE|{fixture}|")) + 1
+
+def regroup_and_rehash():
+    grouped = {fixture: [row for row in traces if row.split("|")[1] == fixture] for fixture in ("zero", "one")}
+    for fixture, rows in grouped.items():
+        path = root / f"{fixture}.raw.log"
+        nontrace = [line for line in path.read_text(encoding="utf-8").splitlines() if not line.startswith("TRACE|")]
+        path.write_text("\n".join(rows + nontrace) + "\n", encoding="utf-8")
+    for index, row in enumerate(cases):
+        parts = row.split("|")
+        if len(parts) == 5 and parts[0] == "CASE" and parts[1] in grouped:
+            rows = grouped[parts[1]]
+            material = ("\n".join(rows) + ("\n" if rows else "")).encode("utf-8")
+            parts[4] = f"{len(rows)}:{hashlib.sha256(material).hexdigest()}"
+            cases[index] = "|".join(parts)
+
+if action == "missing-case":
+    cases.pop()
+elif action == "duplicate-case":
+    cases.append(cases[0])
+elif action == "truncated-trace":
+    traces[0] = "TRACE"
+elif action == "unknown-event":
+    traces.append(f"TRACE|one|{next_sequence('one')}|invented-event")
+    regroup_and_rehash()
+elif action == "bad-arity":
+    traces.append(f"TRACE|one|{next_sequence('one')}|run-entry")
+    regroup_and_rehash()
+elif action == "bad-b64":
+    index = next(i for i, row in enumerate(traces) if "|run-entry|" in row)
+    parts = traces[index].split("|")
+    parts[4] = "!"
+    traces[index] = "|".join(parts)
+    regroup_and_rehash()
+elif action == "bad-count":
+    index = next(i for i, row in enumerate(traces) if row.startswith("TRACE|one|") and "|transaction-entry|" in row)
+    parts = traces[index].split("|")
+    parts[4] = base64.b64encode(b"2").decode("ascii")
+    traces[index] = "|".join(parts)
+    regroup_and_rehash()
+elif action == "malformed-count":
+    index = next(i for i, row in enumerate(traces) if row.startswith("TRACE|one|") and "|transaction-entry|" in row)
+    parts = traces[index].split("|")
+    parts[4] = base64.b64encode(b"not-a-count").decode("ascii")
+    traces[index] = "|".join(parts)
+    regroup_and_rehash()
+elif action == "bad-sequence":
+    one_indexes = [i for i, row in enumerate(traces) if row.startswith("TRACE|one|")]
+    index = one_indexes[1]
+    parts = traces[index].split("|")
+    parts[2] = traces[one_indexes[0]].split("|")[2]
+    traces[index] = "|".join(parts)
+    regroup_and_rehash()
+elif action == "duplicate-trace":
+    row = [row for row in traces if row.startswith("TRACE|one|")][1]
+    traces.append(row)
+    regroup_and_rehash()
+elif action == "contradiction":
+    traces.append(f"TRACE|one|{next_sequence('one')}|run-runtime-exception|amF2YS5sYW5nLlJ1bnRpbWVFeGNlcHRpb24=|-")
+    regroup_and_rehash()
+elif action in {"null-message", "empty-message", "empty-class", "no-exception-nonzero", "unrelated-exception-nonzero"}:
+    traces = [row for row in traces if not row.startswith("TRACE|zero|")]
+    synthetic = ["TRACE|zero|1|transaction-entry|MA==", "TRACE|zero|2|control-run-before|MA=="]
+    if action != "no-exception-nonzero":
+        kind = "" if action == "empty-class" else "amF2YS5sYW5nLlJ1bnRpbWVFeGNlcHRpb24="
+        message = "-" if action == "null-message" else ""
+        event = "run-runtime-exception" if action == "unrelated-exception-nonzero" else "transaction-runtime-exception"
+        synthetic.append(f"TRACE|zero|3|{event}|{kind}|{message}")
+    traces = synthetic + traces
+    cases = [row if not row.startswith("CASE|zero|") else "CASE|zero|0|1|pending" for row in cases]
+    regroup_and_rehash()
+elif action == "event-count-corrupt":
+    index = next(i for i, row in enumerate(cases) if row.startswith("CASE|one|"))
+    parts = cases[index].split("|")
+    count, digest = parts[4].split(":")
+    parts[4] = f"{int(count) + 1}:{digest}"
+    cases[index] = "|".join(parts)
+elif action == "digest-corrupt":
+    index = next(i for i, row in enumerate(cases) if row.startswith("CASE|one|"))
+    parts = cases[index].split("|")
+    count, _ = parts[4].split(":")
+    parts[4] = f"{count}:{'0' * 64}"
+    cases[index] = "|".join(parts)
+elif action == "missing-raw-log":
+    root.joinpath("zero.raw.log").unlink()
+else:
+    raise ValueError(action)
+
+root.joinpath("cases.raw").write_text("\n".join(cases) + "\n", encoding="utf-8")
+root.joinpath("traces.raw").write_text("\n".join(traces) + "\n", encoding="utf-8")
+PY
+  printf '%s\n' "$copy"
+}
+
+validator_fails() {
+  local mutation=$1 expected=$2 copy output status
+  copy=$(mutated_copy "$mutation")
+  printf 'T0013_TRACE_MUTATION=%s|evidence=%s\n' "$mutation" "$copy"
+  if output=$(validate "$copy" 2>&1); then
+    exit 1
+  else
+    status=$?
+  fi
+  [[ "$status" == 4 ]] || exit 1
+  [[ "$output" == "VALIDATION_ERROR|$expected" ]] || {
+    printf 'unexpected validator result for %s: %s\n' "$mutation" "$output" >&2
+    exit 1
+  }
+}
+
+validator_accepts() {
+  local mutation=$1 copy
+  copy=$(mutated_copy "$mutation")
+  printf 'T0013_TRACE_MUTATION=%s|evidence=%s\n' "$mutation" "$copy"
+  validate "$copy"
+}
+
+validator_fails missing-case case-count
+validator_fails duplicate-case case-count
+validator_fails truncated-trace trace-arity-minimum
+validator_fails unknown-event event-known
+validator_fails bad-arity event-arity
+validator_fails bad-b64 canonical-field
+validator_fails bad-count event-requested-count
+validator_fails malformed-count canonical-field
+validator_fails bad-sequence trace-sequence-contiguous
+validator_fails duplicate-trace trace-sequence-contiguous
+validator_fails contradiction run-contradiction
+validator_fails empty-class exception-class-field
+validator_fails no-exception-nonzero nonzero-exception
+validator_fails unrelated-exception-nonzero zero-nonzero-transaction-exception
+validator_fails event-count-corrupt case-event-count-match
+validator_fails digest-corrupt case-digest-match
+validator_fails missing-raw-log raw-log-required
+validator_accepts null-message
+validator_accepts empty-message
+
+printf 'T0013_FULL_PROBE=passed|evidence=%s\n' "$evidence"

--- a/tools/t0013-input-lifecycle/run.sh
+++ b/tools/t0013-input-lifecycle/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+src="$root/tools/t0013-input-lifecycle/src/T0013InputPlugin.java"
+url=https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
+sha=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
+tmp=$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-input-lifecycle.XXXXXX")
+evidence="$tmp/evidence"
+mkdir -p "$evidence" "$tmp/classes" "$tmp/home/lib/m2/repository/org/embulk/t0013/embulk-input-t0013/0.0.1"
+trap 'printf "T0013_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
+jarfile="$tmp/embulk.jar"
+if [[ ${T0013_NEGATIVE:-} == unavailable-asset ]]; then url=https://github.com/embulk/embulk/releases/download/v0.11.5/unavailable.jar; fi
+printf '%s\n' "$url" > "$evidence/executable-url.txt"
+if ! curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error -o "$jarfile" "$url"; then
+  if [[ ${T0013_NEGATIVE:-} == unavailable-asset ]]; then
+    printf '%s\n' unavailable-asset-request-failed > "$evidence/negative-control.txt"
+  fi
+  exit 56
+fi
+if [[ ${T0013_NEGATIVE:-} == corrupt-copy ]]; then
+  printf corrupt >> "$jarfile"
+  printf '%s\n' corrupt-copy-injected > "$evidence/negative-control.txt"
+fi
+actual_sha=$(shasum -a 256 "$jarfile" | awk '{print $1}')
+printf '%s\n' "$actual_sha" > "$evidence/executable.sha256"
+[[ "$actual_sha" == "$sha" ]] || exit 3
+shasum -a 256 "$src" | awk '{print $1}' > "$evidence/plugin-source.sha256"
+unzip -p "$jarfile" META-INF/LICENSE > "$evidence/LICENSE-executable" || [[ -s "$evidence/LICENSE-executable" ]]
+unzip -p "$jarfile" META-INF/NOTICE > "$evidence/NOTICE-executable" || [[ -s "$evidence/NOTICE-executable" ]]
+java -XshowSettings:properties -version > "$evidence/java-version.txt" 2>&1
+javac -cp "$jarfile" -d "$tmp/classes" "$src"
+repo="$tmp/home/lib/m2/repository/org/embulk/t0013/embulk-input-t0013/0.0.1"
+printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0013InputPlugin' 'Embulk-Plugin-Category: input' 'Embulk-Plugin-Type: t0013' 'Embulk-Plugin-Spi-Version: 0' > "$tmp/MANIFEST.MF"
+jar cfm "$repo/embulk-input-t0013-0.0.1.jar" "$tmp/MANIFEST.MF" -C "$tmp/classes" .
+shasum -a 256 "$repo/embulk-input-t0013-0.0.1.jar" | awk '{print $1}' > "$evidence/plugin-jar.sha256"
+printf '%s\n' 'source=maven|group=org.embulk.t0013|name=t0013|version=0.0.1|artifact=embulk-input-t0013|local-only' > "$evidence/plugin-coordinate.txt"
+printf '%s' '<project><modelVersion>4.0.0</modelVersion></project>' > "$repo/embulk-input-t0013-0.0.1.pom"
+: > "$evidence/traces.raw"
+: > "$evidence/cases.raw"
+for spec in zero:0 one:1; do
+  fixture=${spec%%:*}
+  count=${spec##*:}
+  log="$evidence/$fixture.raw.log"
+  config="$tmp/$fixture.yml"
+  case_trace="$tmp/$fixture.trace"
+  printf '%s\n' 'in:' '  type:' '    source: maven' '    group: org.embulk.t0013' '    name: t0013' '    version: 0.0.1' 'out:' '  type: "null"' > "$config"
+  if T0013_FIXTURE="$fixture" T0013_TASK_COUNT="$count" java -jar "$jarfile" "-Xembulk_home=$tmp/home" run "$config" > "$log" 2>&1; then code=0; else code=$?; fi
+  awk '/^TRACE\|/' "$log" > "$case_trace"
+  cat "$case_trace" >> "$evidence/traces.raw"
+  digest=$(shasum -a 256 "$case_trace" | awk '{print $1}')
+  rows=$(wc -l < "$case_trace" | tr -d ' ')
+  printf 'CASE|%s|%s|%s|%s\n' "$fixture" "$count" "$code" "$rows:$digest" >> "$evidence/cases.raw"
+done
+cat "$evidence/cases.raw"

--- a/tools/t0013-input-lifecycle/src/T0013InputPlugin.java
+++ b/tools/t0013-input-lifecycle/src/T0013InputPlugin.java
@@ -1,0 +1,108 @@
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Exec;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.Schema;
+
+/** Local-only T-0013/S01 lifecycle observation probe. */
+public final class T0013InputPlugin implements InputPlugin {
+    private static long sequence;
+
+    @Override
+    public ConfigDiff transaction(ConfigSource config, Control control) {
+        String fixture = System.getenv("T0013_FIXTURE");
+        int count = Integer.parseInt(System.getenv("T0013_TASK_COUNT"));
+        trace(fixture, "transaction-entry", Integer.toString(count));
+        TaskSource inputTaskSource = Exec.newTaskSource();
+        Schema inputSchema = Schema.builder().build();
+        trace(fixture, "control-run-before", Integer.toString(count));
+        RuntimeException operationFailure = null;
+        try {
+            control.run(inputTaskSource, inputSchema, count);
+        } catch (RuntimeException failure) {
+            operationFailure = failure;
+        }
+        if (operationFailure != null) {
+            trace(fixture, "transaction-runtime-exception", operationFailure.getClass().getName(),
+                    operationFailure.getMessage());
+            throw operationFailure;
+        }
+        trace(fixture, "control-run-normal-return", Integer.toString(count));
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "transaction-normal-return", Integer.toString(count));
+        return result;
+    }
+
+    @Override
+    public ConfigDiff resume(TaskSource taskSource, Schema schema, int taskCount, Control control) {
+        String fixture = System.getenv("T0013_FIXTURE");
+        trace(fixture, "resume-entry", Integer.toString(taskCount));
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "resume-normal-return", Integer.toString(taskCount));
+        return result;
+    }
+
+    @Override
+    public void cleanup(TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> reports) {
+        String fixture = System.getenv("T0013_FIXTURE");
+        trace(fixture, "cleanup-entry", Integer.toString(taskCount), Integer.toString(reports.size()));
+        trace(fixture, "cleanup-normal-return", Integer.toString(taskCount));
+    }
+
+    @Override
+    public TaskReport run(TaskSource taskSource, Schema schema, int taskIndex, PageOutput output) {
+        String fixture = System.getenv("T0013_FIXTURE");
+        trace(fixture, "run-entry", Integer.toString(taskIndex));
+        trace(fixture, "finish-before", Integer.toString(taskIndex));
+        RuntimeException operationFailure = null;
+        try {
+            output.finish();
+        } catch (RuntimeException failure) {
+            operationFailure = failure;
+        }
+        if (operationFailure != null) {
+            trace(fixture, "run-runtime-exception", operationFailure.getClass().getName(),
+                    operationFailure.getMessage());
+            throw operationFailure;
+        }
+        trace(fixture, "finish-normal-return", Integer.toString(taskIndex));
+        TaskReport result = Exec.newTaskReport();
+        trace(fixture, "run-normal-return", Integer.toString(taskIndex));
+        return result;
+    }
+
+    @Override
+    public ConfigDiff guess(ConfigSource config) {
+        String fixture = System.getenv("T0013_FIXTURE");
+        trace(fixture, "guess-entry");
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "guess-normal-return");
+        return result;
+    }
+
+    private static synchronized void trace(String fixture, String event, String... fields) {
+        StringBuilder line = new StringBuilder("TRACE|").append(fixture).append('|')
+                .append(++sequence).append('|').append(event);
+        for (String field : fields) {
+            line.append('|').append(field == null ? "-" : Base64.getEncoder()
+                    .encodeToString(field.getBytes(StandardCharsets.UTF_8)));
+        }
+        System.out.println(line);
+        if (System.out.checkError()) {
+            throw new InstrumentationError("trace output failed");
+        }
+    }
+
+    private static final class InstrumentationError extends Error {
+        private InstrumentationError(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
Refs #16. Implements T-0013/S01 only (3 SP within unchanged parent SP 8). Original local-only probe observes actual zero/one empty-task input callbacks using pinned Embulk 0.11.5. No Rust lifecycle policy or output delivery claim. Primary and independent Tester reproduced tests/t0013_input_lifecycle_probe_test.sh at b3f9c68: both processes exit 0, six/ten markers, artifact controls and 17 malformed evidence controls pass. Canonical packet and evidence: docs/provenance/T-0013-input-lifecycle-probe.md. Parent remains open. Final-head acceptance follows.