### PR TITLE
test(t-0013): observe input failure and cleanup capture contexts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S03` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
+`T-0013/S03` is `Review`; `T-0012`, `T-0021` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01/S02 integrated; S03 input failure) | In Progress | P0 | 13 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01/S02 integrated; S03 input failure) | Review | P0 | 13 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -190,3 +190,16 @@ SP changes from 8 to 13 because distinct input/output task contexts and strict
 failure-evidence validation were underrepresented initially. Initial SP remains
 8. No earned parent points or completion follows; retry/resume and the parent
 Differential gate remain open. Combined WIP stays one.
+S03 primary acceptance at `f35cb49` passed the exact normal/failure Demo and
+25 invalid-evidence controls, including same-capture duplicate sequence 1 and
+non-main capture checks. Independent Tester reproduced the full Demo;
+integration remains pending.
+
+Next pull candidate after S03 acceptance: T-0021/S03, a private empty-task
+coordinator with explicit input/output task plans and original fake plugins.
+A separate decision/packet must delimit the supported normal and input-run
+failure paths, cleanup context ownership, and unsupported callback failures.
+It must not infer default executor fan-out, create a public plugin API or claim
+data transfer. Local Unit/Contract acceptance precedes a separately scoped live
+callback comparison under T-0013; neither parent is completed by planning this
+candidate. No implementation files or second WIP lane are activated here.

--- a/TODO.md
+++ b/TODO.md
@@ -183,7 +183,8 @@ Tester reproduced the complete Demo; final-head acceptance at `55ed697` passed
 and PR #71 integrated as `d474b7b`.
 
 T-0013/S03 (3 SP within Current SP 13) observes one input-run exception before
-its own finish call plus a normal control, with unchanged S02 output source.
+its own finish call plus a normal control. S03 retains S02 output behavior in a
+new original fixture with explicit capture-context IDs; S02 remains unchanged.
 See its [packet](docs/provenance/T-0013-input-failure-probe.md). Current parent
 SP changes from 8 to 13 because distinct input/output task contexts and strict
 failure-evidence validation were underrepresented initially. Initial SP remains

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S02` is `Review`; `T-0012`, `T-0021` and all other unfinished items
+`T-0013/S03` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01 integrated; S02 output observations) | Review | P0 | 8 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01/S02 integrated; S03 input failure) | In Progress | P0 | 13 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -179,4 +179,13 @@ excludes failure injection, Pages, delivery guarantees and Rust traits. Parent
 completion and additional parent points are not implied; combined WIP stays one.
 Primary acceptance at `5739052` passed the exact S02 Demo, including actual
 distinct input/output counts and 30 malformed-evidence controls. Independent
-Tester reproduced the complete Demo; integration remains pending.
+Tester reproduced the complete Demo; final-head acceptance at `55ed697` passed
+and PR #71 integrated as `d474b7b`.
+
+T-0013/S03 (3 SP within Current SP 13) observes one input-run exception before
+its own finish call plus a normal control, with unchanged S02 output source.
+See its [packet](docs/provenance/T-0013-input-failure-probe.md). Current parent
+SP changes from 8 to 13 because distinct input/output task contexts and strict
+failure-evidence validation were underrepresented initially. Initial SP remains
+8. No earned parent points or completion follows; retry/resume and the parent
+Differential gate remain open. Combined WIP stays one.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -80,8 +80,12 @@ for zero/one input tasks, respectively. The one-input run records output
 open/finish/commit/close pairs; no add, abort or resume marker occurred. This
 is not a default fan-out algorithm, durable commit, general callback-order
 guarantee or Native/Verified lifecycle claim. Independent acceptance passed;
-PR #71 integrated as `d474b7b`. S03's input-run failure observation is pending;
-no failure-handling or rollback support follows from S02's normal traces.
+PR #71 integrated as `d474b7b`. S03's primary input-run failure observation
+records the exact injected exception propagating, output abort/close and
+cleanup with fresh capture IDs and zero reports. Normal control exited 0;
+failure exited 1. This is Reference Observation / Integration only, not native
+failure handling, rollback, cleanup/retry guarantees or a Java loading contract.
+Independent acceptance passed; integration remains pending.
 
 ## Adding an Entry
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -80,7 +80,8 @@ for zero/one input tasks, respectively. The one-input run records output
 open/finish/commit/close pairs; no add, abort or resume marker occurred. This
 is not a default fan-out algorithm, durable commit, general callback-order
 guarantee or Native/Verified lifecycle claim. Independent acceptance passed;
-integration remains pending.
+PR #71 integrated as `d474b7b`. S03's input-run failure observation is pending;
+no failure-handling or rollback support follows from S02's normal traces.
 
 ## Adding an Entry
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,6 +62,10 @@ default scheduling, failure propagation, recovery or delivery gates.
 Independent and final-head acceptance passed; PR #71 integrated as `d474b7b`.
 S03 now observes one input-run failure boundary before choosing a private
 empty-task coordinator. This is not a pre-publication or rollback guarantee.
+S03 primary acceptance at `f35cb49` passed the normal and injected-run-failure
+fixtures, capture identity validation and strict malformed-evidence controls.
+It supplies bounded candidate evidence for private empty-task execution only;
+parent lifecycle, resume, cleanup-error and delivery gates remain open.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,6 +59,9 @@ for the same empty-task boundary before Rust policy or failure injection.
 S02 primary acceptance passed at `5739052`, including its actual one-input/
 eight-output observation and strict evidence controls. This does not resolve
 default scheduling, failure propagation, recovery or delivery gates.
+Independent and final-head acceptance passed; PR #71 integrated as `d474b7b`.
+S03 now observes one input-run failure boundary before choosing a private
+empty-task coordinator. This is not a pre-publication or rollback guarantee.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -143,7 +143,7 @@ task identity into one counter. The factor eight is a local observation, not a
 portable constant or an accepted scheduling algorithm. Mapping rules, executor
 options and concurrency need separate fixtures before implementation.
 
-S03's initial failure observation (acceptance pending) also records plugin
+S03's primary failure acceptance at `f35cb49` also records plugin
 loading again during cleanup and reset static probe counters. Do not design
 cleanup around a requirement that the original in-memory plugin instance or
 task handle survives. The probe now assigns explicit capture-context IDs so

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -143,6 +143,15 @@ task identity into one counter. The factor eight is a local observation, not a
 portable constant or an accepted scheduling algorithm. Mapping rules, executor
 options and concurrency need separate fixtures before implementation.
 
+S03's initial failure observation (acceptance pending) also records plugin
+loading again during cleanup and reset static probe counters. Do not design
+cleanup around a requirement that the original in-memory plugin instance or
+task handle survives. The probe now assigns explicit capture-context IDs so
+reload-like observations are distinguishable from duplicate transport records.
+Those IDs are instrumentation only, not a proposed resume/task identity format.
+The empty TaskSource fixture does not establish a general reconstruction or
+serialization contract.
+
 | Phase | Coordinator responsibility | Plugin/adapter responsibility | Trace evidence required |
 |---|---|---|---|
 | Resolve and validate | Select pinned factories, resolve configuration | Validate plugin options at the compatible stage | First error, defaults applied, side effects before failure |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -29,7 +29,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S02 (`Review`) is the only active work item. Combined WIP is one of
+T-0013/S03 (`In Progress`) is the only active work item. Combined WIP is one of
 two; no item is `Ready` or `Blocked`. T-0012 and T-0021 return to Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -41,7 +41,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
 | T-0021 | Backlog | S01/S02 integrated; core traits await T-0012/T-0013 contracts |
-| T-0013/S02 | Review | Accept zero-task and one-task output lifecycle traces |
+| T-0013/S03 | In Progress | Observe input-run failure before its finish call |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -154,5 +154,11 @@ separate original local output plugin. Primary acceptance at `5739052` passed
 both fixtures and all artifact/trace controls. One input task produced eight
 output tasks in this local reference run, each with open/finish/commit/close
 pairs; no add, abort or resume marker occurred. Independent Tester reproduced
-the complete Demo; integration is pending. No Rust lifecycle trait or output durability policy
+the complete Demo; final-head acceptance at `55ed697` passed and PR #71
+integrated as `d474b7b`. No Rust lifecycle trait or output durability policy
 is inferred; the fan-out factor is not a portable constant.
+
+S03 adds a normal control and one injected input-run exception before its own
+finish call. Acceptance is pending. T-0013 Current SP is refined from 8 to 13
+for distinct task contexts and failure-evidence validation; Initial SP remains
+8, and parent completion is not implied.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -29,7 +29,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S03 (`In Progress`) is the only active work item. Combined WIP is one of
+T-0013/S03 (`Review`) is the only active work item. Combined WIP is one of
 two; no item is `Ready` or `Blocked`. T-0012 and T-0021 return to Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -41,7 +41,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
 | T-0021 | Backlog | S01/S02 integrated; core traits await T-0012/T-0013 contracts |
-| T-0013/S03 | In Progress | Observe input-run failure before its finish call |
+| T-0013/S03 | Review | Accept input-run failure before its finish call |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -159,6 +159,10 @@ integrated as `d474b7b`. No Rust lifecycle trait or output durability policy
 is inferred; the fan-out factor is not a portable constant.
 
 S03 adds a normal control and one injected input-run exception before its own
-finish call. Acceptance is pending. T-0013 Current SP is refined from 8 to 13
+finish call. Primary acceptance at `f35cb49` passed: normal process exit 0,
+injected failure exit 1 with the exact fixture exception propagated. Failure
+output abort/close and cleanup under fresh capture IDs were observed.
+Independent Tester reproduced the complete Demo; integration is pending.
+T-0013 Current SP is refined from 8 to 13
 for distinct task contexts and failure-evidence validation; Initial SP remains
 8, and parent completion is not implied.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -70,7 +70,13 @@
   Tester reproduced the complete Demo at `5739052`; final-head Demo at `55ed697`
   passed and PR #71 integrated as `d474b7b`, with parent #16 open.
 - Activated S03's normal control and input-run exception before its finish
-  call, preserving S02 output source. Librarian planning was corrected to avoid
+  call, preserving the existing S02 output source. Librarian planning was corrected to avoid
   calling this pre-publication. Current T-0013 estimate changes 8 to 13 for
   distinct task contexts and failure-evidence validation; Initial SP stays 8.
   No parent completion, duplicated points, rollback or retry claim follows.
+- Initial S03 failure observation showed abort/close, then plugin loading logs
+  during cleanup with static counters reset to 1. PM expanded the allowlist by
+  one original S03 output source with equivalent callback bodies, adding explicit
+  capture IDs to both plugins. A counter restart alone cannot establish a new
+  capture, and capture IDs are not recovery/task identities. No external
+  artifact or retry scenario is added.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -80,3 +80,9 @@
   capture IDs to both plugins. A counter restart alone cannot establish a new
   capture, and capture IDs are not recovery/task identities. No external
   artifact or retry scenario is added.
