### PR TITLE
test(t-0013): observe output lifecycle and distinct task counts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S01` is `Review`; `T-0012`, `T-0021` and all other unfinished items
+`T-0013/S02` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01: input callback observations) | Review | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01 integrated; S02 output observations) | In Progress | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -168,6 +168,12 @@ velocity is awarded.
 
 S01 primary acceptance at `b3f9c68` passed the two live input fixtures and all
 artifact/trace controls. Independent Tester reproduced the complete Demo;
-integration remains pending.
+final-head Demo at `84e692f` passed and PR #70 integrated as `e8b5726`.
 The next lifecycle decision needs direct output-side observations before
 assigning commit, abort or close responsibilities to private Rust traits.
+
+T-0013/S02 (3 SP within unchanged parent Current/Initial SP 8) observes output
+callbacks for zero/one empty task through a separately identified original
+output plugin. Its [packet](docs/provenance/T-0013-output-lifecycle-probe.md)
+excludes failure injection, Pages, delivery guarantees and Rust traits. Parent
+completion and additional parent points are not implied; combined WIP stays one.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S02` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
+`T-0013/S02` is `Review`; `T-0012`, `T-0021` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01 integrated; S02 output observations) | In Progress | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01 integrated; S02 output observations) | Review | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -177,3 +177,6 @@ callbacks for zero/one empty task through a separately identified original
 output plugin. Its [packet](docs/provenance/T-0013-output-lifecycle-probe.md)
 excludes failure injection, Pages, delivery guarantees and Rust traits. Parent
 completion and additional parent points are not implied; combined WIP stays one.
+Primary acceptance at `5739052` passed the exact S02 Demo, including actual
+distinct input/output counts and 30 malformed-evidence controls. Independent
+Tester reproduced the complete Demo; integration remains pending.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -75,7 +75,12 @@ probe's call to `PageOutput.finish()` returned normally. No resume or guess
 marker occurred. This does not establish output callback ordering, delivery,
 cleanup guarantees, failure/retry behavior or Native/Verified lifecycle support.
 Primary and independent acceptance passed; PR #70 integrated as `e8b5726`.
-S02's direct output-side observation is pending and adds no support claim.
+S02's direct output-side primary observation records zero/eight output tasks
+for zero/one input tasks, respectively. The one-input run records output
+open/finish/commit/close pairs; no add, abort or resume marker occurred. This
+is not a default fan-out algorithm, durable commit, general callback-order
+guarantee or Native/Verified lifecycle claim. Independent acceptance passed;
+integration remains pending.
 
 ## Adding an Entry
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -74,7 +74,8 @@ with six and ten probe markers respectively, including cleanup. The one-task
 probe's call to `PageOutput.finish()` returned normally. No resume or guess
 marker occurred. This does not establish output callback ordering, delivery,
 cleanup guarantees, failure/retry behavior or Native/Verified lifecycle support.
-Primary and independent acceptance passed; integration is pending.
+Primary and independent acceptance passed; PR #70 integrated as `e8b5726`.
+S02's direct output-side observation is pending and adds no support claim.
 
 ## Adding an Entry
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,6 +56,9 @@ trace controls. This reference observation cannot satisfy the lifecycle exit
 gate; direct output-side and failure/recovery evidence are still missing.
 PR #70 integrated S01 as `e8b5726`; S02 now observes direct output callbacks
 for the same empty-task boundary before Rust policy or failure injection.
+S02 primary acceptance passed at `5739052`, including its actual one-input/
+eight-output observation and strict evidence controls. This does not resolve
+default scheduling, failure propagation, recovery or delivery gates.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,6 +54,8 @@ blocker; callback traits, cleanup guarantees and resume remain unverified.
 Primary acceptance records successful zero/one empty task executions and strict
 trace controls. This reference observation cannot satisfy the lifecycle exit
 gate; direct output-side and failure/recovery evidence are still missing.
+PR #70 integrated S01 as `e8b5726`; S02 now observes direct output callbacks
+for the same empty-task boundary before Rust policy or failure injection.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -135,6 +135,14 @@ probe's `PageOutput.finish()` call. This is reference observation only. It does
 not reveal output commit/abort/close behavior; observe that boundary directly
 before making those responsibilities part of the private Rust execution model.
 
+S02's primary reference acceptance at `5739052` shows why the distinction
+matters: one requested input task reached an output transaction with eight
+tasks. Its runtime log explicitly reported `max_threads=16` and eight output
+tasks. A future coordinator must not collapse input task identity and output
+task identity into one counter. The factor eight is a local observation, not a
+portable constant or an accepted scheduling algorithm. Mapping rules, executor
+options and concurrency need separate fixtures before implementation.
+
 | Phase | Coordinator responsibility | Plugin/adapter responsibility | Trace evidence required |
 |---|---|---|---|
 | Resolve and validate | Select pinned factories, resolve configuration | Validate plugin options at the compatible stage | First error, defaults applied, side effects before failure |
@@ -214,3 +222,22 @@ traces, then implement API contracts with fake plugins. Defer actual Java/Ruby
 hosts and provider integrations until those boundaries are evidenced. This
 document can be reviewed independently; parent task completion still requires
 its original semantic dependencies and executable acceptance evidence.
+
+### Bounded path from observation to private execution
+
+The immediate goal is a testable private empty-task coordinator, not completion
+of every compatibility cell before any execution code. Its activation still
+requires a separate packet and a reviewed decision delimiting unsupported paths.
+
+| Decision point | Required evidence | What it permits, and what it does not |
+|---|---|---|
+| Empty successful orchestration | Accepted S01 input and S02 output observations with actual component traces | A bounded normal-path candidate; not inferred failure handling |
+| Failure before the input's finish call | Same-runtime positive control and an original input-run exception fixture, retaining propagation and all actual output callbacks | A candidate for that exact failure boundary; not pre-publication, rollback, retry or recovery guarantees |
+| Private coordinator acceptance | Independently authored fake plugins, explicit input/output task plans, and live comparisons of the selected complete traces | Private execution of those supplied plans; not a reproduction of default executor fan-out or a public plugin API |
+| Expansion beyond empty tasks | New fixtures for values, output mapping, concurrency and resource bounds | A separately reviewed execution slice; not a silent extension of empty-task evidence |
+
+The proposed failure fixture should throw inside input `run` before its own
+`finish` call. Calling this "before publication" would be unjustified: output
+transaction/open could already have effects in a real plugin. Commit durability
+and lost acknowledgements remain separate D5 gates, even if the empty local
+fixture later records abort and close callbacks.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -29,7 +29,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S01 (`Review`) is the only active work item. Combined WIP is one of
+T-0013/S02 (`In Progress`) is the only active work item. Combined WIP is one of
 two; no item is `Ready` or `Blocked`. T-0012 and T-0021 return to Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -41,7 +41,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
 | T-0021 | Backlog | S01/S02 integrated; core traits await T-0012/T-0013 contracts |
-| T-0013/S01 | Review | Accept zero-task and one-task input lifecycle traces |
+| T-0013/S02 | In Progress | Observe zero-task and one-task output lifecycle traces |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -144,6 +144,11 @@ T-0013/S01 now observes actual input callback traces before Rust lifecycle
 traits are chosen. Primary acceptance at `b3f9c68` passed the exact Demo:
 zero/one empty task processes exited 0 with six/ten input probe markers,
 respectively, plus artifact and malformed-evidence controls. Independent
-Tester reproduced the complete Demo; integration is pending. No callback, cleanup or resume
+Tester reproduced the complete Demo; final-head acceptance at `84e692f` passed
+and PR #70 integrated as `e8b5726`. No callback, cleanup or resume
 contract is implemented or verified. See the
 [S01 evidence record](provenance/T-0013-input-lifecycle-probe.md).
+
+S02 now observes output callbacks using the unchanged S01 input fixture and a
+separate original local output plugin. Acceptance is pending; no Rust lifecycle
+trait or output durability policy is inferred from the S01 input observations.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -29,7 +29,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S02 (`In Progress`) is the only active work item. Combined WIP is one of
+T-0013/S02 (`Review`) is the only active work item. Combined WIP is one of
 two; no item is `Ready` or `Blocked`. T-0012 and T-0021 return to Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -41,7 +41,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
 | T-0021 | Backlog | S01/S02 integrated; core traits await T-0012/T-0013 contracts |
-| T-0013/S02 | In Progress | Observe zero-task and one-task output lifecycle traces |
+| T-0013/S02 | Review | Accept zero-task and one-task output lifecycle traces |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -150,5 +150,9 @@ contract is implemented or verified. See the
 [S01 evidence record](provenance/T-0013-input-lifecycle-probe.md).
 
 S02 now observes output callbacks using the unchanged S01 input fixture and a