+- S03 primary acceptance at `f35cb49` passed the exact Demo: normal exit 0,
+  injected failure exit 1, actual abort/close, and cleanup under fresh capture
+  IDs with zero reports. Twenty-five invalid controls and three synthetic
+  format/context controls passed. Output behavior remains equivalent to S02;
+  capture IDs are instrumentation, not recovery identities. Independent
+  Tester reproduced the complete Demo at `f35cb49`; integration is pending.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -67,4 +67,10 @@
   PM retained the observed distinction without hardcoding the factor or
   inferring durability. Source-local ordering checks were strengthened without
   making cleanup report counts equal an earlier control result. Independent
-  Tester reproduced the complete Demo at `5739052`; integration is pending.
+  Tester reproduced the complete Demo at `5739052`; final-head Demo at `55ed697`
+  passed and PR #71 integrated as `d474b7b`, with parent #16 open.
+- Activated S03's normal control and input-run exception before its finish
+  call, preserving S02 output source. Librarian planning was corrected to avoid
+  calling this pre-publication. Current T-0013 estimate changes 8 to 13 for
+  distinct task contexts and failure-evidence validation; Initial SP stays 8.
+  No parent completion, duplicated points, rollback or retry claim follows.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -15,4 +15,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | Done (selected schema Differential; PR #69) |
 | [T-0013/S01 input lifecycle observation](T-0013-input-lifecycle-probe.md) | Done (Reference Observation / Integration; PR #70) |
 | [T-0013/S02 output lifecycle observation](T-0013-output-lifecycle-probe.md) | Done (Reference Observation / Integration; PR #71) |
-| [T-0013/S03 input-run failure observation](T-0013-input-failure-probe.md) | In Progress (acceptance pending) |
+| [T-0013/S03 input-run failure observation](T-0013-input-failure-probe.md) | Review (Reference Observation / Integration; integration pending) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -14,4 +14,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S05 schema-boundary observation](T-0012-schema-boundary-probe.md) | Done (Reference Observation / Integration; PR #68) |
 | [T-0012/S06 ordered schema differential](T-0012-ordered-schema-differential.md) | Done (selected schema Differential; PR #69) |
 | [T-0013/S01 input lifecycle observation](T-0013-input-lifecycle-probe.md) | Done (Reference Observation / Integration; PR #70) |
-| [T-0013/S02 output lifecycle observation](T-0013-output-lifecycle-probe.md) | Review (Reference Observation / Integration; integration pending) |
+| [T-0013/S02 output lifecycle observation](T-0013-output-lifecycle-probe.md) | Done (Reference Observation / Integration; PR #71) |
+| [T-0013/S03 input-run failure observation](T-0013-input-failure-probe.md) | In Progress (acceptance pending) |

--- a/docs/provenance/T-0013-input-failure-probe.md
+++ b/docs/provenance/T-0013-input-failure-probe.md
@@ -1,7 +1,7 @@
 # T-0013/S03 input-run failure reference observation
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: In Progress; acceptance pending
+- State: Review; primary and independent acceptance passed, integration pending
 - Parent: T-0010; priority P0
 - Slice estimate: 3 SP within parent Current SP 13; Initial SP remains 8
 - Refinement: implementation 1, uncertainty 1, verification 1, environment 1;
@@ -178,3 +178,64 @@ No Rust lifecycle, executor mapping, general callback count/order, durable
 publication, rollback, cleanup guarantee, retry/resume behavior, report
 semantics, transaction atomicity, exactly-once, plugin compatibility,
 performance, security or release claim. Parent #16 remains open after acceptance.
+
+## Acceptance evidence (2026-09-06)
+
+Primary acceptance at `f35cb494037be1f5304e7e8ef310ef47721757f9` ran the
+exact outside-worktree Demo, exit 0, plus per-file `bash -n` and
+`git diff --check`, all passing. Output source review against S02 confirms
+equivalent callback bodies; changes are class/comment identity, UUID capture
+initialization and the trace tag/envelope. No Rust source or suite changed.
+
+Evidence: `${TMPDIR}/t0013-input-failure.aHpYrI/evidence`.
+
+| Fixture | Process exit | Input/output markers | Actual output observations |
+|---|---:|---:|---|
+| Normal, one empty input task | 0 | 10 / 70 | Eight indices opened, finished, committed and closed; normal control/transaction return and cleanup |
+| Injected run failure before input finish | 1 | 8 / 53 | Eight indices opened, then aborted and closed; transaction exception and cleanup |
+
+The failure's input run and both instrumented transaction boundaries record
+the actual class `T0013FailureInputPlugin$InjectedRunFailure` and message
+`t0013-s03-injected-run-failure`. The input's own finish/run normal return and
+output finish/commit were absent in this execution. Input cleanup received
+task count 1 and zero reports; output cleanup received task count 8 and zero
+reports. Normal cleanup received one/eight reports, respectively. No add or
+resume marker occurred. No output absence, task count eight, general callback
+order or cleanup report equality is a hardcoded acceptance gate.
+
+Normal callbacks used one capture ID per component. The failure used separate
+main and cleanup capture IDs for each component, with sequences restarting
+at 1 under the fresh IDs. Raw logging also reported plugin loading in cleanup.
+PM accepts these bounded observations and the exact injected propagation;
+they do not establish rollback, classloader identity guarantees or a general
+reconstruction/serialization contract.
+
+Primary evidence SHA-256 (per-run identity, not cross-run expected values):
+
+- `cases.raw`: `22a2f53f0cc425e55395130ec74d40caabdfc09fec65dc646cfc4cc6489faa86`
+- `traces.raw`: `2aa888b7ae91d1b57da650b62edd531e69997ae6e5f2203f8cbb7d37eeed5d6b`
+- Normal trace: `b8a3cca5cfffb2959e33861d82508f7a34b6d5ccf1676dfabb8edc72b1ccd29d`
+- Failure trace: `cb6082066d7baff6bb7860b73692cfbe7f654ce6f2991c6bbd7eb07957dc66bd`
+
+Actual corrupt-copy control exited 3 (`t0013-input-failure.ISUJVB`) and
+unavailable asset control exited 56 (`t0013-input-failure.9tecAj`). Twenty-five
+invalid-evidence controls reached their intended exact diagnostics. Three
+synthetic valid controls cover null/empty message representation and fresh
+cleanup captures; they are not additional live resume/failure scenarios.
+Review rejected sequence-reset heuristics, changed missing-exception controls
+to genuine added-return contradictions, and required structure/termination
+checks in non-main captures. Malformed transport is not a semantic result.
+
+Java Temurin 17.0.20, Bash 3.2.57 and Python 3.14.6 on macOS arm64 were used;
+runtime identity/settings, notices and both source/JAR hashes are retained in
+the evidence. Independent Tester reproduced the exact Demo and syntax/diff
+checks at `f35cb49`, all exit 0, with no findings. Evidence:
+`${TMPDIR}/t0013-input-failure.T6Sdlj/evidence`; full log
+`/private/tmp/t0013-s03-independent.Q8oPXy/full-probe.log`, SHA-256
+`4bc07797fd898cee878ca02f885b5bcbeec935e3ec8dc984f83d7f516c17c98c`.
+Tester case/trace hashes were
+`6be446943cf625d14dad1c8dea2d4cf77e0c09d5413034c634ddd55dbbfc316c` and
+`303235adefefeb97c297c74195d70b88e8d38d97a304ab9756d795122b1a8b28`.
+Fresh random capture IDs intentionally make them differ from the primary run;
+the actual bounded outcomes and controls were reproduced. PR integration
+remains pending; parent #16 remains open.

--- a/docs/provenance/T-0013-input-failure-probe.md
+++ b/docs/provenance/T-0013-input-failure-probe.md
@@ -19,8 +19,9 @@ retrieval failures are repairable work, not incidents.
 ## Dependencies
 
 T-0011's pinned executable and S01/S02, integrated through PR #70 (`e8b5726`)
-and PR #71 (`d474b7b`). Reuse S02's unchanged original output source in a
-separately identified local output JAR. Input and output tasks are distinct;
+and PR #71 (`d474b7b`). Reuse S02's original output behavior in a separately
+identified S03 source/JAR with explicit capture-context instrumentation.
+The existing S02 source remains unchanged. Input and output tasks are distinct;
 do not equate counts or hardcode the observed factor eight. T-0012 and T-0021
 remain Backlog; combined WIP is one of two.
 
@@ -33,10 +34,11 @@ retry/resume, cleanup-error or partial-publication contracts.
 ## Branch and allowlist
 
 Branch: `research/t-0013-input-failure`.
-Compatibility Host Implementer owns exactly three new files:
+Compatibility Host Implementer owns exactly four new files:
 
 - `tools/t0013-input-failure/run.sh`
 - `tools/t0013-input-failure/src/T0013FailureInputPlugin.java`
+- `tools/t0013-input-failure/src/T0013FailureOutputPlugin.java`
 - `tests/t0013_input_failure_probe_test.sh`
 
 No existing S01/S02 source/runner/test mutation, Rust code, production host,
@@ -48,7 +50,8 @@ COMPATIBILITY, runtime design, provenance/index and dated log reconciliation.
 An original local input fixture and standalone runner/test execute exactly two
 isolated cases, each requesting one empty input task/schema and no Pages or
 values: normal positive control, and an input-run failure before the input's
-own PageOutput.finish call. Output source remains the original S02 fixture.
+own PageOutput.finish call. Output callback bodies remain equivalent to the
+original S02 fixture; only class and capture-context instrumentation changes.
 Reuse project-owned probe structure only, not upstream implementation/tests.
 Use distinct local input/output Maven-style coordinates, categories and JARs;
 retain both source/JAR hashes and never assume shared static marker state.
@@ -88,12 +91,35 @@ in transaction or open. This local empty sink establishes no durability boundary
 
 Validate exactly two complete fixture envelopes, marker grammar and exact
 arity, canonical UTF-8/Base64 and typed numerical fields, raw-log correspondence,
-component-local sequence continuity, source-local entry/return/exception
+capture-local sequence continuity, source-local entry/return/exception
 consistency, required positive/injected markers and count/digest consistency.
 Track per-invocation structure where needed; repeated genuine invocations are
 not duplicate transport records. Output fields use their own observed context;
 cleanup report counts are not equated to control reports. Any unexpected add,
 instrumentation/setup error or unsupported trace interpretation fails acceptance.
+
+### Capture-context refinement
+
+First live evidence at `${TMPDIR}/t0013-input-failure.qiKq6n/evidence` reached
+the injected failure, propagated the exact original exception and exited 1.
+Actual abort/close and cleanup markers occurred. The raw log reports plugin
+loading again during cleanup, and both static counters restart at 1. This is
+pre-refinement evidence, not acceptance of the original single-counter format.
+It does not prove a universal classloader or recovery identity contract.
+
+PM therefore expands the original three-file allowlist by one original S03
+output fixture file, without changing S02. Both S03 plugins emit a canonical
+random UUID capture ID initialized once per loaded class. Validate contiguous
+sequences per fixture/component/capture ID and preserve physical raw order.
+A sequence restart alone is never a new context. Duplicate sequences in the
+same capture must fail even when the repeated sequence is 1. Validate marker
+pairing and open-handle association within their capture context; a cleanup-only
+context need not have an open handle or transaction invocation of its own.
+IDs identify instrumentation contexts, not task attempts, processes or guaranteed
+classloader identities. They intentionally vary between executions; raw digests
+remain per-run identities rather than cross-run equality gates. The existing
+JDK UUID facility adds no dependency or external artifact. Review the output
+diff against S02 to confirm that only class/trace identity changed.
 
 Use mutated evidence copies to reject missing/unknown/truncated/duplicate-
 sequence records, malformed fields, stale counts/hashes/logs, fake injected

--- a/docs/provenance/T-0013-input-failure-probe.md
+++ b/docs/provenance/T-0013-input-failure-probe.md
@@ -1,0 +1,154 @@
+# T-0013/S03 input-run failure reference observation
+
+- Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
+- State: In Progress; acceptance pending
+- Parent: T-0010; priority P0
+- Slice estimate: 3 SP within parent Current SP 13; Initial SP remains 8
+- Refinement: implementation 1, uncertainty 1, verification 1, environment 1;
+  raw 4 maps to 3 SP. No parent completion or duplicate velocity is implied.
+
+## Authority
+
+Repository owner retains final authority. PM owns scope, records, estimates,
+acceptance and integration. Compatibility Host Implementer owns the exact
+source allowlist. Librarian reviewed the existing public-API/adoption boundary;
+Tester independently reproduces the frozen source. Standing owner authority
+permits implementation and integration after acceptance; ordinary harness or
+retrieval failures are repairable work, not incidents.
+
+## Dependencies
+
+T-0011's pinned executable and S01/S02, integrated through PR #70 (`e8b5726`)
+and PR #71 (`d474b7b`). Reuse S02's unchanged original output source in a
+separately identified local output JAR. Input and output tasks are distinct;
+do not equate counts or hardcode the observed factor eight. T-0012 and T-0021
+remain Backlog; combined WIP is one of two.
+
+Current parent estimate changes from 8 to 13, preserving Initial SP 8. Separate
+input/output task contexts and failure-evidence validation were underrepresented
+in the initial lifecycle estimate. S01/S02/S03 are refined slices of the same
+parent scope; their observations do not complete the remaining Rust comparison,
+retry/resume, cleanup-error or partial-publication contracts.
+
+## Branch and allowlist
+
+Branch: `research/t-0013-input-failure`.
+Compatibility Host Implementer owns exactly three new files:
+
+- `tools/t0013-input-failure/run.sh`
+- `tools/t0013-input-failure/src/T0013FailureInputPlugin.java`
+- `tests/t0013_input_failure_probe_test.sh`
+
+No existing S01/S02 source/runner/test mutation, Rust code, production host,
+dependency or public API changes. PM separately owns STATUS, TODO, ROADMAP,
+COMPATIBILITY, runtime design, provenance/index and dated log reconciliation.
+
+## Artifacts
+
+An original local input fixture and standalone runner/test execute exactly two
+isolated cases, each requesting one empty input task/schema and no Pages or
+values: normal positive control, and an input-run failure before the input's
+own PageOutput.finish call. Output source remains the original S02 fixture.
+Reuse project-owned probe structure only, not upstream implementation/tests.
+Use distinct local input/output Maven-style coordinates, categories and JARs;
+retain both source/JAR hashes and never assume shared static marker state.
+
+The failure fixture emits an explicit injection-before marker, throws a distinct
+original RuntimeException class with a fixed non-secret message inside run,
+records the actual caught class/message and rethrows. Keep marker I/O outside
+the caught operation. The positive path actually calls finish and returns a
+new TaskReport, as S01 does. Record actual input transaction/control, run,
+cleanup and any resume/guess callbacks, including normal/exception returns;
+do not fabricate callbacks after the throw. Preserve S02's actual output
+markers, physical cross-component order and component-local sequences.
+
+Retain all actual callbacks, including any repeated calls or attempts; do not
+sort or deduplicate. Capture exact exception classes/messages (null distinct
+from empty), actual requested/input/output counts, indices, schema/report
+counts, raw process exit, raw logs, extracted traces, total/component counts
+and recomputed digests. Preserve notices and executable/source/JAR identities
+and Java environment in unique external evidence directories. Never derive
+outcomes from fixture IDs or compare against a hardcoded trace digest.
+
+## Acceptance criteria
+
+Positive control must exit 0, reach actual input run/finish normal return and
+output open/finish plus normal input/output control and transaction returns.
+The failure case must demonstrably reach the injection and record/rethrow its
+distinct actual run exception before any input finish call. A startup/loading
+failure is not an observation. Retain actual outer propagation and process
+exit; nonzero exit requires actual transaction-exception evidence. If the
+runtime suppresses the injected failure or exposes unexpected propagation,
+retain it for PM interpretation before accepting or imposing a Rust policy.
+
+Observe output abort/close/commit/cleanup and input cleanup without requiring
+that any of them occur or preselecting their counts/order. Calling the injection
+"pre-publication" would be unjustified: a real output could have side effects
+in transaction or open. This local empty sink establishes no durability boundary.
+
+Validate exactly two complete fixture envelopes, marker grammar and exact
+arity, canonical UTF-8/Base64 and typed numerical fields, raw-log correspondence,
+component-local sequence continuity, source-local entry/return/exception
+consistency, required positive/injected markers and count/digest consistency.
+Track per-invocation structure where needed; repeated genuine invocations are
+not duplicate transport records. Output fields use their own observed context;
+cleanup report counts are not equated to control reports. Any unexpected add,
+instrumentation/setup error or unsupported trace interpretation fails acceptance.
+
+Use mutated evidence copies to reject missing/unknown/truncated/duplicate-
+sequence records, malformed fields, stale counts/hashes/logs, fake injected
+exception class, missing injection, normal-return contradictions and unrelated
+nonzero failures. Rehash semantic mutations and check exact diagnostic labels.
+Include null/empty exception-message format controls without presenting them
+as live failures. Actual corrupt-copy rejection exits 3 and unavailable official
+asset rejection exits 56; never skip or replace the pinned runtime.
+
+## Demo Command
+
+`tests/t0013_input_failure_probe_test.sh`
+
+Run from outside the worktree: both live fixtures, artifact rejection and
+malformed-evidence controls must complete with final exit 0. Also run per-file
+`bash -n` and `git diff --check`. Tester independently reproduces the frozen
+source; no unchanged Rust regression suite is required or claimed.
+
+## Evidence class
+
+Reference Observation / Integration only. No Rust comparator or runtime policy.
+
+## Reference and reuse record
+
+Access/review date 2026-09-06. Librarian reviewed only existing admitted public
+API/provenance and original fixtures; no upstream implementation or new artifact
+was inspected. Official [Embulk 0.11.5 executable](https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar)
+SHA-256 `e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`;
+core `c5ac2d471edac465b45088669d376a7e2a525f8f`, SPI 0.11
+`576e98033a14ba8ac994ed581d3c9d8fcdda2749`. Public locators remain
+InputPlugin, InputPlugin$Control, OutputPlugin, OutputPlugin$Control,
+TransactionalPageOutput and PageOutput classes under `org/embulk/spi`, plus
+TaskSource/TaskReport under `org/embulk/config`, as recorded by S01/S02.
+The original injected exception is not an upstream error class or contract.
+
+Core/SPI source classification is Apache-2.0; exact LICENSE/core
+NOTICE-executable locators remain in T-0011. Embedded META-INF/LICENSE and
+META-INF/NOTICE are retained per run. No upstream code/tests/text copied or
+translated. Project-owned fixture reuse is not new upstream adoption. Original
+source is published; executable/generated JARs remain local-only. No new
+external plugin admitted. Transitive SBOM/notices, redistribution,
+patent/standards/trademark, jurisdiction and FTO remain unreviewed; not legal
+clearance.
+
+## Stop rule
+
+Repair ordinary compile/harness/retrieval issues within scope. Send first live
+failure traces to PM for interpretation before finalizing acceptance gates.
+Stop expansion for other injection sites, explicit retry/resume scenarios,
+Pages, durable effects, new artifacts/upstream implementation inspection,
+production traits, redistribution or material IP/security uncertainty.
+
+## Non-claims
+
+No Rust lifecycle, executor mapping, general callback count/order, durable
+publication, rollback, cleanup guarantee, retry/resume behavior, report
+semantics, transaction atomicity, exactly-once, plugin compatibility,
+performance, security or release claim. Parent #16 remains open after acceptance.

--- a/docs/provenance/T-0013-output-lifecycle-probe.md
+++ b/docs/provenance/T-0013-output-lifecycle-probe.md
@@ -1,7 +1,7 @@
 # T-0013/S02 output lifecycle reference observation
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: Review; primary and independent acceptance passed, integration pending
+- State: Done (bounded S02 only); PR #71 integrated as `d474b7b`
 - Parent: T-0010; priority P0
 - Slice estimate: 3 SP within unchanged parent Current/Initial SP 8
 - Refinement: implementation 1, uncertainty 1, verification 1, environment 1;
@@ -197,7 +197,9 @@ at `5739052`, all exit 0, with identical case/trace hashes and no findings.
 Evidence: `${TMPDIR}/t0013-output-lifecycle.UA5fzd/evidence`; full log
 `/private/tmp/t0013-s02-independent.HGLtLk/full-probe.log`, SHA-256
 `27fc9215c7ae3c9de88f4382341e74832e13bd045c3490fc3c2cec28bf3b0d6c`.
-Integration remains pending; parent #16 remains open.
+Final-head acceptance at `55ed697` passed, evidence
+`${TMPDIR}/t0013-output-lifecycle.TnTiku/evidence`. PR #71 integrated as
+`d474b7b8dc1975d486f564b48ca4559ac37978d0`; parent #16 remains open.
 
 ## Non-claims
 

--- a/tests/t0013_input_failure_probe_test.sh
+++ b/tests/t0013_input_failure_probe_test.sh
@@ -1,0 +1,742 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+runner="$root/tools/t0013-input-failure/run.sh"
+[[ -x "$runner" ]] || exit 2
+
+run_negative() {
+  local control=$1 expected=$2 label=$3 output result_code evidence
+  if output=$(T0013_FAILURE_NEGATIVE="$control" "$runner" 2>&1); then
+    exit 1
+  else
+    result_code=$?
+  fi
+  [[ "$result_code" == "$expected" ]] || exit 1
+  evidence=$(printf '%s\n' "$output" | sed -n 's/^T0013_FAILURE_EVIDENCE_DIR=//p' | tail -1)
+  [[ -n "$evidence" && -d "$evidence" ]] || exit 1
+  grep -Fqx "$label" "$evidence/negative-control.txt" || exit 1
+  printf 'T0013_FAILURE_NEGATIVE=%s|exit=%s|evidence=%s\n' "$control" "$result_code" "$evidence"
+}
+
+run_negative corrupt-copy 3 corrupt-copy-injected
+run_negative unavailable-asset 56 unavailable-asset-request-failed
+
+output=$("$runner")
+printf '%s\n' "$output"
+evidence=$(printf '%s\n' "$output" | sed -n 's/^T0013_FAILURE_EVIDENCE_DIR=//p' | tail -1)
+[[ -n "$evidence" && -d "$evidence" ]] || exit 1
+for file in executable.sha256 executable-url.txt LICENSE-executable NOTICE-executable java-version.txt \
+  input-source.sha256 output-source.sha256 input-jar.sha256 output-jar.sha256 \
+  input-coordinate.txt output-coordinate.txt cases.raw traces.raw normal.raw.log failure.raw.log; do
+  [[ -s "$evidence/$file" ]] || exit 1
+done
+
+validate() {
+  python3 - "$1" <<'PY'
+import base64
+import binascii
+import hashlib
+import pathlib
+import sys
+import uuid
+
+root = pathlib.Path(sys.argv[1])
+injected_class = "T0013FailureInputPlugin$InjectedRunFailure"
+injected_message = "t0013-s03-injected-run-failure"
+
+class InvalidEvidence(Exception):
+    pass
+
+def require(label, condition):
+    if not condition:
+        raise InvalidEvidence(label)
+
+def decimal(label, value):
+    require(label, value.isascii() and value.isdigit())
+    return int(value)
+
+def decode_field(label, encoded, *, numeric=False, nonempty=False):
+    require(label, encoded != "-")
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+        value = raw.decode("utf-8")
+    except (binascii.Error, UnicodeError):
+        raise InvalidEvidence(label)
+    require(label, base64.b64encode(raw).decode("ascii") == encoded)
+    if numeric:
+        decimal(label, value)
+    if nonempty:
+        require(label, value != "")
+    return value
+
+input_arity = {
+    "transaction-entry": 1,
+    "control-run-before": 1,
+    "control-run-normal-return": 1,
+    "transaction-normal-return": 1,
+    "transaction-runtime-exception": 2,
+    "run-entry": 1,
+    "injection-before": 1,
+    "finish-before": 1,
+    "finish-normal-return": 1,
+    "run-normal-return": 1,
+    "run-runtime-exception": 2,
+    "cleanup-entry": 2,
+    "cleanup-normal-return": 1,
+    "resume-entry": 1,
+    "resume-normal-return": 1,
+    "guess-entry": 0,
+    "guess-normal-return": 0,
+}
+input_numeric = {
+    "transaction-entry": {0}, "control-run-before": {0}, "control-run-normal-return": {0},
+    "transaction-normal-return": {0}, "run-entry": {0}, "injection-before": {0},
+    "finish-before": {0}, "finish-normal-return": {0}, "run-normal-return": {0},
+    "cleanup-entry": {0, 1}, "cleanup-normal-return": {0}, "resume-entry": {0},
+    "resume-normal-return": {0},
+}
+output_arity = {
+    "transaction-entry": 2,
+    "control-run-before": 2,
+    "control-run-normal-return": 3,
+    "transaction-normal-return": 3,
+    "transaction-runtime-exception": 2,
+    "resume-entry": 2,
+    "resume-control-run-before": 2,
+    "resume-control-run-normal-return": 3,
+    "resume-normal-return": 3,
+    "resume-runtime-exception": 2,
+    "cleanup-entry": 3,
+    "cleanup-normal-return": 3,
+    "open-entry": 2,
+    "open-normal-return": 2,
+    "add-entry": 2,
+    "add-normal-return": 2,
+    "finish-entry": 2,
+    "finish-normal-return": 2,
+    "commit-entry": 2,
+    "commit-normal-return": 2,
+    "abort-entry": 2,
+    "abort-normal-return": 2,
+    "close-entry": 2,
+    "close-normal-return": 2,
+}
+output_numeric = {event: set(range(arity)) for event, arity in output_arity.items()
+                  if not event.endswith("runtime-exception")}
+
+try:
+    require("cases-readable", root.joinpath("cases.raw").is_file())
+    require("traces-readable", root.joinpath("traces.raw").is_file())
+    cases = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+    traces = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+    require("case-count", len(cases) == 2)
+
+    parsed_cases = {}
+    for row in cases:
+        parts = row.split("|")
+        require("case-arity", len(parts) == 5)
+        tag, fixture, requested_text, exit_text, summary = parts
+        require("case-tag", tag == "CASE")
+        require("case-fixture", fixture in {"normal", "failure"})
+        require("case-duplicate", fixture not in parsed_cases)
+        summary_parts = summary.split(":")
+        require("case-summary-arity", len(summary_parts) == 4)
+        total_text, input_text, output_text, digest = summary_parts
+        requested = decimal("case-requested-count", requested_text)
+        process_exit = decimal("case-process-exit", exit_text)
+        total = decimal("case-total-count", total_text)
+        input_count = decimal("case-input-count", input_text)
+        output_count = decimal("case-output-count", output_text)
+        require("case-digest-format", len(digest) == 64 and all(c in "0123456789abcdef" for c in digest))
+        parsed_cases[fixture] = (requested, process_exit, total, input_count, output_count, digest)
+    require("case-fixtures", set(parsed_cases) == {"normal", "failure"})
+    require("requested-count", all(case[0] == 1 for case in parsed_cases.values()))
+
+    grouped_rows = {fixture: [] for fixture in ("normal", "failure")}
+    decoded = {fixture: {"input": [], "output": []} for fixture in ("normal", "failure")}
+    sequence_state = {}
+    for row in traces:
+        parts = row.split("|")
+        require("trace-minimum-arity", len(parts) >= 5)
+        tag, fixture, capture_id, sequence_text, event = parts[:5]
+        require("trace-tag", tag in {"FAILTRACE", "FAILOUTTRACE"})
+        require("trace-fixture", fixture in grouped_rows)
+        try:
+            parsed_capture = uuid.UUID(capture_id)
+        except ValueError:
+            raise InvalidEvidence("capture-id")
+        require("capture-id", str(parsed_capture) == capture_id and parsed_capture.version == 4)
+        sequence = decimal("trace-sequence", sequence_text)
+        component = "input" if tag == "FAILTRACE" else "output"
+        sequence_key = (fixture, component, capture_id)
+        expected = sequence_state.get(sequence_key, 1)
+        require(f"{component}-sequence-contiguous", sequence == expected)
+        sequence_state[sequence_key] = expected + 1
+
+        grammar = input_arity if component == "input" else output_arity
+        numeric_fields = input_numeric if component == "input" else output_numeric
+        require(f"{component}-event-known", event in grammar)
+        require(f"{component}-event-arity", len(parts) == 5 + grammar[event])
+        values = []
+        for index, encoded in enumerate(parts[5:]):
+            if encoded == "-":
+                require(f"{component}-null-position", event.endswith("runtime-exception") and index == 1)
+                values.append(None)
+            else:
+                label = f"{component}-exception-class" if event.endswith("runtime-exception") and index == 0 else f"{component}-canonical-field"
+                values.append(decode_field(label, encoded, numeric=index in numeric_fields.get(event, set()),
+                                           nonempty=event.endswith("runtime-exception") and index == 0))
+        grouped_rows[fixture].append(row)
+        decoded[fixture][component].append((event, values, sequence, capture_id))
+
+    for fixture in ("normal", "failure"):
+        requested, process_exit, total, input_count, output_count, digest = parsed_cases[fixture]
+        rows = grouped_rows[fixture]
+        require("case-total-count-match", len(rows) == total)
+        require("case-component-count-match",
+                sum(row.startswith("FAILTRACE|") for row in rows) == input_count
+                and sum(row.startswith("FAILOUTTRACE|") for row in rows) == output_count
+                and input_count + output_count == total)
+        material = ("\n".join(rows) + ("\n" if rows else "")).encode("utf-8")
+        require("case-digest-match", hashlib.sha256(material).hexdigest() == digest)
+        raw_log = root / f"{fixture}.raw.log"
+        require("raw-log-required", raw_log.is_file())
+        extracted = [line for line in raw_log.read_text(encoding="utf-8").splitlines()
+                     if line.startswith("FAILTRACE|") or line.startswith("FAILOUTTRACE|")]
+        require("raw-log-trace-match", extracted == rows)
+
+        input_events = decoded[fixture]["input"]
+        output_events = decoded[fixture]["output"]
+        input_names = [event for event, _, _, _ in input_events]
+        output_names = [event for event, _, _, _ in output_events]
+        require("input-transaction-boundary",
+                "transaction-entry" in input_names and "control-run-before" in input_names)
+        require("output-transaction-boundary",
+                "transaction-entry" in output_names and "control-run-before" in output_names)
+
+        transaction_markers = {
+            "transaction-entry", "control-run-before", "control-run-normal-return",
+            "transaction-normal-return", "transaction-runtime-exception",
+        }
+        for component, events in (("input", input_events), ("output", output_events)):
+            captures = {}
+            for event, values, sequence, capture in events:
+                captures.setdefault(capture, []).append((event, values, sequence))
+            for capture_events in captures.values():
+                capture_names = [event for event, _, _ in capture_events]
+                if not any(event in transaction_markers for event in capture_names):
+                    continue
+                require(f"{component}-capture-transaction-boundary",
+                        "transaction-entry" in capture_names and "control-run-before" in capture_names)
+                transaction_position = capture_names.index("transaction-entry")
+                control_position = capture_names.index("control-run-before")
+                require(f"{component}-local-transaction-order", transaction_position < control_position)
+                has_exception = "transaction-runtime-exception" in capture_names
+                has_normal = ("control-run-normal-return" in capture_names
+                              or "transaction-normal-return" in capture_names)
+                require(f"{component}-transaction-contradiction", not (has_exception and has_normal))
+                require(f"{component}-capture-transaction-terminal", has_exception or has_normal)
+                if has_exception:
+                    require(f"{component}-local-exception-order",
+                            control_position < capture_names.index("transaction-runtime-exception"))
+                if has_normal:
+                    require(f"{component}-capture-normal-return",
+                            "control-run-normal-return" in capture_names
+                            and "transaction-normal-return" in capture_names)
+                    require(f"{component}-local-normal-order",
+                            control_position < capture_names.index("control-run-normal-return")
+                            < capture_names.index("transaction-normal-return"))
+
+        input_capture_groups = {}
+        for event, values, sequence, capture in input_events:
+            input_capture_groups.setdefault(capture, []).append((event, values, sequence))
+        run_markers = {"run-entry", "injection-before", "finish-before", "finish-normal-return",
+                       "run-normal-return", "run-runtime-exception"}
+        for capture_events in input_capture_groups.values():
+            if not any(event in run_markers for event, _, _ in capture_events):
+                continue
+            capture_invocations = []
+            current = None
+            for event, values, sequence in capture_events:
+                if event == "run-entry":
+                    if current is not None:
+                        prior_names = [name for name, _, _ in current]
+                        require("input-capture-run-terminal", "run-normal-return" in prior_names
+                                or "run-runtime-exception" in prior_names)
+                    current = [(event, values, sequence)]
+                    capture_invocations.append(current)
+                elif event in run_markers:
+                    require("input-capture-run-entry", current is not None)
+                    current.append((event, values, sequence))
+            require("input-capture-run-entry", bool(capture_invocations))
+            for invocation in capture_invocations:
+                invocation_names = [event for event, _, _ in invocation]
+                has_normal = "run-normal-return" in invocation_names
+                has_exception = "run-runtime-exception" in invocation_names
+                require("input-run-contradiction", not (has_normal and has_exception))
+                require("input-capture-run-terminal", has_normal or has_exception)
+
+        input_transaction_capture = next(capture for event, _, _, capture in input_events if event == "transaction-entry")
+        input_main = [(event, values, sequence) for event, values, sequence, capture in input_events
+                      if capture == input_transaction_capture]
+        input_main_names = [event for event, _, _ in input_main]
+        for event, values, _, _ in input_events:
+            if event in {"transaction-entry", "control-run-before", "control-run-normal-return",
+                         "transaction-normal-return", "cleanup-entry", "cleanup-normal-return",
+                         "resume-entry", "resume-normal-return"}:
+                require("input-requested-count-consistency", int(values[0]) == requested)
+
+        output_transaction_capture = next(capture for event, _, _, capture in output_events if event == "transaction-entry")
+        output_main = [(event, values, sequence) for event, values, sequence, capture in output_events
+                       if capture == output_transaction_capture]
+        output_main_names = [event for event, _, _ in output_main]
+        output_transaction = next(values for event, values, _ in output_main if event == "transaction-entry")
+        output_task_count = int(output_transaction[0])
+        output_schema_count = int(output_transaction[1])
+        require("output-empty-schema", output_schema_count == 0)
+        count_schema_events = {
+            "transaction-entry", "control-run-before", "control-run-normal-return",
+            "transaction-normal-return", "resume-entry", "resume-control-run-before",
+            "resume-control-run-normal-return", "resume-normal-return", "cleanup-entry",
+            "cleanup-normal-return",
+        }
+        indexed_events = {
+            "open-entry", "open-normal-return", "add-entry", "add-normal-return",
+            "finish-entry", "finish-normal-return", "commit-entry", "commit-normal-return",
+            "abort-entry", "abort-normal-return", "close-entry", "close-normal-return",
+        }
+        for event, values, _, _ in output_events:
+            if event in count_schema_events:
+                require("output-task-count-consistency", int(values[0]) == output_task_count)
+                require("output-schema-count-consistency", int(values[1]) == output_schema_count)
+            if event in indexed_events:
+                require("output-schema-count-consistency", int(values[1]) == output_schema_count)
+                require("output-index-range", output_task_count > 0 and int(values[0]) < output_task_count)
+
+        opened_at = {}
+        for event, values, sequence, capture in output_events:
+            key = (capture, values[0]) if values and event in indexed_events else None
+            if event == "open-normal-return":
+                opened_at[key] = sequence
+            if event in indexed_events - {"open-entry", "open-normal-return"}:
+                require("output-prior-open", key in opened_at and opened_at[key] < sequence)
+
+        report_values = [int(values[2]) for event, values, _ in output_main
+                         if event in {"control-run-normal-return", "transaction-normal-return"}]
+        if report_values:
+            require("output-report-count-consistency", all(value == report_values[0] for value in report_values))
+        require("unexpected-add", "add-entry" not in output_names and "add-normal-return" not in output_names)
+
+        for component, events in (("input", input_events), ("output", output_events)):
+            callbacks = ("cleanup",) if component == "input" else ("open", "finish", "commit", "abort", "close", "cleanup")
+            for callback in callbacks:
+                balances = {}
+                for event, values, _, capture in events:
+                    if event not in {f"{callback}-entry", f"{callback}-normal-return"}:
+                        continue
+                    key_values = (values[0],) if component == "input" and callback == "cleanup" else tuple(values)
+                    key = (capture, key_values)
+                    balances.setdefault(key, 0)
+                    if event.endswith("-entry"):
+                        balances[key] += 1
+                    else:
+                        balances[key] -= 1
+                        require(f"{component}-callback-pair", balances[key] >= 0)
+                require(f"{component}-callback-pair", all(balance == 0 for balance in balances.values()))
+
+        input_transaction_exceptions = [values for event, values, _ in input_main
+                                        if event == "transaction-runtime-exception"]
+        input_run_exceptions = [values for event, values, _ in input_main if event == "run-runtime-exception"]
+        output_transaction_exceptions = [values for event, values, _ in output_main
+                                         if event == "transaction-runtime-exception"]
+        run_events = {"run-entry", "injection-before", "finish-before", "finish-normal-return",
+                      "run-normal-return", "run-runtime-exception"}
+        invocations = []
+        current_invocation = None
+        for event, values, sequence in input_main:
+            if event == "run-entry":
+                current_invocation = [(event, values, sequence)]
+                invocations.append(current_invocation)
+            elif event in run_events:
+                require("input-run-entry-required", current_invocation is not None)
+                current_invocation.append((event, values, sequence))
+        for invocation in invocations:
+            names = [event for event, _, _ in invocation]
+            has_exception = "run-runtime-exception" in names
+            require("input-run-contradiction", not (has_exception and
+                    ("finish-normal-return" in names or "run-normal-return" in names)))
+        resume_captures = {capture for event, _, _, capture in output_events if event.startswith("resume")}
+        for capture in resume_captures:
+            resume_names = [event for event, _, _, event_capture in output_events if event_capture == capture]
+            require("output-resume-boundary", "resume-entry" in resume_names and
+                    "resume-control-run-before" in resume_names)
+            require("output-resume-order", resume_names.index("resume-entry") <
+                    resume_names.index("resume-control-run-before"))
+            if "resume-runtime-exception" in resume_names:
+                require("output-resume-contradiction", "resume-control-run-normal-return" not in resume_names and
+                        "resume-normal-return" not in resume_names)
+                require("output-resume-order", resume_names.index("resume-control-run-before") <
+                        resume_names.index("resume-runtime-exception"))
+            else:
+                require("output-resume-normal-return", "resume-control-run-normal-return" in resume_names and
+                        "resume-normal-return" in resume_names)
+
+        if fixture == "normal":
+            require("normal-process-success", process_exit == 0)
+            require("normal-no-exception", not any(event.endswith("runtime-exception")
+                    for component in (input_events, output_events) for event, _, _, _ in component))
+            required_input = ["transaction-entry", "control-run-before", "run-entry", "finish-before",
+                              "finish-normal-return", "run-normal-return", "control-run-normal-return",
+                              "transaction-normal-return"]
+            require("normal-input-markers", all(event in input_main_names for event in required_input))
+            require("normal-input-invocations", bool(invocations) and all(
+                    "finish-before" in [event for event, _, _ in invocation]
+                    and "finish-normal-return" in [event for event, _, _ in invocation]
+                    and "run-normal-return" in [event for event, _, _ in invocation]
+                    and "run-runtime-exception" not in [event for event, _, _ in invocation]
+                    for invocation in invocations))
+            require("normal-input-order", [input_main_names.index(event) for event in required_input]
+                    == sorted(input_main_names.index(event) for event in required_input))
+            required_output = ["transaction-entry", "control-run-before", "open-entry", "open-normal-return",
+                               "finish-entry", "finish-normal-return", "control-run-normal-return",
+                               "transaction-normal-return"]
+            require("normal-output-markers", all(event in output_main_names for event in required_output))
+            require("normal-output-transaction-order",
+                    output_main_names.index("control-run-before") < output_main_names.index("control-run-normal-return")
+                    < output_main_names.index("transaction-normal-return"))
+        else:
+            require("failure-process-nonzero", process_exit != 0)
+            require("failure-unrelated-nonzero", bool(invocations))
+            require("failure-run-exception", bool(input_run_exceptions))
+            require("failure-injection-marker", "injection-before" in input_main_names)
+            require("failure-injected-class", all(values[0] == injected_class for values in input_run_exceptions))
+            require("failure-injected-message", all(values[1] == injected_message for values in input_run_exceptions))
+            require("failure-input-transaction-exception", bool(input_transaction_exceptions))
+            require("failure-output-transaction-exception", bool(output_transaction_exceptions))
+            require("failure-propagation", all(values == [injected_class, injected_message]
+                    for values in input_transaction_exceptions + output_transaction_exceptions))
+            require("failure-input-finish-forbidden", not any(event in input_main_names for event in
+                    ("finish-before", "finish-normal-return", "run-normal-return")))
+            require("failure-input-invocations", all(
+                    "injection-before" in [event for event, _, _ in invocation]
+                    and "run-runtime-exception" in [event for event, _, _ in invocation]
+                    and not any(event in [event for event, _, _ in invocation]
+                                for event in ("finish-before", "finish-normal-return", "run-normal-return"))
+                    for invocation in invocations))
+            required_failure = ["transaction-entry", "control-run-before", "run-entry", "injection-before",
+                                "run-runtime-exception", "transaction-runtime-exception"]
+            require("failure-input-order", [input_main_names.index(event) for event in required_failure]
+                    == sorted(input_main_names.index(event) for event in required_failure))
+            require("failure-output-order", output_main_names.index("control-run-before") <
+                    output_main_names.index("transaction-runtime-exception"))
+except (InvalidEvidence, OSError, UnicodeError) as failure:
+    label = failure.args[0] if failure.args else "unclassified"
+    print(f"VALIDATION_ERROR|{label}", file=sys.stderr)
+    sys.exit(4)
+PY
+}
+
+validate "$evidence"
+
+mutated_copy() {
+  local mutation=$1 copy
+  copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-failure-validator.XXXXXX")
+  cp "$evidence/cases.raw" "$evidence/traces.raw" "$evidence/normal.raw.log" "$evidence/failure.raw.log" "$copy/"
+  python3 - "$mutation" "$copy" <<'PY'
+import base64
+import hashlib
+import pathlib
+import sys
+
+action, directory = sys.argv[1:]
+root = pathlib.Path(directory)
+cases = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+traces = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+
+def fixture_rows(fixture):
+    return [row for row in traces if row.split("|")[1] == fixture]
+
+def synchronize():
+    for fixture in ("normal", "failure"):
+        rows = fixture_rows(fixture)
+        path = root / f"{fixture}.raw.log"
+        other = [line for line in path.read_text(encoding="utf-8").splitlines()
+                 if not line.startswith("FAILTRACE|") and not line.startswith("FAILOUTTRACE|")]
+        path.write_text("\n".join(rows + other) + "\n", encoding="utf-8")
+    for index, row in enumerate(cases):
+        parts = row.split("|")
+        if len(parts) != 5 or parts[0] != "CASE" or parts[1] not in {"normal", "failure"}:
+            continue
+        rows = fixture_rows(parts[1])
+        input_count = sum(item.startswith("FAILTRACE|") for item in rows)
+        output_count = sum(item.startswith("FAILOUTTRACE|") for item in rows)
+        material = ("\n".join(rows) + ("\n" if rows else "")).encode("utf-8")
+        parts[4] = f"{len(rows)}:{input_count}:{output_count}:{hashlib.sha256(material).hexdigest()}"
+        cases[index] = "|".join(parts)
+
+def renumber_capture(fixture, tag, capture_id):
+    sequence = 0
+    for index, row in enumerate(traces):
+        parts = row.split("|")
+        if len(parts) < 5 or parts[0] != tag or parts[1] != fixture or parts[2] != capture_id:
+            continue
+        sequence += 1
+        parts[3] = str(sequence)
+        traces[index] = "|".join(parts)
+
+if action == "missing-case":
+    cases.pop()
+elif action == "duplicate-case":
+    cases.append(cases[0])
+elif action == "truncated-trace":
+    traces[0] = "FAILTRACE"
+elif action == "unknown-event":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILTRACE|normal|") and "|run-entry|" in row)
+    parts = traces[index].split("|")
+    parts[4] = "invented"
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "bad-arity":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILTRACE|normal|") and "|run-entry|" in row)
+    traces[index] = "|".join(traces[index].split("|")[:-1])
+    synchronize()
+elif action == "bad-b64":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILTRACE|normal|") and "|run-entry|" in row)
+    parts = traces[index].split("|")
+    parts[5] = "!"
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "malformed-count":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILOUTTRACE|normal|") and "|transaction-entry|" in row)
+    parts = traces[index].split("|")
+    parts[5] = base64.b64encode(b"not-a-count").decode("ascii")
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "mismatched-count":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILOUTTRACE|normal|") and "|control-run-before|" in row)
+    parts = traces[index].split("|")
+    parts[5] = base64.b64encode(str(int(base64.b64decode(parts[5])) + 1).encode()).decode("ascii")
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "duplicate-sequence-one-same-id":
+    indexes = [i for i, row in enumerate(traces) if row.startswith("FAILTRACE|normal|")]
+    parts = traces[indexes[1]].split("|")
+    parts[3] = traces[indexes[0]].split("|")[3]
+    traces[indexes[1]] = "|".join(parts)
+    synchronize()
+elif action == "bad-capture-id":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILTRACE|normal|"))
+    parts = traces[index].split("|")
+    parts[2] = "not-a-uuid"
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "fake-injected-class":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILTRACE|failure|") and "|run-runtime-exception|" in row)
+    parts = traces[index].split("|")
+    parts[5] = base64.b64encode(b"java.lang.RuntimeException").decode("ascii")
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "fake-injected-message":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILTRACE|failure|") and "|run-runtime-exception|" in row)
+    parts = traces[index].split("|")
+    parts[6] = base64.b64encode(b"different").decode("ascii")
+    traces[index] = "|".join(parts)
+    synchronize()
+elif action == "missing-injection":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILTRACE|failure|") and "|injection-before|" in row)
+    capture_id = traces[index].split("|")[2]
+    traces.pop(index)
+    renumber_capture("failure", "FAILTRACE", capture_id)
+    synchronize()
+elif action == "normal-return-contradiction":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILTRACE|failure|") and "|run-runtime-exception|" in row)
+    capture_id = traces[index].split("|")[2]
+    task_index = next(row.split("|")[5] for row in traces if row.startswith(f"FAILTRACE|failure|{capture_id}|") and "|run-entry|" in row)
+    traces.insert(index + 1, f"FAILTRACE|failure|{capture_id}|0|run-normal-return|{task_index}")
+    renumber_capture("failure", "FAILTRACE", capture_id)
+    synchronize()
+elif action == "failure-finish":
+    index = next(i for i, row in enumerate(traces) if row.startswith("FAILTRACE|failure|") and "|injection-before|" in row)
+    capture_id = traces[index].split("|")[2]
+    task_index = traces[index].split("|")[5]
+    traces.insert(index + 1, f"FAILTRACE|failure|{capture_id}|0|finish-before|{task_index}")
+    renumber_capture("failure", "FAILTRACE", capture_id)
+    synchronize()
+elif action == "unrelated-nonzero":
+    generic = base64.b64encode(b"java.lang.RuntimeException").decode("ascii")
+    message = base64.b64encode(b"unrelated").decode("ascii")
+    synthetic = [
+        "FAILTRACE|failure|11111111-1111-4111-8111-111111111111|1|transaction-entry|MQ==",
+        "FAILTRACE|failure|11111111-1111-4111-8111-111111111111|2|control-run-before|MQ==",
+        "FAILOUTTRACE|failure|22222222-2222-4222-8222-222222222222|1|transaction-entry|MA==|MA==",
+        "FAILOUTTRACE|failure|22222222-2222-4222-8222-222222222222|2|control-run-before|MA==|MA==",
+        f"FAILOUTTRACE|failure|22222222-2222-4222-8222-222222222222|3|transaction-runtime-exception|{generic}|{message}",
+        f"FAILTRACE|failure|11111111-1111-4111-8111-111111111111|3|transaction-runtime-exception|{generic}|{message}",
+    ]
+    traces = fixture_rows("normal") + synthetic
+    synchronize()
+elif action in {"null-message", "empty-message"}:
+    message = "-" if action == "null-message" else ""
+    generic = base64.b64encode(b"java.lang.RuntimeException").decode("ascii")
+    failure = fixture_rows("failure")
+    transaction = next(row.split("|") for row in failure
+                       if row.startswith("FAILOUTTRACE|") and "|transaction-entry|" in row)
+    output_count, schema_count = transaction[5], transaction[6]
+    failure += [
+        f"FAILOUTTRACE|failure|33333333-3333-4333-8333-333333333333|1|resume-entry|{output_count}|{schema_count}",
+        f"FAILOUTTRACE|failure|33333333-3333-4333-8333-333333333333|2|resume-control-run-before|{output_count}|{schema_count}",
+        f"FAILOUTTRACE|failure|33333333-3333-4333-8333-333333333333|3|resume-runtime-exception|{generic}|{message}",
+    ]
+    traces = fixture_rows("normal") + failure
+    synchronize()
+elif action == "new-capture-transaction-contradiction":
+    normal = fixture_rows("normal")
+    transaction = next(row.split("|") for row in normal
+                       if row.startswith("FAILOUTTRACE|") and "|transaction-entry|" in row)
+    control_return = next(row.split("|") for row in normal
+                          if row.startswith("FAILOUTTRACE|") and "|control-run-normal-return|" in row)
+    output_count, schema_count, report_count = transaction[5], transaction[6], control_return[7]
+    generic = base64.b64encode(b"java.lang.RuntimeException").decode("ascii")
+    capture = "66666666-6666-4666-8666-666666666666"
+    normal += [
+        f"FAILOUTTRACE|normal|{capture}|1|transaction-entry|{output_count}|{schema_count}",
+        f"FAILOUTTRACE|normal|{capture}|2|control-run-before|{output_count}|{schema_count}",
+        f"FAILOUTTRACE|normal|{capture}|3|control-run-normal-return|{output_count}|{schema_count}|{report_count}",
+        f"FAILOUTTRACE|normal|{capture}|4|transaction-normal-return|{output_count}|{schema_count}|{report_count}",
+        f"FAILOUTTRACE|normal|{capture}|5|transaction-runtime-exception|{generic}|-",
+    ]
+    traces = normal + fixture_rows("failure")
+    synchronize()
+elif action == "incomplete-transaction-capture":
+    normal = fixture_rows("normal")
+    transaction = next(row.split("|") for row in normal
+                       if row.startswith("FAILOUTTRACE|") and "|transaction-entry|" in row)
+    output_count, schema_count = transaction[5], transaction[6]
+    capture = "77777777-7777-4777-8777-777777777777"
+    normal += [
+        f"FAILOUTTRACE|normal|{capture}|1|transaction-entry|{output_count}|{schema_count}",
+        f"FAILOUTTRACE|normal|{capture}|2|control-run-before|{output_count}|{schema_count}",
+    ]
+    traces = normal + fixture_rows("failure")
+    synchronize()
+elif action == "fresh-cleanup-capture":
+    replacements = {
+        "FAILTRACE": "44444444-4444-4444-8444-444444444444",
+        "FAILOUTTRACE": "55555555-5555-4555-8555-555555555555",
+    }
+    next_sequence = {tag: 0 for tag in replacements}
+    for index, row in enumerate(traces):
+        parts = row.split("|")
+        if parts[1] != "normal" or parts[0] not in replacements or not parts[4].startswith("cleanup-"):
+            continue
+        next_sequence[parts[0]] += 1
+        parts[2] = replacements[parts[0]]
+        parts[3] = str(next_sequence[parts[0]])
+        traces[index] = "|".join(parts)
+    synchronize()
+elif action == "unexpected-add":
+    output_main = [row for row in fixture_rows("normal") if row.startswith("FAILOUTTRACE|")]
+    capture_id = next(row.split("|")[2] for row in output_main if "|transaction-entry|" in row)
+    next_sequence = max(int(row.split("|")[3]) for row in output_main if row.split("|")[2] == capture_id) + 1
+    traces += [f"FAILOUTTRACE|normal|{capture_id}|{next_sequence}|add-entry|MA==|MA==",
+               f"FAILOUTTRACE|normal|{capture_id}|{next_sequence + 1}|add-normal-return|MA==|MA=="]
+    synchronize()
+elif action == "missing-prior-open":
+    open_row = next(row for row in traces if row.startswith("FAILOUTTRACE|normal|") and "|open-entry|" in row)
+    capture_id = open_row.split("|")[2]
+    open_index = open_row.split("|")[5]
+    traces = [row for row in traces if not (row.startswith("FAILOUTTRACE|normal|") and
+              ("|open-entry|" in row or "|open-normal-return|" in row) and row.split("|")[5] == open_index)]
+    renumber_capture("normal", "FAILOUTTRACE", capture_id)
+    synchronize()
+elif action == "case-total-corrupt":
+    index = next(i for i, row in enumerate(cases) if row.startswith("CASE|normal|"))
+    parts = cases[index].split("|")
+    summary = parts[4].split(":")
+    summary[0] = str(int(summary[0]) + 1)
+    parts[4] = ":".join(summary)
+    cases[index] = "|".join(parts)
+elif action == "case-component-corrupt":
+    index = next(i for i, row in enumerate(cases) if row.startswith("CASE|normal|"))
+    parts = cases[index].split("|")
+    summary = parts[4].split(":")
+    summary[1] = str(int(summary[1]) + 1)
+    parts[4] = ":".join(summary)
+    cases[index] = "|".join(parts)
+elif action == "digest-corrupt":
+    index = next(i for i, row in enumerate(cases) if row.startswith("CASE|normal|"))
+    parts = cases[index].split("|")
+    summary = parts[4].split(":")
+    summary[3] = "0" * 64
+    parts[4] = ":".join(summary)
+    cases[index] = "|".join(parts)
+elif action == "missing-raw-log":
+    root.joinpath("failure.raw.log").unlink()
+elif action == "raw-log-mismatch":
+    path = root / "failure.raw.log"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines = [line for line in lines if not (line.startswith("FAILOUTTRACE|") and "|abort-normal-return|" in line)]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+else:
+    raise ValueError(action)
+
+root.joinpath("cases.raw").write_text("\n".join(cases) + "\n", encoding="utf-8")
+root.joinpath("traces.raw").write_text("\n".join(traces) + "\n", encoding="utf-8")
+PY
+  printf '%s\n' "$copy"
+}
+
+validator_fails() {
+  local mutation=$1 expected=$2 copy output result_code
+  copy=$(mutated_copy "$mutation")
+  printf 'T0013_FAILURE_MUTATION=%s|evidence=%s\n' "$mutation" "$copy"
+  if output=$(validate "$copy" 2>&1); then
+    exit 1
+  else
+    result_code=$?
+  fi
+  [[ "$result_code" == 4 ]] || exit 1
+  [[ "$output" == "VALIDATION_ERROR|$expected" ]] || {
+    printf 'unexpected validator result for %s: %s\n' "$mutation" "$output" >&2
+    exit 1
+  }
+}
+
+validator_accepts() {
+  local mutation=$1 copy
+  copy=$(mutated_copy "$mutation")
+  printf 'T0013_FAILURE_MUTATION=%s|evidence=%s\n' "$mutation" "$copy"
+  validate "$copy"
+}
+
+validator_fails missing-case case-count
+validator_fails duplicate-case case-count
+validator_fails truncated-trace trace-minimum-arity
+validator_fails unknown-event input-event-known
+validator_fails bad-arity input-event-arity
+validator_fails bad-b64 input-canonical-field
+validator_fails malformed-count output-canonical-field
+validator_fails mismatched-count output-task-count-consistency
+validator_fails duplicate-sequence-one-same-id input-sequence-contiguous
+validator_fails bad-capture-id capture-id
+validator_fails fake-injected-class failure-injected-class
+validator_fails fake-injected-message failure-injected-message
+validator_fails missing-injection failure-injection-marker
+validator_fails normal-return-contradiction input-run-contradiction
+validator_fails failure-finish failure-input-finish-forbidden
+validator_fails unrelated-nonzero failure-unrelated-nonzero
+validator_fails unexpected-add unexpected-add
+validator_fails missing-prior-open output-prior-open
+validator_fails new-capture-transaction-contradiction output-transaction-contradiction
+validator_fails incomplete-transaction-capture output-capture-transaction-terminal
+validator_fails case-total-corrupt case-total-count-match
+validator_fails case-component-corrupt case-component-count-match
+validator_fails digest-corrupt case-digest-match
+validator_fails missing-raw-log raw-log-required
+validator_fails raw-log-mismatch raw-log-trace-match
+validator_accepts null-message
+validator_accepts empty-message
+validator_accepts fresh-cleanup-capture
+
+printf 'T0013_FAILURE_FULL_PROBE=passed|evidence=%s\n' "$evidence"

--- a/tools/t0013-input-failure/run.sh
+++ b/tools/t0013-input-failure/run.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+input_src="$root/tools/t0013-input-failure/src/T0013FailureInputPlugin.java"
+output_src="$root/tools/t0013-input-failure/src/T0013FailureOutputPlugin.java"
+url=https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
+expected_sha=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
+tmp=$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-input-failure.XXXXXX")
+evidence="$tmp/evidence"
+input_repo="$tmp/home/lib/m2/repository/org/embulk/t0013/s03/embulk-input-t0013s03input/0.0.1"
+output_repo="$tmp/home/lib/m2/repository/org/embulk/t0013/s03/embulk-output-t0013s03output/0.0.1"
+mkdir -p "$evidence" "$tmp/input-classes" "$tmp/output-classes" "$input_repo" "$output_repo"
+trap 'printf "T0013_FAILURE_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
+
+jarfile="$tmp/embulk.jar"
+if [[ ${T0013_FAILURE_NEGATIVE:-} == unavailable-asset ]]; then
+  url=https://github.com/embulk/embulk/releases/download/v0.11.5/unavailable.jar
+fi
+printf '%s\n' "$url" > "$evidence/executable-url.txt"
+if ! curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error -o "$jarfile" "$url"; then
+  if [[ ${T0013_FAILURE_NEGATIVE:-} == unavailable-asset ]]; then
+    printf '%s\n' unavailable-asset-request-failed > "$evidence/negative-control.txt"
+  fi
+  exit 56
+fi
+if [[ ${T0013_FAILURE_NEGATIVE:-} == corrupt-copy ]]; then
+  printf corrupt >> "$jarfile"
+  printf '%s\n' corrupt-copy-injected > "$evidence/negative-control.txt"
+fi
+actual_sha=$(shasum -a 256 "$jarfile" | awk '{print $1}')
+printf '%s\n' "$actual_sha" > "$evidence/executable.sha256"
+[[ "$actual_sha" == "$expected_sha" ]] || exit 3
+
+shasum -a 256 "$input_src" | awk '{print $1}' > "$evidence/input-source.sha256"
+shasum -a 256 "$output_src" | awk '{print $1}' > "$evidence/output-source.sha256"
+unzip -p "$jarfile" META-INF/LICENSE > "$evidence/LICENSE-executable" || [[ -s "$evidence/LICENSE-executable" ]]
+unzip -p "$jarfile" META-INF/NOTICE > "$evidence/NOTICE-executable" || [[ -s "$evidence/NOTICE-executable" ]]
+java -XshowSettings:properties -version > "$evidence/java-version.txt" 2>&1
+
+javac -cp "$jarfile" -d "$tmp/input-classes" "$input_src"
+javac -cp "$jarfile" -d "$tmp/output-classes" "$output_src"
+printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0013FailureInputPlugin' \
+  'Embulk-Plugin-Category: input' 'Embulk-Plugin-Type: t0013s03input' \
+  'Embulk-Plugin-Spi-Version: 0' > "$tmp/INPUT.MF"
+jar cfm "$input_repo/embulk-input-t0013s03input-0.0.1.jar" "$tmp/INPUT.MF" -C "$tmp/input-classes" .
+printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0013FailureOutputPlugin' \
+  'Embulk-Plugin-Category: output' 'Embulk-Plugin-Type: t0013s03output' \
+  'Embulk-Plugin-Spi-Version: 0' > "$tmp/OUTPUT.MF"
+jar cfm "$output_repo/embulk-output-t0013s03output-0.0.1.jar" "$tmp/OUTPUT.MF" -C "$tmp/output-classes" .
+
+shasum -a 256 "$input_repo/embulk-input-t0013s03input-0.0.1.jar" | awk '{print $1}' > "$evidence/input-jar.sha256"
+shasum -a 256 "$output_repo/embulk-output-t0013s03output-0.0.1.jar" | awk '{print $1}' > "$evidence/output-jar.sha256"
+printf '%s\n' 'source=maven|group=org.embulk.t0013.s03|name=t0013s03input|version=0.0.1|artifact=embulk-input-t0013s03input|category=input|local-only' > "$evidence/input-coordinate.txt"
+printf '%s\n' 'source=maven|group=org.embulk.t0013.s03|name=t0013s03output|version=0.0.1|artifact=embulk-output-t0013s03output|category=output|local-only' > "$evidence/output-coordinate.txt"
+printf '%s' '<project><modelVersion>4.0.0</modelVersion></project>' > "$input_repo/embulk-input-t0013s03input-0.0.1.pom"
+printf '%s' '<project><modelVersion>4.0.0</modelVersion></project>' > "$output_repo/embulk-output-t0013s03output-0.0.1.pom"
+
+: > "$evidence/traces.raw"
+: > "$evidence/cases.raw"
+for fixture in normal failure; do
+  requested=1
+  log="$evidence/$fixture.raw.log"
+  config="$tmp/$fixture.yml"
+  case_trace="$tmp/$fixture.trace"
+  printf '%s\n' \
+    'in:' \
+    '  type:' \
+    '    source: maven' \
+    '    group: org.embulk.t0013.s03' \
+    '    name: t0013s03input' \
+    '    version: 0.0.1' \
+    'out:' \
+    '  type:' \
+    '    source: maven' \
+    '    group: org.embulk.t0013.s03' \
+    '    name: t0013s03output' \
+    '    version: 0.0.1' > "$config"
+  if T0013_FIXTURE="$fixture" T0013_TASK_COUNT="$requested" \
+    java -jar "$jarfile" "-Xembulk_home=$tmp/home" run "$config" > "$log" 2>&1; then
+    process_exit=0
+  else
+    process_exit=$?
+  fi
+  awk '/^(FAILTRACE|FAILOUTTRACE)\|/' "$log" > "$case_trace"
+  cat "$case_trace" >> "$evidence/traces.raw"
+  digest=$(shasum -a 256 "$case_trace" | awk '{print $1}')
+  total=$(wc -l < "$case_trace" | tr -d ' ')
+  input_count=$(awk '/^FAILTRACE\|/ {count++} END {print count + 0}' "$case_trace")
+  output_count=$(awk '/^FAILOUTTRACE\|/ {count++} END {print count + 0}' "$case_trace")
+  printf 'CASE|%s|%s|%s|%s:%s:%s:%s\n' "$fixture" "$requested" "$process_exit" \
+    "$total" "$input_count" "$output_count" "$digest" >> "$evidence/cases.raw"
+done
+cat "$evidence/cases.raw"

--- a/tools/t0013-input-failure/src/T0013FailureInputPlugin.java
+++ b/tools/t0013-input-failure/src/T0013FailureInputPlugin.java
@@ -1,0 +1,139 @@
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Exec;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.Schema;
+
+/** Local-only T-0013/S03 input-run failure observation probe. */
+public final class T0013FailureInputPlugin implements InputPlugin {
+    private static final String INJECTED_MESSAGE = "t0013-s03-injected-run-failure";
+    private static final String CAPTURE_ID = UUID.randomUUID().toString();
+    private static long sequence;
+
+    @Override
+    public ConfigDiff transaction(ConfigSource config, Control control) {
+        String fixture = fixture();
+        int taskCount = Integer.parseInt(System.getenv("T0013_TASK_COUNT"));
+        String count = Integer.toString(taskCount);
+        trace(fixture, "transaction-entry", count);
+        TaskSource inputTaskSource = Exec.newTaskSource();
+        Schema inputSchema = Schema.builder().build();
+        trace(fixture, "control-run-before", count);
+        RuntimeException operationFailure = null;
+        try {
+            control.run(inputTaskSource, inputSchema, taskCount);
+        } catch (RuntimeException failure) {
+            operationFailure = failure;
+        }
+        if (operationFailure != null) {
+            trace(fixture, "transaction-runtime-exception", operationFailure.getClass().getName(),
+                    operationFailure.getMessage());
+            throw operationFailure;
+        }
+        trace(fixture, "control-run-normal-return", count);
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "transaction-normal-return", count);
+        return result;
+    }
+
+    @Override
+    public ConfigDiff resume(TaskSource taskSource, Schema schema, int taskCount, Control control) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        trace(fixture, "resume-entry", count);
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "resume-normal-return", count);
+        return result;
+    }
+
+    @Override
+    public void cleanup(TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> reports) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        trace(fixture, "cleanup-entry", count, Integer.toString(reports.size()));
+        trace(fixture, "cleanup-normal-return", count);
+    }
+
+    @Override
+    public TaskReport run(TaskSource taskSource, Schema schema, int taskIndex, PageOutput output) {
+        String fixture = fixture();
+        String index = Integer.toString(taskIndex);
+        trace(fixture, "run-entry", index);
+        if ("failure".equals(fixture)) {
+            trace(fixture, "injection-before", index);
+            RuntimeException injectedFailure = null;
+            try {
+                throw new InjectedRunFailure(INJECTED_MESSAGE);
+            } catch (RuntimeException failure) {
+                injectedFailure = failure;
+            }
+            trace(fixture, "run-runtime-exception", injectedFailure.getClass().getName(),
+                    injectedFailure.getMessage());
+            throw injectedFailure;
+        }
+
+        trace(fixture, "finish-before", index);
+        RuntimeException operationFailure = null;
+        try {
+            output.finish();
+        } catch (RuntimeException failure) {
+            operationFailure = failure;
+        }
+        if (operationFailure != null) {
+            trace(fixture, "run-runtime-exception", operationFailure.getClass().getName(),
+                    operationFailure.getMessage());
+            throw operationFailure;
+        }
+        trace(fixture, "finish-normal-return", index);
+        TaskReport result = Exec.newTaskReport();
+        trace(fixture, "run-normal-return", index);
+        return result;
+    }
+
+    @Override
+    public ConfigDiff guess(ConfigSource config) {
+        String fixture = fixture();
+        trace(fixture, "guess-entry");
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "guess-normal-return");
+        return result;
+    }
+
+    private static String fixture() {
+        return System.getenv("T0013_FIXTURE");
+    }
+
+    private static synchronized void trace(String fixture, String event, String... fields) {
+        StringBuilder line = new StringBuilder("FAILTRACE|").append(fixture).append('|')
+                .append(CAPTURE_ID).append('|').append(++sequence).append('|').append(event);
+        for (String field : fields) {
+            line.append('|').append(field == null ? "-" : Base64.getEncoder()
+                    .encodeToString(field.getBytes(StandardCharsets.UTF_8)));
+        }
+        System.out.println(line);
+        if (System.out.checkError()) {
+            throw new InstrumentationError("input failure trace failed");
+        }
+    }
+
+    /** Original exception used only by the bounded injected fixture. */
+    public static final class InjectedRunFailure extends RuntimeException {
+        private InjectedRunFailure(String message) {
+            super(message);
+        }
+    }
+
+    private static final class InstrumentationError extends Error {
+        private InstrumentationError(String message) {
+            super(message);
+        }
+    }
+}

--- a/tools/t0013-input-failure/src/T0013FailureOutputPlugin.java
+++ b/tools/t0013-input-failure/src/T0013FailureOutputPlugin.java
@@ -1,0 +1,160 @@
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Exec;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.Page;
+import org.embulk.spi.Schema;
+import org.embulk.spi.TransactionalPageOutput;
+
+/** Local-only T-0013/S03 output lifecycle observation probe. */
+public final class T0013FailureOutputPlugin implements OutputPlugin {
+    private static final String CAPTURE_ID = UUID.randomUUID().toString();
+    private static long sequence;
+
+    @Override
+    public ConfigDiff transaction(ConfigSource config, Schema schema, int taskCount, Control control) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace(fixture, "transaction-entry", count, columns);
+        TaskSource outputTaskSource = Exec.newTaskSource();
+        trace(fixture, "control-run-before", count, columns);
+        List<TaskReport> reports = runControl(fixture, "transaction-runtime-exception", control, outputTaskSource);
+        if (reports == null) {
+            throw new InstrumentationError("output control returned null reports");
+        }
+        trace(fixture, "control-run-normal-return", count, columns, Integer.toString(reports.size()));
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "transaction-normal-return", count, columns, Integer.toString(reports.size()));
+        return result;
+    }
+
+    @Override
+    public ConfigDiff resume(TaskSource taskSource, Schema schema, int taskCount, Control control) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace(fixture, "resume-entry", count, columns);
+        trace(fixture, "resume-control-run-before", count, columns);
+        List<TaskReport> reports = runControl(fixture, "resume-runtime-exception", control, taskSource);
+        if (reports == null) {
+            throw new InstrumentationError("output resume control returned null reports");
+        }
+        trace(fixture, "resume-control-run-normal-return", count, columns, Integer.toString(reports.size()));
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "resume-normal-return", count, columns, Integer.toString(reports.size()));
+        return result;
+    }
+
+    @Override
+    public void cleanup(TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> reports) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        String columns = Integer.toString(schema.getColumnCount());
+        String reportCount = Integer.toString(reports.size());
+        trace(fixture, "cleanup-entry", count, columns, reportCount);
+        trace(fixture, "cleanup-normal-return", count, columns, reportCount);
+    }
+
+    @Override
+    public TransactionalPageOutput open(TaskSource taskSource, Schema schema, int taskIndex) {
+        String fixture = fixture();
+        String index = Integer.toString(taskIndex);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace(fixture, "open-entry", index, columns);
+        TransactionalPageOutput result = new ObservedPageOutput(fixture, taskIndex, schema.getColumnCount());
+        trace(fixture, "open-normal-return", index, columns);
+        return result;
+    }
+
+    private static List<TaskReport> runControl(
+            String fixture, String exceptionEvent, Control control, TaskSource taskSource) {
+        RuntimeException operationFailure = null;
+        List<TaskReport> reports = null;
+        try {
+            reports = control.run(taskSource);
+        } catch (RuntimeException failure) {
+            operationFailure = failure;
+        }
+        if (operationFailure != null) {
+            trace(fixture, exceptionEvent, operationFailure.getClass().getName(),
+                    operationFailure.getMessage());
+            throw operationFailure;
+        }
+        return reports;
+    }
+
+    private static final class ObservedPageOutput implements TransactionalPageOutput {
+        private final String fixture;
+        private final String index;
+        private final String columns;
+
+        private ObservedPageOutput(String fixture, int taskIndex, int columnCount) {
+            this.fixture = fixture;
+            this.index = Integer.toString(taskIndex);
+            this.columns = Integer.toString(columnCount);
+        }
+
+        @Override
+        public void add(Page page) {
+            trace(fixture, "add-entry", index, columns);
+            trace(fixture, "add-normal-return", index, columns);
+        }
+
+        @Override
+        public void finish() {
+            trace(fixture, "finish-entry", index, columns);
+            trace(fixture, "finish-normal-return", index, columns);
+        }
+
+        @Override
+        public TaskReport commit() {
+            trace(fixture, "commit-entry", index, columns);
+            TaskReport result = Exec.newTaskReport();
+            trace(fixture, "commit-normal-return", index, columns);
+            return result;
+        }
+
+        @Override
+        public void abort() {
+            trace(fixture, "abort-entry", index, columns);
+            trace(fixture, "abort-normal-return", index, columns);
+        }
+
+        @Override
+        public void close() {
+            trace(fixture, "close-entry", index, columns);
+            trace(fixture, "close-normal-return", index, columns);
+        }
+    }
+
+    private static String fixture() {
+        return System.getenv("T0013_FIXTURE");
+    }
+
+    private static synchronized void trace(String fixture, String event, String... fields) {
+        StringBuilder line = new StringBuilder("FAILOUTTRACE|").append(fixture).append('|')
+                .append(CAPTURE_ID).append('|').append(++sequence).append('|').append(event);
+        for (String field : fields) {
+            line.append('|').append(field == null ? "-" : Base64.getEncoder()
+                    .encodeToString(field.getBytes(StandardCharsets.UTF_8)));
+        }
+        System.out.println(line);
+        if (System.out.checkError()) {
+            throw new InstrumentationError("output trace failed");
+        }
+    }
+
+    private static final class InstrumentationError extends Error {
+        private InstrumentationError(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
Refs #16. T-0013/S03 only: a normal empty-input control and an original injected run failure before its finish call. Explicit per-loaded-class capture UUIDs distinguish cleanup contexts from duplicate sequence records; S03 output callback bodies remain equivalent to S02. Primary and independent Tester passed tests/t0013_input_failure_probe_test.sh at f35cb49, including artifact controls, 25 invalid-evidence controls and 3 valid synthetic controls. Normal exit 0 and failure exit 1 were observed, with exact injected class/message propagation. Abort, close and fresh cleanup contexts are observations, not durability or rollback guarantees. Canonical packet/evidence: docs/provenance/T-0013-input-failure-probe.md. Parent Current SP is refined from 8 to 13 while Initial SP stays 8; the parent remains open. No Rust runtime or default fan-out claim. Final-head acceptance follows.