-separate original local output plugin. Acceptance is pending; no Rust lifecycle
-trait or output durability policy is inferred from the S01 input observations.
+separate original local output plugin. Primary acceptance at `5739052` passed
+both fixtures and all artifact/trace controls. One input task produced eight
+output tasks in this local reference run, each with open/finish/commit/close
+pairs; no add, abort or resume marker occurred. Independent Tester reproduced
+the complete Demo; integration is pending. No Rust lifecycle trait or output durability policy
+is inferred; the fan-out factor is not a portable constant.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -61,3 +61,10 @@
   empty task output callbacks. Slice 3 SP stays within unchanged parent 8 SP;
   WIP remains one, Project remains private, and failure/recovery policy is not
   inferred. No new artifact or Rust trait is admitted.
+- S02 primary acceptance at `5739052` passed the exact Demo and 30 invalid-
+  evidence controls plus two valid synthetic message forms. One input task
+  produced eight output tasks with open/finish/commit/close markers, not one.
+  PM retained the observed distinction without hardcoding the factor or
+  inferring durability. Source-local ordering checks were strengthened without
+  making cleanup report counts equal an earlier control result. Independent
+  Tester reproduced the complete Demo at `5739052`; integration is pending.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -53,5 +53,11 @@
   observations, artifact controls, 17 malformed/contradictory evidence controls
   and two synthetic exception-message transport controls. Review tightened
   nonzero zero-task evidence to require a transaction exception. Independent
-  Tester reproduced the complete Demo at `b3f9c68`; integration is pending.
+  Tester reproduced the complete Demo at `b3f9c68`; final-head Demo at `84e692f`
+  passed and PR #70 integrated as `e8b5726`, with parent #16 open.
   No Rust lifecycle policy follows.
+- Activated T-0013/S02's original local output probe after public-signature
+  review. It reuses S01 input source without mutation and observes zero/one
+  empty task output callbacks. Slice 3 SP stays within unchanged parent 8 SP;
+  WIP remains one, Project remains private, and failure/recovery policy is not
+  inferred. No new artifact or Rust trait is admitted.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -14,4 +14,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S05 schema-boundary observation](T-0012-schema-boundary-probe.md) | Done (Reference Observation / Integration; PR #68) |
 | [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | Done (selected schema Differential; PR #69) |
 | [T-0013/S01 input lifecycle observation](T-0013-input-lifecycle-probe.md) | Done (Reference Observation / Integration; PR #70) |
-| [T-0013/S02 output lifecycle observation](T-0013-output-lifecycle-probe.md) | In Progress (acceptance pending) |
+| [T-0013/S02 output lifecycle observation](T-0013-output-lifecycle-probe.md) | Review (Reference Observation / Integration; integration pending) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -13,4 +13,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S04 live scalar differential](T-0012-live-scalar-differential.md) | Done (selected typed Differential; PR #67) |
 | [T-0012/S05 schema-boundary observation](T-0012-schema-boundary-probe.md) | Done (Reference Observation / Integration; PR #68) |
 | [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | Done (selected schema Differential; PR #69) |
-| [T-0013/S01 input lifecycle observation](T-0013-input-lifecycle-probe.md) | Review (Reference Observation / Integration; integration pending) |
+| [T-0013/S01 input lifecycle observation](T-0013-input-lifecycle-probe.md) | Done (Reference Observation / Integration; PR #70) |
+| [T-0013/S02 output lifecycle observation](T-0013-output-lifecycle-probe.md) | In Progress (acceptance pending) |

--- a/docs/provenance/T-0013-input-lifecycle-probe.md
+++ b/docs/provenance/T-0013-input-lifecycle-probe.md
@@ -1,7 +1,7 @@
 # T-0013/S01 input lifecycle reference observation
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: Review; primary and independent acceptance passed, integration pending
+- State: Done (bounded S01 only); PR #70 integrated as `e8b5726`
 - Parent: T-0010; priority P0
 - Slice estimate: 3 SP within unchanged parent Current/Initial SP 8
 - Refinement: implementation 1, uncertainty 1, verification 1, environment 1;
@@ -187,7 +187,9 @@ with identical case/trace hashes and all controls passing. Evidence:
 `71751109dcc4d5b53a6ad49155c1e96bba337e850d1a314f80d366c45609b4c6`.
 The initial sandbox-only attempt could not resolve GitHub; the authorized
 network rerun succeeded without changing source or artifact. No acceptance
-findings remain. PR integration is pending; parent #16 stays open.
+findings remain. Final-head Demo at `84e692f` also passed, evidence
+`${TMPDIR}/t0013-input-lifecycle.WrGfX8/evidence`. PR #70 integrated as
+`e8b5726586fc79a4dd34dba50f4fdca51a7761a1`; parent #16 remains open.
 
 ## Non-claims
 

--- a/docs/provenance/T-0013-output-lifecycle-probe.md
+++ b/docs/provenance/T-0013-output-lifecycle-probe.md
@@ -1,0 +1,146 @@
+# T-0013/S02 output lifecycle reference observation
+
+- Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
+- State: In Progress; acceptance pending
+- Parent: T-0010; priority P0
+- Slice estimate: 3 SP within unchanged parent Current/Initial SP 8
+- Refinement: implementation 1, uncertainty 1, verification 1, environment 1;
+  raw 4 maps to 3 SP. No parent completion or duplicate velocity is implied.
+
+## Authority
+
+Repository owner retains final authority. Project Manager owns lifecycle,
+scope, records and integration. Compatibility Host Implementer owns the exact
+source allowlist below. Librarian supplies the public-interface/provenance gate;
+Tester independently reproduces the frozen revision. Standing owner authority
+permits implementation and integration after acceptance without treating
+ordinary harness or retrieval failures as incidents.
+
+## Dependencies
+
+T-0011's existing official executable pin and T-0013/S01, integrated through
+PR #70 as `e8b5726`. Reuse the unchanged original S01 empty input probe source;
+do not edit its source, runner or test. T-0012 and T-0021 remain Backlog.
+Combined WIP stays one of two. This slice precedes choosing Rust lifecycle
+traits; it does not complete the parent Differential gate.
+
+## Branch and allowlist
+
+Branch: `research/t-0013-output-lifecycle`.
+Compatibility Host Implementer owns exactly these three new files:
+
+- `tools/t0013-output-lifecycle/run.sh`
+- `tools/t0013-output-lifecycle/src/T0013OutputPlugin.java`
+- `tests/t0013_output_lifecycle_probe_test.sh`
+
+PM owns canonical STATUS, TODO, ROADMAP, COMPATIBILITY, runtime design,
+provenance/index and dated log reconciliation. No other mutation, dependency,
+Rust code, production host, public API, input probe or existing test changes.
+
+## Artifacts
+
+Author an original local-only output plugin, runner and full acceptance test.
+Execute exactly two isolated fixtures using S01's unchanged empty input source:
+zero requested tasks and one empty task/schema, no Pages or values. Compile
+input and output into separately identified local Maven-style plugin JARs and
+coordinates with the correct category. Do not assume a shared classloader or
+static counter between input and output. Retain both source and JAR hashes.
+
+The output fixture returns newly created TaskSource/ConfigDiff/TaskReport
+objects at its applicable return sites, without durability or report semantics.
+Log actual entry and normal-return markers for transaction, open, cleanup,
+resume, and the returned object's add/finish/commit/abort/close methods. An
+unexpected add must remain visible and fail this no-Page fixture acceptance.
+Record actual task count/index, schema count and report count where applicable;
+do not invent callback invocation, ordering or missing return markers.
+Surround the actual output Control.run call with before/normal-return markers;
+retain returned report count. Catch RuntimeExceptions only from the operation
+being observed, preserve exact class and nullable message and rethrow. Keep
+trace I/O outside caught operations; instrumentation and setup Errors are not
+semantic outcomes. No fault injection, Pages, retries or resume scenarios.
+
+Keep S01 input TRACE lines and distinct output markers in physical raw-log
+order, with component-local sequence counters and canonical encoded fields.
+Do not assert a shared numeric sequence across components. Retain per-case
+raw logs, process exits, requested counts, extracted traces, event counts and
+digests, executable identity, Java version/settings, generated coordinates and
+source/JAR hashes, executable LICENSE/NOTICE in unique external directories.
+No hardcoded output snapshot hash or fixture-ID-derived outcome.
+
+## Acceptance criteria
+
+Both fixtures must reach the actual input transaction/control and output
+transaction/control boundaries; startup/loading failure cannot be an accepted
+result. One-task positive control must exit 0, reach input run/normal finish
+and actual output open/finish normal return plus normal transaction/control
+return. Other actual output callbacks (commit, abort, close, cleanup, resume)
+are observations for PM interpretation, not preselected expected counts/order.
+Zero may succeed or reject; rejection requires an actual output transaction
+exception, propagated input transaction exception, and nonzero process exit.
+No unexpected add, instrumentation/setup failure or unaccounted process failure.
+
+Validate exactly two complete case envelopes, known events and exact arity,
+canonical UTF-8/Base64 including null versus empty exception messages, typed
+count/index fields, contiguous component-local sequences, required positive
+markers, normal/exception consistency, raw-log correspondence and recomputed
+counts/digests. Unknown, missing, truncated, duplicate sequence, malformed,
+contradictory and unrelated-exception evidence must fail closed. Rehashed
+mutated copies must reach intended exact diagnostic labels, not merely stale
+checksum failures. Include valid synthetic null/empty message controls; these
+are format controls, not live fault observations.
+
+Run actual corrupt-executable-copy rejection (exit 3) and unavailable official
+asset rejection (exit 56); never skip a missing runtime or substitute a pin.
+Tester independently reproduces the exact full Demo at a frozen revision.
+
+## Demo Command
+
+`tests/t0013_output_lifecycle_probe_test.sh`
+
+Run from outside the repository. It executes both live fixtures, artifact
+negative controls and strict trace validation controls, exiting 0 only on full
+completion. Run per-file `bash -n` and `git diff --check`. No unchanged Rust
+regression suite is claimed or required for this separate test-only slice.
+
+## Evidence class
+
+Reference Observation / Integration only. No Rust comparator is implemented.
+
+## Reference and reuse record
+
+Access/review date 2026-09-06. Librarian gate and PM inspection used public
+`javap -public` signatures from the already admitted official
+[Embulk 0.11.5 executable](https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar),
+SHA-256 `e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`.
+Core commit `c5ac2d471edac465b45088669d376a7e2a525f8f`; SPI 0.11 commit
+`576e98033a14ba8ac994ed581d3c9d8fcdda2749`. API locators:
+`org/embulk/spi/OutputPlugin.class`, `OutputPlugin$Control.class`,
+`TransactionalPageOutput.class`, `PageOutput.class`,
+`org/embulk/config/TaskReport.class`. Transaction/resume return ConfigDiff;
+Control.run returns List<TaskReport>; commit returns TaskReport. Public
+signatures permit original fixture calls, not conclusions about lifecycle.
+
+Core/SPI source license classification is Apache-2.0. Exact source LICENSE and
+core NOTICE-executable locators remain in the T-0011 inventory; embedded
+META-INF/LICENSE and META-INF/NOTICE are retained per run. No upstream
+implementation/tests/text are copied or translated. S01 probe/runner reuse is
+project-owned original code. Executable and generated JARs remain local-only;
+original probe source is published. No new external plugin or artifact admitted.
+Transitive SBOM/notices, redistribution, patent/standards/trademark,
+jurisdiction and freedom-to-operate remain unreviewed; this is not legal
+clearance.
+
+## Stop rule
+
+Repair ordinary compilation, harness and authorized retrieval issues within the
+packet. Escalate unexpected trace interpretation to PM before choosing policy.
+Stop expansion for new artifacts, upstream implementation inspection, injected
+failures, resume/retry scenarios, production traits, redistribution or material
+IP/security uncertainty. Do not hide negative evidence or silently weaken gates.
+
+## Non-claims
+
+No Rust lifecycle, full callback ordering/count guarantee, data transfer,
+durability, cleanup guarantee, retry/resume behavior, report semantics,
+transaction atomicity, exactly-once, plugin compatibility, performance,
+security or release claim. Parent T-0013 remains open after bounded acceptance.

--- a/docs/provenance/T-0013-output-lifecycle-probe.md
+++ b/docs/provenance/T-0013-output-lifecycle-probe.md
@@ -1,7 +1,7 @@
 # T-0013/S02 output lifecycle reference observation
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: In Progress; acceptance pending
+- State: Review; primary and independent acceptance passed, integration pending
 - Parent: T-0010; priority P0
 - Slice estimate: 3 SP within unchanged parent Current/Initial SP 8
 - Refinement: implementation 1, uncertainty 1, verification 1, environment 1;
@@ -89,6 +89,11 @@ mutated copies must reach intended exact diagnostic labels, not merely stale
 checksum failures. Include valid synthetic null/empty message controls; these
 are format controls, not live fault observations.
 
+Input requested count and output transaction count are separate observed
+quantities. Validate output fields against the actual output transaction
+context, not against requested input count. Do not force executor settings to
+make the quantities equal or assert a portable fan-out factor.
+
 Run actual corrupt-executable-copy rejection (exit 3) and unavailable official
 asset rejection (exit 56); never skip a missing runtime or substitute a pin.
 Tester independently reproduces the exact full Demo at a frozen revision.
@@ -137,6 +142,62 @@ packet. Escalate unexpected trace interpretation to PM before choosing policy.
 Stop expansion for new artifacts, upstream implementation inspection, injected
 failures, resume/retry scenarios, production traits, redistribution or material
 IP/security uncertainty. Do not hide negative evidence or silently weaken gates.
+
+## Acceptance evidence (2026-09-06)
+
+Primary acceptance at `57390529daeb0d3f937f455f4e02f98d3cb742d6` ran the
+exact Demo from `/private/tmp`, exit 0. Per-file `bash -n` and
+`git diff --check` passed. No Rust code changed or new Rust test run is claimed.
+Evidence: `${TMPDIR}/t0013-output-lifecycle.3Tto9c/evidence`.
+
+| Fixture | Requested input tasks | Observed output tasks | Process exit | Input/output markers |
+|---|---:|---:|---:|---:|
+| Zero | 0 | 0 | 0 | 6 / 6 |
+| One empty input task | 1 | 8 | 0 | 10 / 70 |
+
+In the one-input case, the actual output trace records open, finish, commit
+and close entry/normal-return pairs for indices 0 through 7. All opens precede
+the input run marker; output finishes occur inside the input finish markers;
+commits then closes occur after input run normal return. Output control and
+transaction return normally, followed by input control/transaction return,
+input cleanup, then output cleanup. Both zero-task transactions return normally
+and input cleanup precedes output cleanup. Output cleanup report counts were
+zero/eight respectively. No add, abort or resume marker occurred.
+
+These are actual sequences for the two original empty fixtures, not universal
+callback ordering or report semantics. Runtime logging reported `max_threads=16`
+and output tasks `8 = input tasks 1 * 8`. PM accepted the differing task counts
+as evidence, not an incident, and explicitly rejected equating input/output
+counts or treating eight as a portable constant. The default mapping algorithm
+and executor configuration remain unverified.
+
+Evidence SHA-256:
+
+- `cases.raw`: `9c08408c10f8fd1a50c63eb9dc09f3ed8401fb65b9069965acb13625b8f9c3ca`
+- `traces.raw`: `06cc4542e428511062bfd575546471d1acd2dba2af64cc9e79ef468ee302b453`
+- Zero mixed trace: `12263d6c29045e10311b5e053b46c86c1f85d8189ce0dec1b0cd0479b1d4f2ec`
+- One mixed trace: `e6b18edff2a49aba53bb1ad7e5df2b9194e61427b8c7c4e5e7db39b1d81aa001`
+
+Corrupt-copy control exited 3 (`t0013-output-lifecycle.UJAZuL`); unavailable
+asset control exited 56 (`t0013-output-lifecycle.nKkXIn`). Thirty mutated
+invalid-evidence controls reached their exact intended diagnostics; null/empty
+synthetic transaction-exception messages remained valid transport forms.
+Checks include source-local marker ordering and a prior matching open before
+handle methods, without prescribing ordering among output tasks. Cleanup's
+received report count is not equated to the earlier control result. No fixed
+outcome hash, output task count or absent callback is an acceptance constant.
+
+Both separately identified local JAR/source hashes, executable hash, notices
+and Java settings remain in the evidence directory. Java is Temurin 17.0.20
+on macOS arm64, with Bash 3.2.57 and Python 3.14.6. This does not demonstrate
+sink durability or Rust lifecycle behavior.
+
+Independent Tester reproduced the exact Demo and per-file syntax/diff checks
+at `5739052`, all exit 0, with identical case/trace hashes and no findings.
+Evidence: `${TMPDIR}/t0013-output-lifecycle.UA5fzd/evidence`; full log
+`/private/tmp/t0013-s02-independent.HGLtLk/full-probe.log`, SHA-256
+`27fc9215c7ae3c9de88f4382341e74832e13bd045c3490fc3c2cec28bf3b0d6c`.
+Integration remains pending; parent #16 remains open.
 
 ## Non-claims
 

--- a/tests/t0013_output_lifecycle_probe_test.sh
+++ b/tests/t0013_output_lifecycle_probe_test.sh
@@ -1,0 +1,617 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+runner="$root/tools/t0013-output-lifecycle/run.sh"
+[[ -x "$runner" ]] || exit 2
+
+run_negative() {
+  local control=$1 expected=$2 label=$3 output result_code evidence
+  if output=$(T0013_OUTPUT_NEGATIVE="$control" "$runner" 2>&1); then
+    exit 1
+  else
+    result_code=$?
+  fi
+  [[ "$result_code" == "$expected" ]] || exit 1
+  evidence=$(printf '%s\n' "$output" | sed -n 's/^T0013_OUTPUT_EVIDENCE_DIR=//p' | tail -1)
+  [[ -n "$evidence" && -d "$evidence" ]] || exit 1
+  grep -Fqx "$label" "$evidence/negative-control.txt" || exit 1
+  printf 'T0013_OUTPUT_NEGATIVE=%s|exit=%s|evidence=%s\n' "$control" "$result_code" "$evidence"
+}
+
+run_negative corrupt-copy 3 corrupt-copy-injected
+run_negative unavailable-asset 56 unavailable-asset-request-failed
+
+output=$("$runner")
+printf '%s\n' "$output"
+evidence=$(printf '%s\n' "$output" | sed -n 's/^T0013_OUTPUT_EVIDENCE_DIR=//p' | tail -1)
+[[ -n "$evidence" && -d "$evidence" ]] || exit 1
+for file in executable.sha256 executable-url.txt LICENSE-executable NOTICE-executable java-version.txt \
+  input-source.sha256 output-source.sha256 input-jar.sha256 output-jar.sha256 \
+  input-coordinate.txt output-coordinate.txt cases.raw traces.raw zero.raw.log one.raw.log; do
+  [[ -s "$evidence/$file" ]] || exit 1
+done
+
+validate() {
+  python3 - "$1" <<'PY'
+import base64
+import binascii
+import hashlib
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+
+class InvalidEvidence(Exception):
+    pass
+
+def require(label, condition):
+    if not condition:
+        raise InvalidEvidence(label)
+
+def decimal(label, value):
+    require(label, value.isascii() and value.isdigit())
+    return int(value)
+
+def decode_field(label, encoded, *, numeric=False, nonempty=False):
+    require(label, encoded != "-")
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+        value = raw.decode("utf-8")
+    except (binascii.Error, UnicodeError):
+        raise InvalidEvidence(label)
+    require(label, base64.b64encode(raw).decode("ascii") == encoded)
+    if numeric:
+        decimal(label, value)
+    if nonempty:
+        require(label, value != "")
+    return value
+
+input_arity = {
+    "transaction-entry": 1,
+    "control-run-before": 1,
+    "control-run-normal-return": 1,
+    "transaction-normal-return": 1,
+    "transaction-runtime-exception": 2,
+    "run-entry": 1,
+    "finish-before": 1,
+    "finish-normal-return": 1,
+    "run-normal-return": 1,
+    "run-runtime-exception": 2,
+    "cleanup-entry": 2,
+    "cleanup-normal-return": 1,
+    "resume-entry": 1,
+    "resume-normal-return": 1,
+    "guess-entry": 0,
+    "guess-normal-return": 0,
+}
+input_numeric = {
+    "transaction-entry": {0}, "control-run-before": {0}, "control-run-normal-return": {0},
+    "transaction-normal-return": {0}, "run-entry": {0}, "finish-before": {0},
+    "finish-normal-return": {0}, "run-normal-return": {0}, "cleanup-entry": {0, 1},
+    "cleanup-normal-return": {0}, "resume-entry": {0}, "resume-normal-return": {0},
+}
+output_arity = {
+    "transaction-entry": 2,
+    "control-run-before": 2,
+    "control-run-normal-return": 3,
+    "transaction-normal-return": 3,
+    "transaction-runtime-exception": 2,
+    "resume-entry": 2,
+    "resume-control-run-before": 2,
+    "resume-control-run-normal-return": 3,
+    "resume-normal-return": 3,
+    "resume-runtime-exception": 2,
+    "cleanup-entry": 3,
+    "cleanup-normal-return": 3,
+    "open-entry": 2,
+    "open-normal-return": 2,
+    "add-entry": 2,
+    "add-normal-return": 2,
+    "finish-entry": 2,
+    "finish-normal-return": 2,
+    "commit-entry": 2,
+    "commit-normal-return": 2,
+    "abort-entry": 2,
+    "abort-normal-return": 2,
+    "close-entry": 2,
+    "close-normal-return": 2,
+}
+output_numeric = {event: set(range(arity)) for event, arity in output_arity.items()
+                  if not event.endswith("runtime-exception")}
+
+try:
+    require("cases-readable", root.joinpath("cases.raw").is_file())
+    require("traces-readable", root.joinpath("traces.raw").is_file())
+    cases = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+    traces = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+    require("case-count", len(cases) == 2)
+
+    parsed_cases = {}
+    for row in cases:
+        parts = row.split("|")
+        require("case-arity", len(parts) == 5)
+        tag, fixture, requested_text, exit_text, summary = parts
+        require("case-tag", tag == "CASE")
+        require("case-fixture", fixture in {"zero", "one"})
+        require("case-duplicate", fixture not in parsed_cases)
+        summary_parts = summary.split(":")
+        require("case-summary-arity", len(summary_parts) == 4)
+        total_text, input_text, output_text, digest = summary_parts
+        requested = decimal("case-requested-count", requested_text)
+        process_exit = decimal("case-process-exit", exit_text)
+        total = decimal("case-total-count", total_text)
+        input_count = decimal("case-input-count", input_text)
+        output_count = decimal("case-output-count", output_text)
+        require("case-digest-format", len(digest) == 64 and all(c in "0123456789abcdef" for c in digest))
+        parsed_cases[fixture] = (requested, process_exit, total, input_count, output_count, digest)
+    require("case-fixtures", set(parsed_cases) == {"zero", "one"})
+    require("requested-fixtures", parsed_cases["zero"][0] == 0 and parsed_cases["one"][0] == 1)
+
+    grouped_rows = {fixture: [] for fixture in ("zero", "one")}
+    decoded = {fixture: {"input": [], "output": []} for fixture in ("zero", "one")}
+    for row in traces:
+        parts = row.split("|")
+        require("trace-minimum-arity", len(parts) >= 4)
+        tag, fixture, sequence_text, event = parts[:4]
+        require("trace-tag", tag in {"TRACE", "OUTTRACE"})
+        require("trace-fixture", fixture in grouped_rows)
+        decimal("trace-sequence", sequence_text)
+        component = "input" if tag == "TRACE" else "output"
+        grammar = input_arity if component == "input" else output_arity
+        numeric_fields = input_numeric if component == "input" else output_numeric
+        require(f"{component}-event-known", event in grammar)
+        require(f"{component}-event-arity", len(parts) == 4 + grammar[event])
+        values = []
+        for index, encoded in enumerate(parts[4:]):
+            if encoded == "-":
+                require(f"{component}-null-position", event.endswith("runtime-exception") and index == 1)
+                values.append(None)
+            else:
+                label = f"{component}-exception-class" if event.endswith("runtime-exception") and index == 0 else f"{component}-canonical-field"
+                values.append(decode_field(label, encoded, numeric=index in numeric_fields.get(event, set()),
+                                           nonempty=event.endswith("runtime-exception") and index == 0))
+        grouped_rows[fixture].append(row)
+        decoded[fixture][component].append((event, values, int(sequence_text)))
+
+    for fixture in ("zero", "one"):
+        requested, process_exit, total, input_count, output_count, digest = parsed_cases[fixture]
+        rows = grouped_rows[fixture]
+        require("case-total-count-match", len(rows) == total)
+        require("case-component-count-match",
+                sum(row.startswith("TRACE|") for row in rows) == input_count
+                and sum(row.startswith("OUTTRACE|") for row in rows) == output_count
+                and input_count + output_count == total)
+        material = ("\n".join(rows) + ("\n" if rows else "")).encode("utf-8")
+        require("case-digest-match", hashlib.sha256(material).hexdigest() == digest)
+        raw_log = root / f"{fixture}.raw.log"
+        require("raw-log-required", raw_log.is_file())
+        raw_traces = [line for line in raw_log.read_text(encoding="utf-8").splitlines()
+                      if line.startswith("TRACE|") or line.startswith("OUTTRACE|")]
+        require("raw-log-trace-match", raw_traces == rows)
+
+        for component, expected_count in (("input", input_count), ("output", output_count)):
+            sequences = [sequence for _, _, sequence in decoded[fixture][component]]
+            require(f"{component}-sequence-contiguous", sequences == list(range(1, expected_count + 1)))
+
+        input_events = decoded[fixture]["input"]
+        output_events = decoded[fixture]["output"]
+        input_names = [event for event, _, _ in input_events]
+        output_names = [event for event, _, _ in output_events]
+        require("input-transaction-boundary",
+                "transaction-entry" in input_names and "control-run-before" in input_names)
+        require("output-transaction-boundary",
+                "transaction-entry" in output_names and "control-run-before" in output_names)
+
+        input_transaction_position = input_names.index("transaction-entry")
+        input_control_position = input_names.index("control-run-before")
+        require("input-local-transaction-order", input_transaction_position < input_control_position)
+        output_transaction_position = output_names.index("transaction-entry")
+        output_control_position = output_names.index("control-run-before")
+        require("output-local-transaction-order", output_transaction_position < output_control_position)
+
+        for event, values, _ in input_events:
+            if event in {"transaction-entry", "control-run-before", "control-run-normal-return",
+                         "transaction-normal-return", "cleanup-entry", "cleanup-normal-return",
+                         "resume-entry", "resume-normal-return"}:
+                require("input-requested-count-consistency", int(values[0]) == requested)
+
+        output_transaction = next(values for event, values, _ in output_events if event == "transaction-entry")
+        output_task_count = int(output_transaction[0])
+        output_schema_count = int(output_transaction[1])
+        require("output-empty-schema", output_schema_count == 0)
+        count_schema_events = {
+            "transaction-entry", "control-run-before", "control-run-normal-return",
+            "transaction-normal-return", "resume-entry", "resume-control-run-before",
+            "resume-control-run-normal-return", "resume-normal-return", "cleanup-entry",
+            "cleanup-normal-return",
+        }
+        indexed_events = {
+            "open-entry", "open-normal-return", "add-entry", "add-normal-return",
+            "finish-entry", "finish-normal-return", "commit-entry", "commit-normal-return",
+            "abort-entry", "abort-normal-return", "close-entry", "close-normal-return",
+        }
+        for event, values, _ in output_events:
+            if event in count_schema_events:
+                require("output-task-count-consistency", int(values[0]) == output_task_count)
+                require("output-schema-count-consistency", int(values[1]) == output_schema_count)
+            if event in indexed_events:
+                require("output-schema-count-consistency", int(values[1]) == output_schema_count)
+                require("output-index-range", output_task_count > 0 and int(values[0]) < output_task_count)
+
+        opened_at = {}
+        for event, values, sequence in output_events:
+            if event == "open-normal-return":
+                opened_at.setdefault(values[0], sequence)
+            if event in {"add-entry", "add-normal-return", "finish-entry", "finish-normal-return",
+                         "commit-entry", "commit-normal-return", "abort-entry", "abort-normal-return",
+                         "close-entry", "close-normal-return"}:
+                require("output-prior-open", values[0] in opened_at and opened_at[values[0]] < sequence)
+
+        transaction_report_values = [int(values[2]) for event, values, _ in output_events
+                                     if event in {"control-run-normal-return", "transaction-normal-return"}]
+        if transaction_report_values:
+            require("output-report-count-consistency",
+                    all(value == transaction_report_values[0] for value in transaction_report_values))
+        resume_report_values = [int(values[2]) for event, values, _ in output_events
+                                if event in {"resume-control-run-normal-return", "resume-normal-return"}]
+        if resume_report_values:
+            require("output-resume-report-count-consistency",
+                    all(value == resume_report_values[0] for value in resume_report_values))
+
+        require("unexpected-add", "add-entry" not in output_names and "add-normal-return" not in output_names)
+
+        for callback in ("open", "finish", "commit", "abort", "close", "cleanup"):
+            balances = {}
+            for event, values, _ in output_events:
+                if event not in {f"{callback}-entry", f"{callback}-normal-return"}:
+                    continue
+                key = tuple(values)
+                balances.setdefault(key, 0)
+                if event.endswith("-entry"):
+                    balances[key] += 1
+                else:
+                    balances[key] -= 1
+                    require("output-callback-pair", balances[key] >= 0)
+            require("output-callback-pair", all(balance == 0 for balance in balances.values()))
+
+        input_transaction_exception = "transaction-runtime-exception" in input_names
+        input_run_exception = "run-runtime-exception" in input_names
+        output_transaction_exception = "transaction-runtime-exception" in output_names
+        output_resume_exception = "resume-runtime-exception" in output_names
+        require("input-transaction-contradiction", not (input_transaction_exception and
+                ("control-run-normal-return" in input_names or "transaction-normal-return" in input_names)))
+        require("input-run-contradiction", not (input_run_exception and
+                ("finish-normal-return" in input_names or "run-normal-return" in input_names)))
+        require("output-transaction-contradiction", not (output_transaction_exception and
+                ("control-run-normal-return" in output_names or "transaction-normal-return" in output_names)))
+        require("output-resume-contradiction", not (output_resume_exception and
+                ("resume-control-run-normal-return" in output_names or "resume-normal-return" in output_names)))
+        if input_transaction_exception:
+            require("input-local-exception-order",
+                    input_control_position < input_names.index("transaction-runtime-exception"))
+        if output_transaction_exception:
+            require("output-local-exception-order",
+                    output_control_position < output_names.index("transaction-runtime-exception"))
+
+        exceptions = [(component, event, values) for component in ("input", "output")
+                      for event, values, _ in decoded[fixture][component] if event.endswith("runtime-exception")]
+        if process_exit != 0:
+            require("nonzero-exception", bool(exceptions))
+            if fixture == "zero":
+                require("zero-output-transaction-exception", output_transaction_exception)
+                require("zero-input-propagated-exception", input_transaction_exception)
+
+        if any(event.startswith("resume") for event in output_names):
+            require("output-resume-boundary", "resume-entry" in output_names and
+                    "resume-control-run-before" in output_names)
+            if not output_resume_exception:
+                require("output-resume-normal-return", "resume-control-run-normal-return" in output_names and
+                        "resume-normal-return" in output_names)
+
+        if process_exit == 0:
+            require("zero-exit-no-exception", not exceptions)
+            require("input-normal-transaction", "control-run-normal-return" in input_names and
+                    "transaction-normal-return" in input_names)
+            require("output-normal-transaction", "control-run-normal-return" in output_names and
+                    "transaction-normal-return" in output_names)
+            require("input-local-normal-order", input_control_position < input_names.index("control-run-normal-return") <
+                    input_names.index("transaction-normal-return"))
+            require("output-local-normal-order", output_control_position < output_names.index("control-run-normal-return") <
+                    output_names.index("transaction-normal-return"))
+
+    one_input_names = [event for event, _, _ in decoded["one"]["input"]]
+    one_output_names = [event for event, _, _ in decoded["one"]["output"]]
+    require("one-process-success", parsed_cases["one"][1] == 0)
+    require("one-input-finish-before", "finish-before" in one_input_names)
+    require("one-input-positive", all(event in one_input_names for event in
+            ("run-entry", "finish-normal-return", "run-normal-return", "control-run-normal-return",
+             "transaction-normal-return")))
+    input_positive_order = ["transaction-entry", "control-run-before", "run-entry", "finish-before",
+                            "finish-normal-return", "run-normal-return", "control-run-normal-return",
+                            "transaction-normal-return"]
+    require("one-input-positive-order",
+            [one_input_names.index(event) for event in input_positive_order]
+            == sorted(one_input_names.index(event) for event in input_positive_order))
+    require("one-output-positive", all(event in one_output_names for event in
+            ("open-entry", "open-normal-return", "finish-entry", "finish-normal-return",
+             "control-run-normal-return", "transaction-normal-return")))
+except (InvalidEvidence, OSError, UnicodeError) as failure:
+    label = failure.args[0] if failure.args else "unclassified"
+    print(f"VALIDATION_ERROR|{label}", file=sys.stderr)
+    sys.exit(4)
+PY
+}
+
+validate "$evidence"
+
+mutated_copy() {
+  local mutation=$1 copy
+  copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-output-validator.XXXXXX")
+  cp "$evidence/cases.raw" "$evidence/traces.raw" "$evidence/zero.raw.log" "$evidence/one.raw.log" "$copy/"
+  python3 - "$mutation" "$copy" <<'PY'
+import base64
+import hashlib
+import pathlib
+import sys
+
+action, directory = sys.argv[1:]
+root = pathlib.Path(directory)
+cases = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+traces = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+
+def fixture_rows(fixture):
+    return [row for row in traces if row.split("|")[1] == fixture]
+
+def next_sequence(fixture, tag):
+    return max(int(row.split("|")[2]) for row in traces if row.startswith(f"{tag}|{fixture}|")) + 1
+
+def renumber(fixture, tag):
+    sequence = 0
+    for index, row in enumerate(traces):
+        if not row.startswith(f"{tag}|{fixture}|"):
+            continue
+        sequence += 1
+        parts = row.split("|")
+        parts[2] = str(sequence)
+        traces[index] = "|".join(parts)
+
+def synchronize():
+    for fixture in ("zero", "one"):
+        rows = fixture_rows(fixture)
+        path = root / f"{fixture}.raw.log"
+        other = [line for line in path.read_text(encoding="utf-8").splitlines()
+                 if not line.startswith("TRACE|") and not line.startswith("OUTTRACE|")]
+        path.write_text("\n".join(rows + other) + "\n", encoding="utf-8")
+    for index, row in enumerate(cases):
+        parts = row.split("|")
+        if len(parts) != 5 or parts[0] != "CASE" or parts[1] not in {"zero", "one"}:
+            continue
+        rows = fixture_rows(parts[1])
+        input_count = sum(item.startswith("TRACE|") for item in rows)
+        output_count = sum(item.startswith("OUTTRACE|") for item in rows)
+        material = ("\n".join(rows) + ("\n" if rows else "")).encode("utf-8")
+        parts[4] = f"{len(rows)}:{input_count}:{output_count}:{hashlib.sha256(material).hexdigest()}"
+        cases[index] = "|".join(parts)
+
+if action == "missing-case":
+    cases.pop()
+elif action == "duplicate-case":
+    cases.append(cases[0])
+elif action == "truncated-trace":
+    traces[0] = "OUTTRACE"
+elif action == "unknown-output-event":
+    traces.append(f"OUTTRACE|one|{next_sequence('one', 'OUTTRACE')}|invented")
+    synchronize()
+elif action == "bad-output-arity":
+    traces.append(f"OUTTRACE|one|{next_sequence('one', 'OUTTRACE')}|open-entry|MA==")
+    synchronize()
+elif action == "bad-output-b64":
+    index = next(i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|") and "|open-entry|" in row)
+    parts = traces[index].split("|")
+    parts[4] = "!"
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "malformed-output-count":
+    index = next(i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|") and "|transaction-entry|" in row)
+    parts = traces[index].split("|")
+    parts[4] = base64.b64encode(b"not-a-count").decode("ascii")
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "mismatched-output-count":
+    index = next(i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|") and "|control-run-before|" in row)
+    parts = traces[index].split("|")
+    parts[4] = base64.b64encode(str(int(base64.b64decode(parts[4])) + 1).encode()).decode("ascii")
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "mismatched-schema-count":
+    index = next(i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|") and "|open-entry|" in row)
+    parts = traces[index].split("|")
+    parts[5] = base64.b64encode(b"1").decode("ascii")
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "mismatched-report-count":
+    index = next(i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|") and "|transaction-normal-return|" in row)
+    parts = traces[index].split("|")
+    parts[6] = base64.b64encode(str(int(base64.b64decode(parts[6])) + 1).encode()).decode("ascii")
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "input-local-order":
+    transaction = next(i for i, row in enumerate(traces) if row.startswith("TRACE|one|") and "|transaction-entry|" in row)
+    control = next(i for i, row in enumerate(traces) if row.startswith("TRACE|one|") and "|control-run-before|" in row)
+    transaction_parts = traces[transaction].split("|")
+    control_parts = traces[control].split("|")
+    transaction_parts[3], control_parts[3] = control_parts[3], transaction_parts[3]
+    traces[transaction] = "|".join(transaction_parts)
+    traces[control] = "|".join(control_parts)
+    synchronize()
+elif action == "output-local-order":
+    transaction = next(i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|") and "|transaction-entry|" in row)
+    control = next(i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|") and "|control-run-before|" in row)
+    transaction_parts = traces[transaction].split("|")
+    control_parts = traces[control].split("|")
+    transaction_parts[3], control_parts[3] = control_parts[3], transaction_parts[3]
+    traces[transaction] = "|".join(transaction_parts)
+    traces[control] = "|".join(control_parts)
+    synchronize()
+elif action == "malformed-index":
+    index = next(i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|") and "|open-entry|" in row)
+    parts = traces[index].split("|")
+    parts[4] = base64.b64encode(b"not-an-index").decode("ascii")
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "out-of-range-index":
+    output_count_row = next(row for row in traces if row.startswith("OUTTRACE|one|") and "|transaction-entry|" in row)
+    output_count = output_count_row.split("|")[4]
+    index = next(i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|") and "|open-entry|" in row)
+    parts = traces[index].split("|")
+    parts[4] = output_count
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "duplicate-output-sequence":
+    indexes = [i for i, row in enumerate(traces) if row.startswith("OUTTRACE|one|")]
+    parts = traces[indexes[1]].split("|")
+    parts[2] = traces[indexes[0]].split("|")[2]
+    traces[indexes[1]] = "|".join(parts)
+    synchronize()
+elif action == "duplicate-output-trace":
+    traces.append(next(row for row in traces if row.startswith("OUTTRACE|one|") and "|open-entry|" in row))
+    synchronize()
+elif action == "output-transaction-contradiction":
+    traces.append(f"OUTTRACE|one|{next_sequence('one', 'OUTTRACE')}|transaction-runtime-exception|amF2YS5sYW5nLlJ1bnRpbWVFeGNlcHRpb24=|-")
+    synchronize()
+elif action == "unexpected-add":
+    sequence = next_sequence("one", "OUTTRACE")
+    traces += [f"OUTTRACE|one|{sequence}|add-entry|MA==|MA==",
+               f"OUTTRACE|one|{sequence + 1}|add-normal-return|MA==|MA=="]
+    synchronize()
+elif action == "missing-output-return":
+    sequence = next_sequence("one", "OUTTRACE")
+    close = next(row for row in traces if row.startswith("OUTTRACE|one|") and "|close-entry|" in row).split("|")
+    traces.append(f"OUTTRACE|one|{sequence}|close-entry|{close[4]}|{close[5]}")
+    synchronize()
+elif action == "missing-input-finish-before":
+    traces = [row for row in traces if not (row.startswith("TRACE|one|") and "|finish-before|" in row)]
+    renumber("one", "TRACE")
+    synchronize()
+elif action == "missing-matching-open":
+    open_row = next(row for row in traces if row.startswith("OUTTRACE|one|") and "|open-entry|" in row)
+    open_index = open_row.split("|")[4]
+    traces = [row for row in traces if not (row.startswith("OUTTRACE|one|") and
+              ("|open-entry|" in row or "|open-normal-return|" in row) and row.split("|")[4] == open_index)]
+    renumber("one", "OUTTRACE")
+    synchronize()
+elif action in {"null-message", "empty-message", "empty-class", "nonzero-no-exception",
+                "unrelated-output-exception", "missing-input-propagation"}:
+    input_class = "amF2YS5sYW5nLlJ1bnRpbWVFeGNlcHRpb24="
+    output_class = "" if action == "empty-class" else input_class
+    message = "-" if action == "null-message" else ""
+    synthetic = [
+        "TRACE|zero|1|transaction-entry|MA==",
+        "TRACE|zero|2|control-run-before|MA==",
+        "OUTTRACE|zero|1|transaction-entry|MA==|MA==",
+        "OUTTRACE|zero|2|control-run-before|MA==|MA==",
+    ]
+    if action not in {"nonzero-no-exception", "unrelated-output-exception"}:
+        synthetic.append(f"OUTTRACE|zero|3|transaction-runtime-exception|{output_class}|{message}")
+    if action == "unrelated-output-exception":
+        synthetic.append(f"OUTTRACE|zero|3|resume-runtime-exception|{output_class}|{message}")
+    if action not in {"nonzero-no-exception", "missing-input-propagation"}:
+        synthetic.append(f"TRACE|zero|3|transaction-runtime-exception|{input_class}|{message}")
+    traces = synthetic + fixture_rows("one")
+    cases = [row if not row.startswith("CASE|zero|") else "CASE|zero|0|1|pending" for row in cases]
+    synchronize()
+elif action == "case-total-corrupt":
+    index = next(i for i, row in enumerate(cases) if row.startswith("CASE|one|"))
+    parts = cases[index].split("|")
+    summary = parts[4].split(":")
+    summary[0] = str(int(summary[0]) + 1)
+    parts[4] = ":".join(summary)
+    cases[index] = "|".join(parts)
+elif action == "case-component-corrupt":
+    index = next(i for i, row in enumerate(cases) if row.startswith("CASE|one|"))
+    parts = cases[index].split("|")
+    summary = parts[4].split(":")
+    summary[1] = str(int(summary[1]) + 1)
+    parts[4] = ":".join(summary)
+    cases[index] = "|".join(parts)
+elif action == "digest-corrupt":
+    index = next(i for i, row in enumerate(cases) if row.startswith("CASE|one|"))
+    parts = cases[index].split("|")
+    summary = parts[4].split(":")
+    summary[3] = "0" * 64
+    parts[4] = ":".join(summary)
+    cases[index] = "|".join(parts)
+elif action == "missing-raw-log":
+    root.joinpath("zero.raw.log").unlink()
+elif action == "raw-log-mismatch":
+    path = root / "one.raw.log"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines = [line for line in lines if not (line.startswith("OUTTRACE|") and "|close-normal-return|" in line)]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+else:
+    raise ValueError(action)
+
+root.joinpath("cases.raw").write_text("\n".join(cases) + "\n", encoding="utf-8")
+root.joinpath("traces.raw").write_text("\n".join(traces) + "\n", encoding="utf-8")
+PY
+  printf '%s\n' "$copy"
+}
+
+validator_fails() {
+  local mutation=$1 expected=$2 copy output result_code
+  copy=$(mutated_copy "$mutation")
+  printf 'T0013_OUTPUT_MUTATION=%s|evidence=%s\n' "$mutation" "$copy"
+  if output=$(validate "$copy" 2>&1); then
+    exit 1
+  else
+    result_code=$?
+  fi
+  [[ "$result_code" == 4 ]] || exit 1
+  [[ "$output" == "VALIDATION_ERROR|$expected" ]] || {
+    printf 'unexpected validator result for %s: %s\n' "$mutation" "$output" >&2
+    exit 1
+  }
+}
+
+validator_accepts() {
+  local mutation=$1 copy
+  copy=$(mutated_copy "$mutation")
+  printf 'T0013_OUTPUT_MUTATION=%s|evidence=%s\n' "$mutation" "$copy"
+  validate "$copy"
+}
+
+validator_fails missing-case case-count
+validator_fails duplicate-case case-count
+validator_fails truncated-trace trace-minimum-arity
+validator_fails unknown-output-event output-event-known
+validator_fails bad-output-arity output-event-arity
+validator_fails bad-output-b64 output-canonical-field
+validator_fails malformed-output-count output-canonical-field
+validator_fails mismatched-output-count output-task-count-consistency
+validator_fails mismatched-schema-count output-schema-count-consistency
+validator_fails mismatched-report-count output-report-count-consistency
+validator_fails input-local-order input-local-transaction-order
+validator_fails output-local-order output-local-transaction-order
+validator_fails malformed-index output-canonical-field
+validator_fails out-of-range-index output-index-range
+validator_fails duplicate-output-sequence output-sequence-contiguous
+validator_fails duplicate-output-trace output-sequence-contiguous
+validator_fails output-transaction-contradiction output-transaction-contradiction
+validator_fails unexpected-add unexpected-add
+validator_fails missing-output-return output-callback-pair
+validator_fails missing-input-finish-before one-input-finish-before
+validator_fails missing-matching-open output-prior-open
+validator_fails empty-class output-exception-class
+validator_fails nonzero-no-exception nonzero-exception
+validator_fails unrelated-output-exception zero-output-transaction-exception
+validator_fails missing-input-propagation zero-input-propagated-exception
+validator_fails case-total-corrupt case-total-count-match
+validator_fails case-component-corrupt case-component-count-match
+validator_fails digest-corrupt case-digest-match
+validator_fails missing-raw-log raw-log-required
+validator_fails raw-log-mismatch raw-log-trace-match
+validator_accepts null-message
+validator_accepts empty-message
+
+printf 'T0013_OUTPUT_FULL_PROBE=passed|evidence=%s\n' "$evidence"

--- a/tools/t0013-output-lifecycle/run.sh
+++ b/tools/t0013-output-lifecycle/run.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+input_src="$root/tools/t0013-input-lifecycle/src/T0013InputPlugin.java"
+output_src="$root/tools/t0013-output-lifecycle/src/T0013OutputPlugin.java"
+url=https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
+expected_sha=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
+tmp=$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-output-lifecycle.XXXXXX")
+evidence="$tmp/evidence"
+input_repo="$tmp/home/lib/m2/repository/org/embulk/t0013/s02/embulk-input-t0013s02input/0.0.1"
+output_repo="$tmp/home/lib/m2/repository/org/embulk/t0013/s02/embulk-output-t0013s02output/0.0.1"
+mkdir -p "$evidence" "$tmp/input-classes" "$tmp/output-classes" "$input_repo" "$output_repo"
+trap 'printf "T0013_OUTPUT_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
+
+jarfile="$tmp/embulk.jar"
+if [[ ${T0013_OUTPUT_NEGATIVE:-} == unavailable-asset ]]; then
+  url=https://github.com/embulk/embulk/releases/download/v0.11.5/unavailable.jar
+fi
+printf '%s\n' "$url" > "$evidence/executable-url.txt"
+if ! curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error -o "$jarfile" "$url"; then
+  if [[ ${T0013_OUTPUT_NEGATIVE:-} == unavailable-asset ]]; then
+    printf '%s\n' unavailable-asset-request-failed > "$evidence/negative-control.txt"
+  fi
+  exit 56
+fi
+if [[ ${T0013_OUTPUT_NEGATIVE:-} == corrupt-copy ]]; then
+  printf corrupt >> "$jarfile"
+  printf '%s\n' corrupt-copy-injected > "$evidence/negative-control.txt"
+fi
+actual_sha=$(shasum -a 256 "$jarfile" | awk '{print $1}')
+printf '%s\n' "$actual_sha" > "$evidence/executable.sha256"
+[[ "$actual_sha" == "$expected_sha" ]] || exit 3
+
+shasum -a 256 "$input_src" | awk '{print $1}' > "$evidence/input-source.sha256"
+shasum -a 256 "$output_src" | awk '{print $1}' > "$evidence/output-source.sha256"
+unzip -p "$jarfile" META-INF/LICENSE > "$evidence/LICENSE-executable" || [[ -s "$evidence/LICENSE-executable" ]]
+unzip -p "$jarfile" META-INF/NOTICE > "$evidence/NOTICE-executable" || [[ -s "$evidence/NOTICE-executable" ]]
+java -XshowSettings:properties -version > "$evidence/java-version.txt" 2>&1
+
+javac -cp "$jarfile" -d "$tmp/input-classes" "$input_src"
+javac -cp "$jarfile" -d "$tmp/output-classes" "$output_src"
+
+printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0013InputPlugin' \
+  'Embulk-Plugin-Category: input' 'Embulk-Plugin-Type: t0013s02input' \
+  'Embulk-Plugin-Spi-Version: 0' > "$tmp/INPUT.MF"
+jar cfm "$input_repo/embulk-input-t0013s02input-0.0.1.jar" "$tmp/INPUT.MF" -C "$tmp/input-classes" .
+printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0013OutputPlugin' \
+  'Embulk-Plugin-Category: output' 'Embulk-Plugin-Type: t0013s02output' \
+  'Embulk-Plugin-Spi-Version: 0' > "$tmp/OUTPUT.MF"
+jar cfm "$output_repo/embulk-output-t0013s02output-0.0.1.jar" "$tmp/OUTPUT.MF" -C "$tmp/output-classes" .
+
+shasum -a 256 "$input_repo/embulk-input-t0013s02input-0.0.1.jar" | awk '{print $1}' > "$evidence/input-jar.sha256"
+shasum -a 256 "$output_repo/embulk-output-t0013s02output-0.0.1.jar" | awk '{print $1}' > "$evidence/output-jar.sha256"
+printf '%s\n' 'source=maven|group=org.embulk.t0013.s02|name=t0013s02input|version=0.0.1|artifact=embulk-input-t0013s02input|category=input|local-only' > "$evidence/input-coordinate.txt"
+printf '%s\n' 'source=maven|group=org.embulk.t0013.s02|name=t0013s02output|version=0.0.1|artifact=embulk-output-t0013s02output|category=output|local-only' > "$evidence/output-coordinate.txt"
+printf '%s' '<project><modelVersion>4.0.0</modelVersion></project>' > "$input_repo/embulk-input-t0013s02input-0.0.1.pom"
+printf '%s' '<project><modelVersion>4.0.0</modelVersion></project>' > "$output_repo/embulk-output-t0013s02output-0.0.1.pom"
+
+: > "$evidence/traces.raw"
+: > "$evidence/cases.raw"
+for spec in zero:0 one:1; do
+  fixture=${spec%%:*}
+  count=${spec##*:}
+  log="$evidence/$fixture.raw.log"
+  config="$tmp/$fixture.yml"
+  case_trace="$tmp/$fixture.trace"
+  printf '%s\n' \
+    'in:' \
+    '  type:' \
+    '    source: maven' \
+    '    group: org.embulk.t0013.s02' \
+    '    name: t0013s02input' \
+    '    version: 0.0.1' \
+    'out:' \
+    '  type:' \
+    '    source: maven' \
+    '    group: org.embulk.t0013.s02' \
+    '    name: t0013s02output' \
+    '    version: 0.0.1' > "$config"
+  if T0013_FIXTURE="$fixture" T0013_TASK_COUNT="$count" \
+    java -jar "$jarfile" "-Xembulk_home=$tmp/home" run "$config" > "$log" 2>&1; then
+    code=0
+  else
+    code=$?
+  fi
+  awk '/^(TRACE|OUTTRACE)\|/' "$log" > "$case_trace"
+  cat "$case_trace" >> "$evidence/traces.raw"
+  digest=$(shasum -a 256 "$case_trace" | awk '{print $1}')
+  total=$(wc -l < "$case_trace" | tr -d ' ')
+  input_count=$(awk '/^TRACE\|/ {count++} END {print count + 0}' "$case_trace")
+  output_count=$(awk '/^OUTTRACE\|/ {count++} END {print count + 0}' "$case_trace")
+  printf 'CASE|%s|%s|%s|%s:%s:%s:%s\n' "$fixture" "$count" "$code" \
+    "$total" "$input_count" "$output_count" "$digest" >> "$evidence/cases.raw"
+done
+cat "$evidence/cases.raw"

--- a/tools/t0013-output-lifecycle/src/T0013OutputPlugin.java
+++ b/tools/t0013-output-lifecycle/src/T0013OutputPlugin.java
@@ -1,0 +1,158 @@
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Exec;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.Page;
+import org.embulk.spi.Schema;
+import org.embulk.spi.TransactionalPageOutput;
+
+/** Local-only T-0013/S02 output lifecycle observation probe. */
+public final class T0013OutputPlugin implements OutputPlugin {
+    private static long sequence;
+
+    @Override
+    public ConfigDiff transaction(ConfigSource config, Schema schema, int taskCount, Control control) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace(fixture, "transaction-entry", count, columns);
+        TaskSource outputTaskSource = Exec.newTaskSource();
+        trace(fixture, "control-run-before", count, columns);
+        List<TaskReport> reports = runControl(fixture, "transaction-runtime-exception", control, outputTaskSource);
+        if (reports == null) {
+            throw new InstrumentationError("output control returned null reports");
+        }
+        trace(fixture, "control-run-normal-return", count, columns, Integer.toString(reports.size()));
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "transaction-normal-return", count, columns, Integer.toString(reports.size()));
+        return result;
+    }
+
+    @Override
+    public ConfigDiff resume(TaskSource taskSource, Schema schema, int taskCount, Control control) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace(fixture, "resume-entry", count, columns);
+        trace(fixture, "resume-control-run-before", count, columns);
+        List<TaskReport> reports = runControl(fixture, "resume-runtime-exception", control, taskSource);
+        if (reports == null) {
+            throw new InstrumentationError("output resume control returned null reports");
+        }
+        trace(fixture, "resume-control-run-normal-return", count, columns, Integer.toString(reports.size()));
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "resume-normal-return", count, columns, Integer.toString(reports.size()));
+        return result;
+    }
+
+    @Override
+    public void cleanup(TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> reports) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        String columns = Integer.toString(schema.getColumnCount());
+        String reportCount = Integer.toString(reports.size());
+        trace(fixture, "cleanup-entry", count, columns, reportCount);
+        trace(fixture, "cleanup-normal-return", count, columns, reportCount);
+    }
+
+    @Override
+    public TransactionalPageOutput open(TaskSource taskSource, Schema schema, int taskIndex) {
+        String fixture = fixture();
+        String index = Integer.toString(taskIndex);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace(fixture, "open-entry", index, columns);
+        TransactionalPageOutput result = new ObservedPageOutput(fixture, taskIndex, schema.getColumnCount());
+        trace(fixture, "open-normal-return", index, columns);
+        return result;
+    }
+
+    private static List<TaskReport> runControl(
+            String fixture, String exceptionEvent, Control control, TaskSource taskSource) {
+        RuntimeException operationFailure = null;
+        List<TaskReport> reports = null;
+        try {
+            reports = control.run(taskSource);
+        } catch (RuntimeException failure) {
+            operationFailure = failure;
+        }
+        if (operationFailure != null) {
+            trace(fixture, exceptionEvent, operationFailure.getClass().getName(),
+                    operationFailure.getMessage());
+            throw operationFailure;
+        }
+        return reports;
+    }
+
+    private static final class ObservedPageOutput implements TransactionalPageOutput {
+        private final String fixture;
+        private final String index;
+        private final String columns;
+
+        private ObservedPageOutput(String fixture, int taskIndex, int columnCount) {
+            this.fixture = fixture;
+            this.index = Integer.toString(taskIndex);
+            this.columns = Integer.toString(columnCount);
+        }
+
+        @Override
+        public void add(Page page) {
+            trace(fixture, "add-entry", index, columns);
+            trace(fixture, "add-normal-return", index, columns);
+        }
+
+        @Override
+        public void finish() {
+            trace(fixture, "finish-entry", index, columns);
+            trace(fixture, "finish-normal-return", index, columns);
+        }
+
+        @Override
+        public TaskReport commit() {
+            trace(fixture, "commit-entry", index, columns);
+            TaskReport result = Exec.newTaskReport();
+            trace(fixture, "commit-normal-return", index, columns);
+            return result;
+        }
+
+        @Override
+        public void abort() {
+            trace(fixture, "abort-entry", index, columns);
+            trace(fixture, "abort-normal-return", index, columns);
+        }
+
+        @Override
+        public void close() {
+            trace(fixture, "close-entry", index, columns);
+            trace(fixture, "close-normal-return", index, columns);
+        }
+    }
+
+    private static String fixture() {
+        return System.getenv("T0013_FIXTURE");
+    }
+
+    private static synchronized void trace(String fixture, String event, String... fields) {
+        StringBuilder line = new StringBuilder("OUTTRACE|").append(fixture).append('|')
+                .append(++sequence).append('|').append(event);
+        for (String field : fields) {
+            line.append('|').append(field == null ? "-" : Base64.getEncoder()
+                    .encodeToString(field.getBytes(StandardCharsets.UTF_8)));
+        }
+        System.out.println(line);
+        if (System.out.checkError()) {
+            throw new InstrumentationError("output trace failed");
+        }
+    }
+
+    private static final class InstrumentationError extends Error {
+        private InstrumentationError(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
Refs #16. T-0013/S02 only, 3 SP within unchanged parent SP 8. Original separately identified local output plugin and unchanged S01 input fixture observe zero/one empty input tasks against pinned Embulk 0.11.5. One input task produced eight output tasks in this environment; no count-eight or snapshot acceptance constant is used. Primary and independent Tester passed tests/t0013_output_lifecycle_probe_test.sh at 5739052, including artifact controls and 30 strict malformed-evidence controls. Canonical evidence: docs/provenance/T-0013-output-lifecycle-probe.md. S01 integration closeout and bounded Rust execution decision gates included. Reference Observation / Integration only; no durability, scheduler mapping, failure/retry, or Rust lifecycle claim. Parent remains open. Final-head acceptance follows.