### PR TITLE
test: observe selected output commit failure (T-0013/S05)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S05` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
+`T-0013/S05` is `Review` (PR #75); `T-0012`, `T-0021` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S05: output commit failure observation) | In Progress | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S05: output commit failure observation) | Review | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core

--- a/TODO.md
+++ b/TODO.md
@@ -229,3 +229,8 @@ fallibility. Current parent SP is refined 13 to 21: S01–S04 already represent
 12 SP of accepted slices, while output-failure verification and recovery
 uncertainty remain. Initial SP stays 8; no parent completion or earned parent
 points are implied. Combined WIP stays one.
+
+S05 primary acceptance at `876e861` passed both live fixtures, 21 targeted
+evidence controls and two executable controls, separate shell syntax and diff
+checks. Independent Tester reproduced these results; integration remains pending. Only selected
+last-index reference observations are claimed, not general commit handling.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S04` is `Review` (PR #74); `T-0012`, `T-0021` and all other unfinished items
+`T-0013/S05` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S04: selected live empty-lifecycle comparison) | Review | P0 | 13 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S05: output commit failure observation) | In Progress | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -220,4 +220,12 @@ additional points follow. Combined WIP stays one.
 S04 primary acceptance at `98b6cac` passed both live comparisons and 13 raw
 controls; workspace tests passed 20 with three intentional live ignores, plus
 format and strict Clippy. Independent Tester reproduced these results;
-final-head acceptance and integration remain pending.
+final-head acceptance at `09ac159` passed and PR #74 integrated as `68d848c`.
+
+T-0013/S05 (3 SP) is active under its
+[packet](docs/provenance/T-0013-output-commit-failure-probe.md). Observe normal
+and selected output commit failure callbacks before choosing Rust output
+fallibility. Current parent SP is refined 13 to 21: S01–S04 already represent
+12 SP of accepted slices, while output-failure verification and recovery
+uncertainty remain. Initial SP stays 8; no parent completion or earned parent
+points are implied. Combined WIP stays one.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,7 +48,8 @@ T-0013/S04 adds a test-only driver and private child test bridge, leaving the
 coordinator and fake behavior unchanged. It compares two live declared event
 projections and separate cleanup counts using the reference output count as a
 supplied Rust plan. Primary and independent acceptance pass at `98b6cac`;
-integration remains pending. The test adapter is not a host API.
+final-head acceptance passed and PR #74 integrated as `68d848c`. The test adapter
+is not a host API.
 
 T-0012 reference probes and S04's ignored live comparison are test-only tools
 outside the Emburk runtime. Their local executable retrieval and generated probe

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -93,9 +93,13 @@ Unit/Contract only, integrated through PR #73 (`14d5fb5`); no new Native/Verifie
 entry follows.
 
 T-0013/S04's two selected live projections pass primary acceptance at `98b6cac`;
-independent Tester reproduced the results, with integration pending. Its projections exclude
+independent Tester reproduced the results, and PR #74 integrated as `68d848c`
+after final-head acceptance at `09ac159`. Its projections exclude
 default planning, capture identity, Java report contents and zero-task live
 coverage; no generalized lifecycle claim follows from activation.
+
+S05's selected output commit failure observation is pending. It adds no native
+output-failure, partial-publication or rollback policy.
 
 ## Adding an Entry
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -98,8 +98,11 @@ after final-head acceptance at `09ac159`. Its projections exclude
 default planning, capture identity, Java report contents and zero-task live
 coverage; no generalized lifecycle claim follows from activation.
 
-S05's selected output commit failure observation is pending. It adds no native
-output-failure, partial-publication or rollback policy.
+S05's selected output commit failure observation passes primary acceptance at
+`876e861`: only the failed handle aborts, all close, and cleanup receives input
+1/output 7 reports for the observed 1/8 plan. Independent acceptance passes;
+integration remains pending. It adds no native output-failure, partial-publication or rollback
+policy, and does not observe arbitrary failure indexes.
 
 ## Adding an Entry
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -73,8 +73,11 @@ independent acceptance; final-head acceptance passed and PR #73 integrated as
 `14d5fb5`. T-0013/S04 now activates a separately scoped two-case live projection
 comparison. Neither slice completes Phase 0 or the File-to-File milestone.
 S04 primary acceptance at `98b6cac` passes both declared projections and strict
-negative controls; independent Tester reproduced the results. Integration remains
-pending.
+negative controls; independent Tester reproduced the results. Final-head
+acceptance at `09ac159` passed and PR #74 integrated as `68d848c`.
+S05 now observes selected output commit failure before expanding Rust output
+fallibility. This reference-only gate cannot establish partial publication,
+rollback, retry or resume behavior.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -78,6 +78,9 @@ acceptance at `09ac159` passed and PR #74 integrated as `68d848c`.
 S05 now observes selected output commit failure before expanding Rust output
 fallibility. This reference-only gate cannot establish partial publication,
 rollback, retry or resume behavior.
+S05 primary acceptance at `876e861` passes the two live fixtures and 23 controls;
+independent Tester reproduced these results, with integration pending. It distinguishes selected
+output commit failure from input-run failure without completing parent gates.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -251,8 +251,18 @@ and a complete lifecycle contract are not approved by this internal slice.
 | Empty successful orchestration | Accepted S01 input and S02 output observations with actual component traces | A bounded normal-path candidate; not inferred failure handling |
 | Failure before the input's finish call | Same-runtime positive control and an original input-run exception fixture, retaining propagation and all actual output callbacks | A candidate for that exact failure boundary; not pre-publication, rollback, retry or recovery guarantees |
 | Private coordinator acceptance | Independently authored fake plugins and explicit input/output plans (T-0021/S03 Unit); two live declared projections pass T-0013/S04 primary and independent acceptance at `98b6cac`, integrated by PR #74 (`68d848c`) | Private execution of those supplied plans; not default executor fan-out, identical instrumentation or a public plugin API |
-| Output commit callback exception | S05 original normal control plus one selected output commit exception; actual outcomes pending | Evidence to review before output fallibility; not durable publication, rollback or recovery guarantees |
+| Output commit callback exception | S05 original normal control plus one selected output commit exception; primary and independent acceptance pass at `876e861`, integration pending | Evidence to review before output fallibility; not durable publication, rollback or recovery guarantees |
 | Expansion beyond empty tasks | New fixtures for values, output mapping, concurrency and resource bounds | A separately reviewed execution slice; not a silent extension of empty-task evidence |
+
+S05's initial last-index observation differs from input-run failure: only the
+failed output is aborted, all handles close, and earlier returned reports remain
+available to cleanup. Primary and independent acceptance pass at `876e861`;
+integration is pending. A future private candidate
+would need typed output errors, incremental report retention and common typed
+scope outcomes while preserving S04 regressions; no such mutation is authorized
+here. Last-index evidence is not arbitrary-index coverage. Observe first/middle
+commit failures before choosing a broader policy, and never infer publication
+or rollback from these empty fixtures.
 
 The proposed failure fixture should throw inside input `run` before its own
 `finish` call. Calling this "before publication" would be unjustified: output

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -250,7 +250,8 @@ and a complete lifecycle contract are not approved by this internal slice.
 |---|---|---|
 | Empty successful orchestration | Accepted S01 input and S02 output observations with actual component traces | A bounded normal-path candidate; not inferred failure handling |
 | Failure before the input's finish call | Same-runtime positive control and an original input-run exception fixture, retaining propagation and all actual output callbacks | A candidate for that exact failure boundary; not pre-publication, rollback, retry or recovery guarantees |
-| Private coordinator acceptance | Independently authored fake plugins and explicit input/output plans (T-0021/S03 Unit); two live declared projections pass T-0013/S04 primary and independent acceptance at `98b6cac`, integration pending | Private execution of those supplied plans; not default executor fan-out, identical instrumentation or a public plugin API |
+| Private coordinator acceptance | Independently authored fake plugins and explicit input/output plans (T-0021/S03 Unit); two live declared projections pass T-0013/S04 primary and independent acceptance at `98b6cac`, integrated by PR #74 (`68d848c`) | Private execution of those supplied plans; not default executor fan-out, identical instrumentation or a public plugin API |
+| Output commit callback exception | S05 original normal control plus one selected output commit exception; actual outcomes pending | Evidence to review before output fallibility; not durable publication, rollback or recovery guarantees |
 | Expansion beyond empty tasks | New fixtures for values, output mapping, concurrency and resource bounds | A separately reviewed execution slice; not a silent extension of empty-task evidence |
 
 The proposed failure fixture should throw inside input `run` before its own

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -196,3 +196,10 @@ S05 now observes a normal control and one selected output commit exception.
 No output-failure Rust policy is added before that evidence. T-0013 Current SP
 is refined 13 to 21 to include output-failure verification and remaining lifecycle
 uncertainty; Initial SP stays 8 and the parent remains open.
+
+S05 primary acceptance at `876e861` passed the normal/selected commit-failure
+Demo and 23 controls. Failure aborted only the failed handle, closed all, and
+fresh cleanup captures received input 1/output 7 reports in the observed 1/8
+plan. Independent Tester reproduced these results. This is Reference Observation
+/ Integration only; final-head acceptance and integration remain pending, with
+no Rust output-failure policy added.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -33,7 +33,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S05 (`In Progress`) is the only active work item. Combined WIP is one of
+T-0013/S05 (`Review`, PR #75) is the only active work item. Combined WIP is one of
 two; no item is `Ready` or `Blocked`. T-0012 and T-0021 remain Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -44,7 +44,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
-| T-0013/S05 | In Progress | Observe one output commit failure before Rust policy |
+| T-0013/S05 | Review | Selected output commit failure observation; PR #75 |
 | T-0021 | Backlog | S01–S03 integrated; remaining core contracts |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -33,7 +33,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S04 (`Review`, PR #74) is the only active work item. Combined WIP is one of
+T-0013/S05 (`In Progress`) is the only active work item. Combined WIP is one of
 two; no item is `Ready` or `Blocked`. T-0012 and T-0021 remain Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -44,7 +44,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
-| T-0013/S04 | Review | Two selected live empty-lifecycle projections; PR #74 |
+| T-0013/S05 | In Progress | Observe one output commit failure before Rust policy |
 | T-0021 | Backlog | S01–S03 integrated; remaining core contracts |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
@@ -188,6 +188,11 @@ projections. It compares actual callbacks and cleanup counts for supplied plans,
 not default fan-out, raw instrumentation identity or general lifecycle behavior.
 Primary acceptance at `98b6cac` passed both comparisons, 13 raw-evidence controls,
 20 offline workspace tests (three intentional live ignores), format and strict
-Clippy. Independent Tester reproduced these results; final-head acceptance and
-integration remain pending. Evidence is
+Clippy. Independent Tester reproduced these results; final-head acceptance at
+`09ac159` passed and PR #74 integrated as `68d848c`. Evidence is
 Differential for those two projections only; zero tasks remain Unit/Contract.
+
+S05 now observes a normal control and one selected output commit exception.
+No output-failure Rust policy is added before that evidence. T-0013 Current SP
+is refined 13 to 21 to include output-failure verification and remaining lifecycle
+uncertainty; Initial SP stays 8 and the parent remains open.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -118,3 +118,15 @@
   changes 13 to 21 for remaining output-failure/recovery verification; Initial
   SP stays 8. Parent #16 stays open, WIP stays one. No Rust fallibility or
   rollback policy is inferred from an empty commit returning or throwing.
+- First S05 trace reached commit failure at observed index 7 of 8 after normal
+  input finish/run and seven output commit returns. Only the failed handle was
+  aborted; all eight were closed. Fresh cleanup captures received input 1 and
+  output 7 reports. PM read the raw trace before authorizing bounded assertions.
+  This differs from input-run failure and does not establish rollback or durable
+  publication; strict acceptance is pending.
+- S05 primary acceptance at `876e861` passes both live fixtures and 23 controls
+  (21 targeted evidence mutations plus two executable controls). PM required
+  successful-commit pairing, strict phase/scope/cleanup order and targeted
+  repaired-transport controls. Independent Tester reproduced the frozen source;
+  integration remains pending. No Rust behavior or broader commit/rollback
+  guarantee is added.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -109,6 +109,12 @@
   corruption controls and the exact selected Rust test. Observed plans are 1/8;
   normal projection has 44 events and cleanup counts 1/8, failure has 34 and 0/0.
   Excluded marker controls repair sequences/hashes before targeted rejection.
-  Independent Tester reproduced all results at the frozen source; integration
-  remains pending. No planner, full
+  Independent Tester reproduced all results at the frozen source; final-head
+  acceptance at `09ac159` passed and PR #74 integrated as `68d848c`. No planner, full
   instrumentation, zero-task live or report-content equivalence is claimed.
+- Activated T-0013/S05 (3 SP) for normal/output-commit-failure observation with
+  unchanged S03 input and one new original output fixture. PM must interpret
+  the first actual trace before failure-outcome assertions. Current parent SP
+  changes 13 to 21 for remaining output-failure/recovery verification; Initial
+  SP stays 8. Parent #16 stays open, WIP stays one. No Rust fallibility or
+  rollback policy is inferred from an empty commit returning or throwing.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -18,4 +18,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S03 input-run failure observation](T-0013-input-failure-probe.md) | Done (Reference Observation / Integration; PR #72) |
 | [T-0021/S03 private empty-task coordinator](T-0021-empty-task-coordinator.md) | Done (Unit/Contract; PR #73) |
 | [T-0013/S04 selected empty-lifecycle differential](T-0013-empty-lifecycle-differential.md) | Done (two selected Differential projections; PR #74) |
-| [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | In Progress (acceptance pending) |
+| [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | Review (Reference Observation / Integration; PR #75) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -17,4 +17,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S02 output lifecycle observation](T-0013-output-lifecycle-probe.md) | Done (Reference Observation / Integration; PR #71) |
 | [T-0013/S03 input-run failure observation](T-0013-input-failure-probe.md) | Done (Reference Observation / Integration; PR #72) |
 | [T-0021/S03 private empty-task coordinator](T-0021-empty-task-coordinator.md) | Done (Unit/Contract; PR #73) |
-| [T-0013/S04 selected empty-lifecycle differential](T-0013-empty-lifecycle-differential.md) | Review (two selected Differential projections; PR #74) |
+| [T-0013/S04 selected empty-lifecycle differential](T-0013-empty-lifecycle-differential.md) | Done (two selected Differential projections; PR #74) |
+| [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | In Progress (acceptance pending) |

--- a/docs/provenance/T-0013-empty-lifecycle-differential.md
+++ b/docs/provenance/T-0013-empty-lifecycle-differential.md
@@ -1,7 +1,8 @@
 # T-0013/S04 selected empty-lifecycle differential
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: Review; PR #74, final-head acceptance and integration pending
+- State: Done (two selected Differential projections); PR #74 integrated
+- Parent: Issue #16 remains open for S05 and remaining contracts
 - Priority: P0; parent T-0010
 - Slice estimate: 3 SP within parent Current SP 13, Initial SP 8; no new parent
   points or parent completion. Refinement: implementation 1, uncertainty 1,
@@ -183,7 +184,10 @@ Independent reference evidence is `${TMPDIR}/t0013-input-failure.MdR7qO/evidence
 `3f438b9c3d85af64f9334119938cd68f058f455af5013c0348bb60afef187106`;
 `traces.raw` SHA-256:
 `3963a21d36a56ab3c4eae523f9e284853c6f7be136b5ceed11cb317bcf5b5e2d`.
-Final-head acceptance and integration remain pending.
+Final-head acceptance at `09ac159020d530136e20b82028935cbb4d61b589` reproduced
+the exact Demo and all strict checks (exit 0), with evidence root
+`${TMPDIR}/t0013-s04.1VYi4N`. PR #74 integrated as
+`68d848c0214d33077a80cfe4dafb5dbba85c3b06`; Issue #16 remains open.
 The live result applies only to the declared projection, not raw marker identity,
 default planning, report contents, zero-task behavior or complete lifecycle.
 

--- a/docs/provenance/T-0013-output-commit-failure-probe.md
+++ b/docs/provenance/T-0013-output-commit-failure-probe.md
@@ -1,7 +1,7 @@
 # T-0013/S05 output commit failure observation
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: In Progress; acceptance pending
+- State: Review; PR #75, final-head acceptance and integration pending
 - Priority: P0; parent T-0010
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0; raw 3 maps to 3 SP)

--- a/docs/provenance/T-0013-output-commit-failure-probe.md
+++ b/docs/provenance/T-0013-output-commit-failure-probe.md
@@ -1,0 +1,161 @@
+# T-0013/S05 output commit failure observation
+
+- Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
+- State: In Progress; acceptance pending
+- Priority: P0; parent T-0010
+- Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
+  environment 0; raw 3 maps to 3 SP)
+- Parent Current SP: 21, refined from 13; Initial SP remains 8. Four accepted
+  3-SP slices already represent 12 SP, while output-failure observation and
+  remaining lifecycle/recovery contracts are not complete. The former estimate
+  underrepresented verification and failure uncertainty. This is a forecast
+  refinement, not earned parent points or parent completion.
+
+## Authority
+
+PM owns scope, first-observation interpretation, canonical records, acceptance
+and integration. One Compatibility Host implementation lane owns the three
+source/test paths below; Tester is read-only. Standing owner authority permits
+bounded implementation and PR integration after acceptance.
+
+## Dependencies
+
+Pinned T-0011 executable/API provenance, original T-0013/S03 input/output fixtures
+and capture grammar (PR #72, `8e43948`), and T-0013/S04's accepted two selected
+input-failure projections (PR #74, `68d848c`). T-0021/S03 remains unchanged.
+No parent dependency is declared complete; combined WIP remains one.
+
+## Branch and allowlist
+
+Branch: `research/t-0013-output-commit-failure`.
+One implementer owns exactly:
+
+- `tools/t0013-output-commit-failure/run.sh` (new)
+- `tools/t0013-output-commit-failure/src/T0013CommitFailureOutputPlugin.java` (new)
+- `tests/t0013_output_commit_failure_probe_test.sh` (new)
+
+Compile the existing `tools/t0013-input-failure/src/T0013FailureInputPlugin.java`
+read-only under a distinct local-only Maven coordinate. Preserve its hash and
+source location in evidence. Do not change S03/S04, Rust code, manifests,
+dependencies, CLI, public API, other probes or upstream sources. PM owns STATUS,
+TODO, ROADMAP, COMPATIBILITY, ARCHITECTURE, runtime design, provenance and dated log.
+
+## Artifacts
+
+Use the same pinned official Embulk 0.11.5 executable and a new original local
+output fixture, independently packaged from the unchanged input fixture. Retain
+executable/source/JAR hashes, URL, coordinates, LICENSE/NOTICE, Java version,
+raw process logs, raw cases/traces and callback capture identities. No generated
+JAR or downloaded executable is published. Prefix the new output trace distinctly
+and validate the existing input trace independently; never merge their counters.
+
+Run two separate processes: `normal` and `commit-failure`, each requesting one
+empty input task. These names leave the unchanged input fixture's `failure`
+branch inactive. Preserve a same-runtime positive control before interpreting
+the selected failure. No Pages, add, resume or guess execution is introduced.
+
+In the output transaction, require a positive actual task count and select
+`taskCount - 1`; record the count and selected index. A fixture-local volatile
+selection initialized to an invalid sentinel may transfer this instrumentation
+to handles in the same capture. Do not infer shared class state if it is not
+observed: a missing selection or unreached injection is a failed observation,
+not permission to invent a state transport. Cleanup may use a fresh capture and
+must not depend on retained transaction selection. No fixed fan-out is allowed.
+
+At the selected handle's commit in `commit-failure`, emit commit entry and one
+injection-before marker, construct an original fixture exception, record its
+actual class/message, and throw before `Exec.newTaskReport()` or a commit normal
+return. Use an exact fixture-owned class such as
+`T0013CommitFailureOutputPlugin$InjectedCommitFailure` with message
+`t0013-output-commit-failure`. Other output callback bodies retain S03 behavior;
+all their actual entry/return markers remain recorded. Trace I/O failures must
+not be confused with the injected operation exception.
+
+Selecting the last numerical index does not guarantee previous commits occurred
+first. Observe physical order; do not sort the raw trace or infer concurrency
+ordering. Record every actual open/finish/commit/abort/close callback, input run
+and finish, both transaction/control outcomes and both cleanup/report paths.
+Preserve outer exception class/messages exactly, including wrappers; do not
+assume they equal the injection before the first run has been interpreted.
+
+### Observation before policy
+
+The first live failure trace must be sent to PM with raw paths and actual counts
+before adding lifecycle-outcome assertions to acceptance. Injection reachability,
+typed grammar, callback pair integrity and artifact identity can be validated
+in advance. Abort/close cardinality, successful commits, cleanup presence/counts,
+report availability and outer propagation are observations, not predetermined
+success expectations. PM records the actual boundary before Rust fallibility or
+any new Differential comparison is considered.
+
+Validate canonical UUIDv4 captures and per-capture contiguous sequences, exact
+event arities, Base64/UTF-8, null-message positions, task indices/counts, zero
+schema columns, same-capture callback pairs and prior matching opens. A thrown
+selected commit has a distinct exception terminal, never a fabricated normal
+return. Capture IDs remain instrumentation, not recovery or process identities.
+Retain independent cleanup report counts; do not make them equal an earlier
+control report count or the number of successful commit callbacks by assumption.
+
+## Acceptance criteria
+
+- Normal process exits 0 and exposes complete original input/output callbacks.
+- Failure reaches the selected injection exactly once at observed `N - 1`,
+  records its exact exception, has no normal return for that invocation and
+  exits nonzero for that reached operation, not an unrelated startup failure.
+- Actual failure lifecycle outcomes are reviewed by PM and retained, with no
+  rollback, durability or general partial-publication inference.
+- Strict artifact/hash/raw-log/capture/grammar checks pass; malformed and
+  contradictory evidence fails closed with targeted diagnostics.
+- Negative controls cover unavailable/corrupt executable, missing/duplicate
+  injection, wrong selection, altered injected class/message, fabricated commit
+  normal return, missing operation terminal, sequence/capture errors, malformed
+  fields, stale hashes/logs, unknown/add/resume callbacks and contradictory
+  transaction outcomes. Repair unrelated sequence/hash/log metadata when testing
+  semantic missing/contradictory markers so the intended validator is exercised.
+- Unchanged input source hash and narrowly changed original output behavior
+  are reviewed; no upstream implementation inspection or production Rust edit.
+
+## Demo Command
+
+`bash tests/t0013_output_commit_failure_probe_test.sh`
+
+Run each shell syntax check separately and `git diff --check`. Tester reproduces
+the frozen source and PM reruns the exact Demo at final PR head. Retain failures
+and retry safe pinned-network execution as needed; ordinary tooling problems are
+not an incident or permission to stop unrelated authorized work.
+
+## Evidence class
+
+Reference Observation / Integration only if acceptance passes. No Rust behavior
+or Differential result is added by this observation. Planning is not evidence
+that the injection has been reached or that cleanup/rollback works.
+
+## Reference and reuse record
+
+Access/review date: 2026-09-06. Uses the exact official executable URL recorded
+in T-0011 and T-0013/S03:
+`https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar`,
+SHA-256 `e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`.
+Core `c5ac2d471edac465b45088669d376a7e2a525f8f`, SPI 0.11
+`576e98033a14ba8ac994ed581d3c9d8fcdda2749`, Apache-2.0 classification and exact
+public API locators remain in T-0011/S03 records. This slice reuses only original
+repository-owned fixture/runner ideas, not upstream implementation/test code.
+No new artifact, dependency or external plugin is admitted. Transitive SBOM and
+notices, redistribution, patent/standards/trademark, jurisdiction and freedom to
+operate remain unreviewed, not cleared.
+
+## Stop rule
+
+Repair ordinary compilation/test issues within the allowlist. Send the first
+failure trace to PM before policy assertions. Return to PM for unreachable
+injection/class-state gaps, new artifact/API/state transport, changed scope or
+material IP/security uncertainty. Do not silently edit accepted probes, weaken
+controls or assume a failed operation was rolled back.
+
+## Non-claims
+
+No Rust output-failure handling, full lifecycle/plugin compatibility, general
+commit ordering, durable publication, rollback, lost acknowledgement, retry,
+resume, atomicity, exactly-once, performance, isolation, production loader or
+parent #16 completion. A normal empty commit return proves only that the fixture
+returned its TaskReport, not that external data was durably committed.

--- a/docs/provenance/T-0013-output-commit-failure-probe.md
+++ b/docs/provenance/T-0013-output-commit-failure-probe.md
@@ -130,6 +130,100 @@ Reference Observation / Integration only if acceptance passes. No Rust behavior
 or Differential result is added by this observation. Planning is not evidence
 that the injection has been reached or that cleanup/rollback works.
 
+Independent read-only Planning review at `45839d5` found no material ambiguity
+or overclaim. It confirmed the unchanged-input/new-output boundary, dynamic
+capture-local selection, first-trace interpretation gate and explicit absence
+of rollback/publication or Rust-policy claims. Source acceptance remains pending.
+
+## Initial observation and PM interpretation
+
+Before failure-outcome assertions were added, the original runner produced
+local-only evidence at `${TMPDIR}/t0013-output-commit-failure.Whvtnv/evidence`.
+PM read the full decoded failure trace on 2026-09-06. Normal process exit was 0
+with 81 markers (10 input, 71 output); failure exit was 1 with 82 (9 input,
+73 output). Both observed output counts were 8, schema count 0, selected index 7.
+
+All eight output handles opened and finished, and the input finish/run returned
+normally before commit. Failure commits at indexes 0–6 returned normally;
+index 7 reached the injection and recorded the exact original exception without
+a commit normal return. Only index 7 received abort; all eight received close.
+Output transaction then input transaction recorded the same original exception,
+not normal control/transaction returns. Fresh input cleanup capture received
+task count 1/report count 1; fresh output cleanup capture received task count
+8/schema count 0/report count 7. These are distinct from S03 input-run failure's
+all-output abort and empty report collections.
+
+PM authorizes assertions for that selected fixture pattern using observed N and
+selected N - 1, retaining physical event order and independent cleanup counts.
+This is not a universal equality between successful commits and cleanup reports,
+an arbitrary failing-index observation, or evidence of durable publication or
+rollback. Numerical last-index selection does not establish a concurrent order.
+No Rust output-failure policy is implemented or accepted by this interpretation.
+
+Initial raw SHA-256 (per-run evidence, not golden values):
+
+- `cases.raw`:
+  `57f4a36145ac0336cd2b6318bc68d0ca86130d923a41e9eb65be999e08e875d6`
+- `traces.raw`:
+  `095a51068f1273a6d573e9c3e71ddc0002faf4d84a2cbd9e58c724a939d1eec0`
+- `normal.raw.log`:
+  `3ccb2c5b34a27a45efc37fb042c26c8b5d18501b6e755cc7fb0318206d54ba28`
+- `commit-failure.raw.log`:
+  `91a429bb8594250edff725be4e20b8a5f5a25c62bb7f2c862272894fe645599b`
+
+This initial capture preceded strict source acceptance; later evidence follows.
+
+## Source acceptance
+
+Primary acceptance at `876e861853e723391347f2473e9da630c2dfb033` on 2026-09-06
+passed the exact Demo (exit 0): normal exit 0 with 81 markers (10 input/71
+output), selected commit failure exit 1 with 82 (9/73), matching the interpreted
+boundary above. Actual N was 8 and selected index 7; those are observations,
+not constants inside selection or validation. Both executable controls and all
+21 targeted semantic/envelope controls passed. Missing, duplicate, contradictory
+and reordered semantic markers have repaired sequence/hash/raw-log metadata and
+must fail with their specific diagnostic. A one-output plan no longer crashes
+the parser's zero-prior-commit ordering check; this is parser robustness, not a
+new live observation of N = 1.
+
+Both shell syntax checks were run separately and passed; `git diff --check`
+exited 0. Environment remains macOS arm64, Temurin 17.0.20+8, Python 3.14.6 and
+Bash 3.2.57. The pinned self-executable's known 7451-byte zip prefix warning and
+public-API deprecation notes are retained, not suppressed or new artifacts.
+No Rust or existing probe source changed. PM reviewed the output/S03 source diff:
+changes are confined to fixture identity, selection and the original injection.
+
+Primary local-only evidence:
+`${TMPDIR}/t0013-output-commit-failure.tQ5LZR/evidence`.
+
+- `cases.raw` SHA-256:
+  `55e3794bffd144418edce00386214c14151846e47436c47c8121495e1c80ff8c`
+- `traces.raw` SHA-256:
+  `a9c4ddac0cca23f796118269f2cb784a70cd76dbf8057b7af236404124d81b4a`
+- Runner SHA-256:
+  `a49aa3869677fa1db7ad7e989697fd59d78fbd9bad64d895ff71ed7468b1acb3`
+- New output Java SHA-256:
+  `6889081e838e19052ba7ea34193a8ad7bf64ec5b7339e4d825e1ad09adfb65d3`
+- Acceptance wrapper SHA-256:
+  `2c5c7e20cc515836459d4d15b52f1dde4ed1bc4fbd0bdf3cf9a7ba53752275b6`
+- Unchanged S03 input Java SHA-256:
+  `d45f0b6e83d39458331a2cf1be27a01d1b6863017bd87807f0e49d160c96d252`
+
+Independent Tester reproduced the frozen source: exact Demo exit 0 with both
+fixtures and all 23 controls, separate shell syntax and diff checks passing.
+The initial sandbox attempt exited 1 without evidence; the approved exact
+pinned-network rerun passed. No acceptance finding remains. Logs are local-only
+at `/private/tmp/emburk-t0013-s05-acceptance.X684fr`; `demo-escalated.log` SHA-256:
+`a129739e86bab0d7328dfe76b04f922631f21363cf47e01936374456ac3995b9`.
+Independent reference root is
+`${TMPDIR}/t0013-output-commit-failure.z9E3Nq/evidence`; `cases.raw` SHA-256:
+`38acff4e916c0fbd18d193390b652f4c3e9d423242986c15b66a785721c714e8`;
+`traces.raw` SHA-256:
+`1b4048b0b32450e0b910fdc7bdeb1fc08776037cf8c1193299e6fa6b84f28114`.
+Final-head acceptance and integration remain pending.
+Evidence is Reference Observation / Integration only. Other commit positions,
+general output-error semantics, publication and rollback remain unverified.
+
 ## Reference and reuse record
 
 Access/review date: 2026-09-06. Uses the exact official executable URL recorded

--- a/tests/t0013_output_commit_failure_probe_test.sh
+++ b/tests/t0013_output_commit_failure_probe_test.sh
@@ -1,0 +1,587 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+runner="$root/tools/t0013-output-commit-failure/run.sh"
+[[ -x "$runner" ]] || exit 2
+
+run_artifact_negative() {
+  local control=$1 expected=$2 label=$3 output result_code evidence
+  if output=$(T0013_COMMIT_NEGATIVE="$control" "$runner" 2>&1); then
+    exit 1
+  else
+    result_code=$?
+  fi
+  [[ "$result_code" == "$expected" ]] || exit 1
+  evidence=$(printf '%s\n' "$output" | sed -n 's/^T0013_COMMIT_EVIDENCE_DIR=//p' | tail -1)
+  [[ -n "$evidence" && -d "$evidence" ]] || exit 1
+  grep -Fqx "$label" "$evidence/negative-control.txt" || exit 1
+  printf 'T0013_COMMIT_NEGATIVE=%s|exit=%s|evidence=%s\n' "$control" "$result_code" "$evidence"
+}
+
+run_artifact_negative corrupt-copy 3 corrupt-copy-injected
+run_artifact_negative unavailable-asset 56 unavailable-asset-request-failed
+
+output=$("$runner")
+printf '%s\n' "$output"
+evidence=$(printf '%s\n' "$output" | sed -n 's/^T0013_COMMIT_EVIDENCE_DIR=//p' | tail -1)
+[[ -n "$evidence" && -d "$evidence" ]] || exit 1
+for file in executable.sha256 executable-url.txt LICENSE-executable NOTICE-executable java-version.txt \
+  input-source.sha256 input-source-path.txt output-source.sha256 output-source-vs-s03.diff \
+  input-jar.sha256 output-jar.sha256 input-coordinate.txt output-coordinate.txt \
+  cases.raw traces.raw normal.raw.log commit-failure.raw.log; do
+  [[ -s "$evidence/$file" ]] || exit 1
+done
+expected_input_sha=$(shasum -a 256 "$root/tools/t0013-input-failure/src/T0013FailureInputPlugin.java" | awk '{print $1}')
+grep -Fqx "$expected_input_sha" "$evidence/input-source.sha256"
+grep -Fqx 'tools/t0013-input-failure/src/T0013FailureInputPlugin.java' "$evidence/input-source-path.txt"
+
+validate() {
+  python3 - "$1" <<'PY'
+import base64
+import binascii
+import hashlib
+import pathlib
+import sys
+import uuid
+
+root = pathlib.Path(sys.argv[1])
+fixtures = ("normal", "commit-failure")
+injected_class = "T0013CommitFailureOutputPlugin$InjectedCommitFailure"
+injected_message = "t0013-output-commit-failure"
+
+class InvalidEvidence(Exception):
+    pass
+
+def require(label, condition):
+    if not condition:
+        raise InvalidEvidence(label)
+
+def decimal(label, value):
+    require(label, value and value.isascii() and value.isdigit())
+    return int(value)
+
+def decode(label, value, *, numeric=False, nonempty=False):
+    require(label, value != "-")
+    try:
+        raw = base64.b64decode(value, validate=True)
+        text = raw.decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        raise InvalidEvidence(label)
+    require(label, base64.b64encode(raw).decode("ascii") == value)
+    if numeric:
+        decimal(label, text)
+    if nonempty:
+        require(label, text != "")
+    return text
+
+input_arity = {
+    "transaction-entry": 1, "control-run-before": 1, "control-run-normal-return": 1,
+    "transaction-normal-return": 1, "transaction-runtime-exception": 2,
+    "run-entry": 1, "injection-before": 1, "finish-before": 1,
+    "finish-normal-return": 1, "run-normal-return": 1, "run-runtime-exception": 2,
+    "cleanup-entry": 2, "cleanup-normal-return": 1, "resume-entry": 1,
+    "resume-normal-return": 1, "guess-entry": 0, "guess-normal-return": 0,
+}
+input_numeric = {
+    "transaction-entry": {0}, "control-run-before": {0}, "control-run-normal-return": {0},
+    "transaction-normal-return": {0}, "run-entry": {0}, "injection-before": {0},
+    "finish-before": {0}, "finish-normal-return": {0}, "run-normal-return": {0},
+    "cleanup-entry": {0, 1}, "cleanup-normal-return": {0}, "resume-entry": {0},
+    "resume-normal-return": {0},
+}
+output_arity = {
+    "transaction-entry": 2, "commit-selection": 2, "control-run-before": 2,
+    "control-run-normal-return": 3, "transaction-normal-return": 3,
+    "transaction-runtime-exception": 2, "resume-entry": 2,
+    "resume-control-run-before": 2, "resume-control-run-normal-return": 3,
+    "resume-normal-return": 3, "resume-runtime-exception": 2,
+    "cleanup-entry": 3, "cleanup-normal-return": 3,
+    "open-entry": 2, "open-normal-return": 2, "add-entry": 2,
+    "add-normal-return": 2, "finish-entry": 2, "finish-normal-return": 2,
+    "commit-entry": 2, "commit-injection-before": 2,
+    "commit-normal-return": 2, "commit-runtime-exception": 4,
+    "abort-entry": 2, "abort-normal-return": 2,
+    "close-entry": 2, "close-normal-return": 2,
+}
+output_numeric = {event: set(range(arity)) for event, arity in output_arity.items()
+                  if not event.endswith("runtime-exception")}
+output_numeric["commit-runtime-exception"] = {0, 1}
+
+def only(rows, component, event, label):
+    found = [row for row in rows if row[0] == component and row[1] == event]
+    require(label, len(found) == 1)
+    return found[0]
+
+def positions(rows, component, event):
+    return [row[5] for row in rows if row[0] == component and row[1] == event]
+
+try:
+    case_lines = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+    trace_lines = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+    require("case-count", len(case_lines) == 2)
+    cases = {}
+    for expected_fixture, line in zip(fixtures, case_lines, strict=True):
+        fields = line.split("|")
+        require("case-arity", len(fields) == 5 and fields[0] == "COMMITCASE")
+        _, fixture, requested_text, exit_text, summary = fields
+        require("case-fixture", fixture == expected_fixture and fixture not in cases)
+        values = summary.split(":")
+        require("case-summary-arity", len(values) == 4)
+        total, input_count, output_count = [decimal("case-count-field", value) for value in values[:3]]
+        digest = values[3]
+        require("case-digest-format", len(digest) == 64 and all(char in "0123456789abcdef" for char in digest))
+        cases[fixture] = (decimal("requested-count", requested_text), decimal("process-exit", exit_text),
+                          total, input_count, output_count, digest)
+    require("requested-count", all(case[0] == 1 for case in cases.values()))
+
+    grouped = {fixture: [] for fixture in fixtures}
+    decoded = {fixture: [] for fixture in fixtures}
+    sequences = {}
+    for physical, line in enumerate(trace_lines):
+        fields = line.split("|")
+        require("trace-minimum-arity", len(fields) >= 5)
+        tag, fixture, capture, sequence_text, event = fields[:5]
+        require("trace-component", tag in {"FAILTRACE", "COMMITOUTTRACE"})
+        require("trace-fixture", fixture in grouped)
+        try:
+            parsed_capture = uuid.UUID(capture)
+        except ValueError:
+            raise InvalidEvidence("capture-id")
+        require("capture-id", str(parsed_capture) == capture and parsed_capture.version == 4)
+        component = "input" if tag == "FAILTRACE" else "output"
+        sequence = decimal("capture-sequence", sequence_text)
+        key = (fixture, component, capture)
+        require(f"{component}-sequence-contiguous", sequence == sequences.get(key, 0) + 1)
+        sequences[key] = sequence
+        grammar = input_arity if component == "input" else output_arity
+        numeric = input_numeric if component == "input" else output_numeric
+        require(f"{component}-event-known", event in grammar)
+        require(f"{component}-event-arity", len(fields) == 5 + grammar[event])
+        values = []
+        for index, encoded in enumerate(fields[5:]):
+            if encoded == "-":
+                is_message = event.endswith("runtime-exception") and index == grammar[event] - 1
+                require(f"{component}-null-position", is_message)
+                values.append(None)
+            else:
+                exception_field = event.endswith("runtime-exception") and index >= grammar[event] - 2
+                values.append(decode(f"{component}-canonical-field", encoded,
+                                     numeric=index in numeric.get(event, set()),
+                                     nonempty=exception_field and index == grammar[event] - 2))
+        require("unexpected-callback", not (event.startswith("resume") or event.startswith("guess")
+                                             or event.startswith("add")))
+        grouped[fixture].append(line)
+        decoded[fixture].append((component, event, values, capture, sequence, physical))
+
+    for fixture in fixtures:
+        requested, process_exit, total, input_count, output_count, digest = cases[fixture]
+        raw_rows = grouped[fixture]
+        require("case-total-count-match", len(raw_rows) == total)
+        require("case-component-count-match",
+                sum(row.startswith("FAILTRACE|") for row in raw_rows) == input_count
+                and sum(row.startswith("COMMITOUTTRACE|") for row in raw_rows) == output_count
+                and input_count + output_count == total)
+        material = ("\n".join(raw_rows) + "\n").encode("utf-8")
+        require("case-digest-match", hashlib.sha256(material).hexdigest() == digest)
+        raw_log = root / f"{fixture}.raw.log"
+        require("raw-log-required", raw_log.is_file())
+        extracted = [line for line in raw_log.read_text(encoding="utf-8").splitlines()
+                     if line.startswith("FAILTRACE|") or line.startswith("COMMITOUTTRACE|")]
+        require("raw-log-trace-match", extracted == raw_rows)
+
+        rows = decoded[fixture]
+        input_transaction = only(rows, "input", "transaction-entry", "input-transaction-entry")
+        output_transaction = only(rows, "output", "transaction-entry", "output-transaction-entry")
+        selection = only(rows, "output", "commit-selection", "commit-selection")
+        input_main_capture = input_transaction[3]
+        output_main_capture = output_transaction[3]
+        task_count = decimal("output-task-count", output_transaction[2][0])
+        schema_count = decimal("output-schema-count", output_transaction[2][1])
+        require("positive-output-task-count", task_count > 0)
+        require("bounded-output-task-count", task_count <= len(rows))
+        require("empty-output-schema", schema_count == 0)
+        selected = decimal("selected-index", selection[2][1])
+        require("selection-count", decimal("selection-count", selection[2][0]) == task_count)
+        require("selection-index", selected == task_count - 1)
+        require("selection-capture", selection[3] == output_main_capture)
+        output_chain = ["transaction-entry", "commit-selection", "control-run-before"]
+        output_chain += (["control-run-normal-return", "transaction-normal-return"]
+                         if fixture == "normal" else ["transaction-runtime-exception"])
+        output_chain_rows = [only(rows, "output", event, f"output-{event}") for event in output_chain]
+        require("output-main-capture", all(row[3] == output_main_capture for row in output_chain_rows))
+        require("output-main-order", [row[4] for row in output_chain_rows]
+                == sorted(row[4] for row in output_chain_rows))
+
+        indexed = {"open-entry", "open-normal-return", "finish-entry", "finish-normal-return",
+                   "commit-entry", "commit-injection-before", "commit-normal-return",
+                   "commit-runtime-exception", "abort-entry", "abort-normal-return",
+                   "close-entry", "close-normal-return"}
+        counted = {"transaction-entry", "control-run-before", "control-run-normal-return",
+                   "transaction-normal-return", "cleanup-entry", "cleanup-normal-return"}
+        for component, event, values, capture, sequence, physical in rows:
+            if component == "input" and event in {"transaction-entry", "control-run-before",
+                    "control-run-normal-return", "transaction-normal-return", "cleanup-entry",
+                    "cleanup-normal-return"}:
+                require("input-count-consistency", decimal("input-count", values[0]) == requested)
+            if component == "input" and event in {"run-entry", "finish-before", "finish-normal-return",
+                                                   "run-normal-return", "injection-before"}:
+                require("input-index", decimal("input-index", values[0]) == 0)
+            if component == "output" and event in indexed:
+                require("output-index-range", decimal("output-index", values[0]) < task_count)
+                require("output-schema-consistency", decimal("output-schema", values[1]) == schema_count)
+            if component == "output" and event in counted:
+                require("output-count-consistency", decimal("output-count", values[0]) == task_count)
+                require("output-schema-consistency", decimal("output-schema", values[1]) == schema_count)
+
+        expected_indices = set(range(task_count))
+        opened = {}
+        for row in rows:
+            component, event, values, capture, sequence, physical = row
+            if component != "output" or event not in indexed:
+                continue
+            index = decimal("output-index", values[0])
+            key = (capture, index)
+            if event == "open-normal-return":
+                opened[key] = sequence
+            elif not event.startswith("open"):
+                require("output-prior-open", key in opened and opened[key] < sequence)
+
+        def pair(event, indices):
+            entries = [row for row in rows if row[0] == "output" and row[1] == f"{event}-entry"]
+            returns = [row for row in rows if row[0] == "output" and row[1] == f"{event}-normal-return"]
+            require(f"{event}-entry-indexes", len(entries) == len(indices)
+                    and {decimal("pair-index", row[2][0]) for row in entries} == indices)
+            require(f"{event}-return-indexes", len(returns) == len(indices)
+                    and {decimal("pair-index", row[2][0]) for row in returns} == indices)
+            for entry in entries:
+                index = decimal("pair-index", entry[2][0])
+                returned = next(row for row in returns if decimal("pair-index", row[2][0]) == index)
+                require(f"{event}-callback-pair", entry[2] == returned[2]
+                        and entry[3] == returned[3] and entry[4] < returned[4])
+
+        pair("open", expected_indices)
+        pair("finish", expected_indices)
+        pair("close", expected_indices)
+        for component in ("input", "output"):
+            cleanup_entry = only(rows, component, "cleanup-entry", f"{component}-cleanup-entry")
+            cleanup_return = only(rows, component, "cleanup-normal-return", f"{component}-cleanup-return")
+            require(f"{component}-cleanup-pair", cleanup_entry[3] == cleanup_return[3]
+                    and cleanup_entry[4] < cleanup_return[4])
+            if component == "output":
+                require("output-cleanup-fields", cleanup_entry[2] == cleanup_return[2])
+
+        input_required = {"transaction-entry", "control-run-before", "run-entry", "finish-before",
+                          "finish-normal-return", "run-normal-return", "cleanup-entry", "cleanup-normal-return"}
+        input_names = [row[1] for row in rows if row[0] == "input"]
+        output_names = [row[1] for row in rows if row[0] == "output"]
+        require("input-failure-branch-inactive", "injection-before" not in input_names
+                and "run-runtime-exception" not in input_names)
+        require("input-required", input_required.issubset(input_names))
+        require("input-singletons", all(input_names.count(name) == 1 for name in input_required))
+        input_chain = ["transaction-entry", "control-run-before", "run-entry", "finish-before",
+                       "finish-normal-return", "run-normal-return"]
+        input_chain += (["control-run-normal-return", "transaction-normal-return"]
+                        if fixture == "normal" else ["transaction-runtime-exception"])
+        input_chain_rows = [only(rows, "input", event, f"input-{event}") for event in input_chain]
+        require("input-main-capture", all(row[3] == input_main_capture for row in input_chain_rows))
+        require("input-main-order", [row[4] for row in input_chain_rows]
+                == sorted(row[4] for row in input_chain_rows))
+        commit_entry_positions = positions(rows, "output", "commit-entry")
+        require("commit-entry-required", bool(commit_entry_positions))
+        require("input-finish-before-commit", only(rows, "input", "run-normal-return", "input-run-return")[5]
+                < min(commit_entry_positions))
+        input_run_position = only(rows, "input", "run-entry", "input-run-entry")[5]
+        input_finish_before = only(rows, "input", "finish-before", "input-finish-before")[5]
+        input_finish_return = only(rows, "input", "finish-normal-return", "input-finish-return")[5]
+        require("open-before-input-run", max(positions(rows, "output", "open-normal-return"))
+                < input_run_position)
+        require("output-control-before-open", only(rows, "output", "control-run-before",
+                "output-control-before")[5] < min(positions(rows, "output", "open-entry")))
+        require("output-finish-inside-input-finish", input_finish_before
+                < min(positions(rows, "output", "finish-entry"))
+                and max(positions(rows, "output", "finish-normal-return")) < input_finish_return)
+
+        if fixture == "normal":
+            require("normal-process-success", process_exit == 0)
+            require("normal-no-exception", not any(name.endswith("runtime-exception") for name in input_names + output_names))
+            require("normal-no-injection", "commit-injection-before" not in output_names)
+            pair("commit", expected_indices)
+            pair("abort", set())
+            require("normal-output-scope", output_names.count("control-run-normal-return") == 1
+                    and output_names.count("transaction-normal-return") == 1)
+            require("normal-input-scope", input_names.count("control-run-normal-return") == 1
+                    and input_names.count("transaction-normal-return") == 1)
+            output_reports = only(rows, "output", "cleanup-entry", "output-cleanup-entry")[2][2]
+            input_reports = only(rows, "input", "cleanup-entry", "input-cleanup-entry")[2][1]
+            require("normal-cleanup-reports", decimal("input-reports", input_reports) == 1
+                    and decimal("output-reports", output_reports) == task_count)
+            require("normal-control-reports",
+                    decimal("control-reports", only(rows, "output", "control-run-normal-return",
+                            "output-control-return")[2][2]) == task_count
+                    and decimal("transaction-reports", only(rows, "output", "transaction-normal-return",
+                            "output-transaction-return")[2][2]) == task_count)
+            require("normal-close-after-commit",
+                    max(positions(rows, "output", "commit-normal-return"))
+                    < min(positions(rows, "output", "close-entry")))
+            output_scope = only(rows, "output", "transaction-normal-return", "output-scope-return")
+            output_control = only(rows, "output", "control-run-normal-return", "output-control-return-order")
+            input_control = only(rows, "input", "control-run-normal-return", "input-control-return")
+            input_scope = only(rows, "input", "transaction-normal-return", "input-scope-return")
+            require("normal-scope-physical-order",
+                    max(positions(rows, "output", "close-normal-return")) < output_control[5]
+                    < output_scope[5] < input_control[5] < input_scope[5])
+        else:
+            require("failure-process-nonzero", process_exit != 0)
+            require("failure-no-normal-scopes", "control-run-normal-return" not in input_names
+                    and "transaction-normal-return" not in input_names
+                    and "control-run-normal-return" not in output_names
+                    and "transaction-normal-return" not in output_names)
+            injection = only(rows, "output", "commit-injection-before", "failure-injection")
+            commit_failure = only(rows, "output", "commit-runtime-exception", "commit-exception")
+            require("failure-selected-index", decimal("injection-index", injection[2][0]) == selected
+                    and decimal("exception-index", commit_failure[2][0]) == selected)
+            require("failure-exact-error", commit_failure[2][2:] == [injected_class, injected_message])
+            commit_entries = [decimal("commit-index", row[2][0]) for row in rows
+                              if row[0] == "output" and row[1] == "commit-entry"]
+            commit_returns = [decimal("commit-index", row[2][0]) for row in rows
+                              if row[0] == "output" and row[1] == "commit-normal-return"]
+            require("failure-commit-entries", len(commit_entries) == task_count and set(commit_entries) == expected_indices)
+            require("failure-other-commit-returns", len(commit_returns) == task_count - 1
+                    and set(commit_returns) == expected_indices - {selected})
+            require("failure-selected-no-normal-return", selected not in commit_returns)
+            for index in expected_indices - {selected}:
+                entries = [row for row in rows if row[0] == "output" and row[1] == "commit-entry"
+                           and decimal("commit-index", row[2][0]) == index]
+                returns = [row for row in rows if row[0] == "output" and row[1] == "commit-normal-return"
+                           and decimal("commit-index", row[2][0]) == index]
+                require("failure-other-commit-pair", len(entries) == 1 and len(returns) == 1
+                        and entries[0][2] == returns[0][2] and entries[0][3] == returns[0][3]
+                        and entries[0][4] < returns[0][4])
+            commit_entry = next(row for row in rows if row[0] == "output" and row[1] == "commit-entry"
+                                and decimal("commit-index", row[2][0]) == selected)
+            require("failure-commit-terminal", commit_entry[3] == injection[3] == commit_failure[3]
+                    and commit_entry[4] < injection[4] < commit_failure[4])
+            pair("abort", {selected})
+            output_error = only(rows, "output", "transaction-runtime-exception", "output-transaction-error")
+            input_error = only(rows, "input", "transaction-runtime-exception", "input-transaction-error")
+            require("failure-outer-errors", output_error[2] == [injected_class, injected_message]
+                    and input_error[2] == [injected_class, injected_message])
+            require("failure-physical-order", commit_failure[5]
+                    < only(rows, "output", "abort-entry", "abort-entry")[5]
+                    < only(rows, "output", "abort-normal-return", "abort-return")[5]
+                    < min(positions(rows, "output", "close-entry"))
+                    and max(positions(rows, "output", "close-normal-return")) < output_error[5] < input_error[5])
+            input_cleanup = only(rows, "input", "cleanup-entry", "input-cleanup-entry")
+            output_cleanup = only(rows, "output", "cleanup-entry", "output-cleanup-entry")
+            require("failure-fresh-cleanup-captures", input_cleanup[3] != input_main_capture
+                    and output_cleanup[3] != output_main_capture)
+            require("failure-cleanup-reports", decimal("input-reports", input_cleanup[2][1]) == 1
+                    and decimal("output-reports", output_cleanup[2][2]) == task_count - 1)
+            successful_commit_positions = positions(rows, "output", "commit-normal-return")
+            require("failure-other-commits-before-selected", not successful_commit_positions
+                    or max(successful_commit_positions) < commit_entry[5])
+            output_scope, input_scope = output_error, input_error
+        input_cleanup = only(rows, "input", "cleanup-entry", "input-cleanup-order")
+        input_cleanup_return = only(rows, "input", "cleanup-normal-return", "input-cleanup-return-order")
+        output_cleanup = only(rows, "output", "cleanup-entry", "output-cleanup-order")
+        output_cleanup_return = only(rows, "output", "cleanup-normal-return", "output-cleanup-return-order")
+        require("cleanup-physical-order", output_scope[5] < input_scope[5] < input_cleanup[5]
+                < input_cleanup_return[5] < output_cleanup[5] < output_cleanup_return[5])
+except (InvalidEvidence, OSError, UnicodeError) as error:
+    label = error.args[0] if error.args else "unclassified"
+    print(f"VALIDATION_ERROR|{label}", file=sys.stderr)
+    sys.exit(4)
+PY
+}
+
+validate "$evidence"
+
+mutated_copy() {
+  local mutation=$1 copy
+  copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-commit-validator.XXXXXX")
+  cp "$evidence/cases.raw" "$evidence/traces.raw" "$evidence/normal.raw.log" \
+    "$evidence/commit-failure.raw.log" "$copy/"
+  python3 - "$mutation" "$copy" <<'PY'
+import base64
+import hashlib
+import pathlib
+import sys
+
+action, directory = sys.argv[1:]
+root = pathlib.Path(directory)
+cases = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+traces = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+
+def find(fixture, tag, event):
+    return next(index for index, row in enumerate(traces)
+                if row.startswith(f"{tag}|{fixture}|") and row.split("|")[4] == event)
+
+def renumber(fixture, tag, capture):
+    sequence = 0
+    for index, row in enumerate(traces):
+        fields = row.split("|")
+        if len(fields) >= 5 and fields[0] == tag and fields[1] == fixture and fields[2] == capture:
+            sequence += 1
+            fields[3] = str(sequence)
+            traces[index] = "|".join(fields)
+
+def remove(fixture, tag, event):
+    index = find(fixture, tag, event)
+    capture = traces[index].split("|")[2]
+    traces.pop(index)
+    renumber(fixture, tag, capture)
+
+def insert_after(fixture, tag, event, row):
+    index = find(fixture, tag, event)
+    capture = traces[index].split("|")[2]
+    traces.insert(index + 1, row)
+    renumber(fixture, tag, capture)
+
+def encoded(text):
+    return base64.b64encode(text.encode()).decode()
+
+if action == "missing-injection":
+    remove("commit-failure", "COMMITOUTTRACE", "commit-injection-before")
+elif action == "duplicate-injection":
+    index = find("commit-failure", "COMMITOUTTRACE", "commit-injection-before")
+    insert_after("commit-failure", "COMMITOUTTRACE", "commit-injection-before", traces[index])
+elif action == "wrong-selection":
+    index = find("commit-failure", "COMMITOUTTRACE", "commit-selection")
+    fields = traces[index].split("|"); fields[6] = fields[5]; traces[index] = "|".join(fields)
+elif action in {"wrong-class", "wrong-message"}:
+    for event in ("commit-runtime-exception", "transaction-runtime-exception"):
+        tags = ("COMMITOUTTRACE",) if event == "commit-runtime-exception" else ("COMMITOUTTRACE", "FAILTRACE")
+        for tag in tags:
+            index = find("commit-failure", tag, event)
+            fields = traces[index].split("|")
+            target = -2 if action == "wrong-class" else -1
+            fields[target] = encoded("java.lang.RuntimeException" if action == "wrong-class" else "changed")
+            traces[index] = "|".join(fields)
+elif action == "fabricated-normal-return":
+    failure = traces[find("commit-failure", "COMMITOUTTRACE", "commit-runtime-exception")].split("|")
+    row = "|".join(failure[:4] + ["commit-normal-return"] + failure[5:7])
+    insert_after("commit-failure", "COMMITOUTTRACE", "commit-runtime-exception", row)
+elif action == "missing-terminal":
+    remove("commit-failure", "COMMITOUTTRACE", "commit-runtime-exception")
+elif action == "missing-abort":
+    remove("commit-failure", "COMMITOUTTRACE", "abort-normal-return")
+elif action == "missing-close":
+    remove("commit-failure", "COMMITOUTTRACE", "close-normal-return")
+elif action == "reversed-successful-commit":
+    entry = find("commit-failure", "COMMITOUTTRACE", "commit-entry")
+    returned = find("commit-failure", "COMMITOUTTRACE", "commit-normal-return")
+    row = traces.pop(returned)
+    if returned < entry:
+        entry -= 1
+    traces.insert(entry, row)
+    renumber("commit-failure", "COMMITOUTTRACE", row.split("|")[2])
+elif action == "early-cleanup":
+    entry = find("commit-failure", "FAILTRACE", "cleanup-entry")
+    returned = find("commit-failure", "FAILTRACE", "cleanup-normal-return")
+    pair = [traces[entry], traces[returned]]
+    for index in sorted((entry, returned), reverse=True):
+        traces.pop(index)
+    target = find("commit-failure", "FAILTRACE", "transaction-runtime-exception")
+    traces[target:target] = pair
+elif action == "reordered-scope":
+    control = find("normal", "COMMITOUTTRACE", "control-run-normal-return")
+    transaction = find("normal", "COMMITOUTTRACE", "transaction-normal-return")
+    row = traces.pop(transaction)
+    if transaction < control:
+        control -= 1
+    traces.insert(control, row)
+    renumber("normal", "COMMITOUTTRACE", row.split("|")[2])
+elif action == "sequence":
+    index = find("commit-failure", "COMMITOUTTRACE", "commit-entry")
+    fields = traces[index].split("|"); fields[3] = "1"; traces[index] = "|".join(fields)
+elif action == "capture":
+    index = find("commit-failure", "COMMITOUTTRACE", "commit-injection-before")
+    fields = traces[index].split("|"); fields[2] = "not-a-uuid"; traces[index] = "|".join(fields)
+elif action == "malformed":
+    index = find("normal", "COMMITOUTTRACE", "commit-entry")
+    fields = traces[index].split("|"); fields[5] = "!"; traces[index] = "|".join(fields)
+elif action == "unknown":
+    index = find("normal", "COMMITOUTTRACE", "commit-entry")
+    fields = traces[index].split("|"); fields[4] = "invented"; traces[index] = "|".join(fields)
+elif action in {"add", "resume"}:
+    transaction = traces[find("normal", "COMMITOUTTRACE", "transaction-entry")].split("|")
+    event = "add-entry" if action == "add" else "resume-entry"
+    row = "|".join(transaction[:4] + [event, encoded("0"), encoded("0")])
+    insert_after("normal", "COMMITOUTTRACE", "transaction-entry", row)
+elif action == "contradictory-transaction":
+    error = traces[find("commit-failure", "COMMITOUTTRACE", "transaction-runtime-exception")].split("|")
+    selection = traces[find("commit-failure", "COMMITOUTTRACE", "commit-selection")].split("|")
+    cleanup = traces[find("commit-failure", "COMMITOUTTRACE", "cleanup-entry")].split("|")
+    row = "|".join(error[:4] + ["transaction-normal-return", selection[5], encoded("0"), cleanup[-1]])
+    insert_after("commit-failure", "COMMITOUTTRACE", "transaction-runtime-exception", row)
+
+def synchronize():
+    for fixture in ("normal", "commit-failure"):
+        rows = [row for row in traces if row.split("|")[1] == fixture]
+        log = root / f"{fixture}.raw.log"
+        other = [line for line in log.read_text(encoding="utf-8").splitlines()
+                 if not line.startswith("FAILTRACE|") and not line.startswith("COMMITOUTTRACE|")]
+        log.write_text("\n".join(rows + other) + "\n", encoding="utf-8")
+        index = next(i for i, row in enumerate(cases) if row.startswith(f"COMMITCASE|{fixture}|"))
+        fields = cases[index].split("|")
+        input_count = sum(row.startswith("FAILTRACE|") for row in rows)
+        output_count = sum(row.startswith("COMMITOUTTRACE|") for row in rows)
+        digest = hashlib.sha256(("\n".join(rows) + "\n").encode()).hexdigest()
+        fields[4] = f"{len(rows)}:{input_count}:{output_count}:{digest}"
+        cases[index] = "|".join(fields)
+
+if action == "hash":
+    fields = cases[0].split("|"); summary = fields[4].split(":"); summary[3] = "0" * 64
+    fields[4] = ":".join(summary); cases[0] = "|".join(fields)
+elif action == "raw-log":
+    log = root / "commit-failure.raw.log"
+    log.write_text(log.read_text(encoding="utf-8").replace("COMMITOUTTRACE|", "BROKEN|", 1), encoding="utf-8")
+else:
+    synchronize()
+
+root.joinpath("cases.raw").write_text("\n".join(cases) + "\n", encoding="utf-8")
+root.joinpath("traces.raw").write_text("\n".join(traces) + "\n", encoding="utf-8")
+PY
+  printf '%s\n' "$copy"
+}
+
+validator_fails() {
+  local mutation=$1 expected=$2 copy result result_code
+  copy=$(mutated_copy "$mutation")
+  printf 'T0013_COMMIT_MUTATION=%s|evidence=%s\n' "$mutation" "$copy"
+  if result=$(validate "$copy" 2>&1); then
+    exit 1
+  else
+    result_code=$?
+  fi
+  [[ "$result_code" == 4 ]] || exit 1
+  [[ "$result" == "VALIDATION_ERROR|$expected" ]] || {
+    printf 'unexpected validator result for %s: %s\n' "$mutation" "$result" >&2
+    exit 1
+  }
+}
+
+validator_fails missing-injection failure-injection
+validator_fails duplicate-injection failure-injection
+validator_fails wrong-selection selection-index
+validator_fails wrong-class failure-exact-error
+validator_fails wrong-message failure-exact-error
+validator_fails fabricated-normal-return failure-other-commit-returns
+validator_fails missing-terminal commit-exception
+validator_fails missing-abort abort-return-indexes
+validator_fails missing-close close-return-indexes
+validator_fails reversed-successful-commit failure-other-commit-pair
+validator_fails early-cleanup cleanup-physical-order
+validator_fails reordered-scope output-main-order
+validator_fails sequence output-sequence-contiguous
+validator_fails capture capture-id
+validator_fails malformed output-canonical-field
+validator_fails hash case-digest-match
+validator_fails raw-log raw-log-trace-match
+validator_fails unknown output-event-known
+validator_fails add unexpected-callback
+validator_fails resume unexpected-callback
+validator_fails contradictory-transaction failure-no-normal-scopes
+
+printf 'T0013_COMMIT_FULL_PROBE=passed|evidence=%s\n' "$evidence"

--- a/tools/t0013-output-commit-failure/run.sh
+++ b/tools/t0013-output-commit-failure/run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+input_src="$root/tools/t0013-input-failure/src/T0013FailureInputPlugin.java"
+output_src="$root/tools/t0013-output-commit-failure/src/T0013CommitFailureOutputPlugin.java"
+url=https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
+expected_sha=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
+tmp=$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-output-commit-failure.XXXXXX")
+evidence="$tmp/evidence"
+input_repo="$tmp/home/lib/m2/repository/org/embulk/t0013/s05/embulk-input-t0013s05input/0.0.1"
+output_repo="$tmp/home/lib/m2/repository/org/embulk/t0013/s05/embulk-output-t0013s05output/0.0.1"
+mkdir -p "$evidence" "$tmp/input-classes" "$tmp/output-classes" "$input_repo" "$output_repo"
+trap 'printf "T0013_COMMIT_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
+
+jarfile="$tmp/embulk.jar"
+if [[ ${T0013_COMMIT_NEGATIVE:-} == unavailable-asset ]]; then
+  url=https://github.com/embulk/embulk/releases/download/v0.11.5/unavailable.jar
+fi
+printf '%s\n' "$url" > "$evidence/executable-url.txt"
+if ! curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error -o "$jarfile" "$url"; then
+  if [[ ${T0013_COMMIT_NEGATIVE:-} == unavailable-asset ]]; then
+    printf '%s\n' unavailable-asset-request-failed > "$evidence/negative-control.txt"
+  fi
+  exit 56
+fi
+if [[ ${T0013_COMMIT_NEGATIVE:-} == corrupt-copy ]]; then
+  printf corrupt >> "$jarfile"
+  printf '%s\n' corrupt-copy-injected > "$evidence/negative-control.txt"
+fi
+actual_sha=$(shasum -a 256 "$jarfile" | awk '{print $1}')
+printf '%s\n' "$actual_sha" > "$evidence/executable.sha256"
+[[ "$actual_sha" == "$expected_sha" ]] || exit 3
+
+shasum -a 256 "$input_src" | awk '{print $1}' > "$evidence/input-source.sha256"
+shasum -a 256 "$output_src" | awk '{print $1}' > "$evidence/output-source.sha256"
+printf '%s\n' 'tools/t0013-input-failure/src/T0013FailureInputPlugin.java' > "$evidence/input-source-path.txt"
+if diff -u "$root/tools/t0013-input-failure/src/T0013FailureOutputPlugin.java" "$output_src" \
+    > "$evidence/output-source-vs-s03.diff"; then
+  exit 4
+else
+  diff_code=$?
+  [[ "$diff_code" == 1 ]] || exit "$diff_code"
+fi
+unzip -p "$jarfile" META-INF/LICENSE > "$evidence/LICENSE-executable" || [[ -s "$evidence/LICENSE-executable" ]]
+unzip -p "$jarfile" META-INF/NOTICE > "$evidence/NOTICE-executable" || [[ -s "$evidence/NOTICE-executable" ]]
+java -XshowSettings:properties -version > "$evidence/java-version.txt" 2>&1
+
+javac -cp "$jarfile" -d "$tmp/input-classes" "$input_src"
+javac -cp "$jarfile" -d "$tmp/output-classes" "$output_src"
+printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0013FailureInputPlugin' \
+  'Embulk-Plugin-Category: input' 'Embulk-Plugin-Type: t0013s05input' \
+  'Embulk-Plugin-Spi-Version: 0' > "$tmp/INPUT.MF"
+jar cfm "$input_repo/embulk-input-t0013s05input-0.0.1.jar" "$tmp/INPUT.MF" -C "$tmp/input-classes" .
+printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0013CommitFailureOutputPlugin' \
+  'Embulk-Plugin-Category: output' 'Embulk-Plugin-Type: t0013s05output' \
+  'Embulk-Plugin-Spi-Version: 0' > "$tmp/OUTPUT.MF"
+jar cfm "$output_repo/embulk-output-t0013s05output-0.0.1.jar" "$tmp/OUTPUT.MF" -C "$tmp/output-classes" .
+
+shasum -a 256 "$input_repo/embulk-input-t0013s05input-0.0.1.jar" | awk '{print $1}' > "$evidence/input-jar.sha256"
+shasum -a 256 "$output_repo/embulk-output-t0013s05output-0.0.1.jar" | awk '{print $1}' > "$evidence/output-jar.sha256"
+printf '%s\n' 'source=maven|group=org.embulk.t0013.s05|name=t0013s05input|version=0.0.1|artifact=embulk-input-t0013s05input|category=input|local-only' > "$evidence/input-coordinate.txt"
+printf '%s\n' 'source=maven|group=org.embulk.t0013.s05|name=t0013s05output|version=0.0.1|artifact=embulk-output-t0013s05output|category=output|local-only' > "$evidence/output-coordinate.txt"
+printf '%s' '<project><modelVersion>4.0.0</modelVersion></project>' > "$input_repo/embulk-input-t0013s05input-0.0.1.pom"
+printf '%s' '<project><modelVersion>4.0.0</modelVersion></project>' > "$output_repo/embulk-output-t0013s05output-0.0.1.pom"
+
+: > "$evidence/traces.raw"
+: > "$evidence/cases.raw"
+for fixture in normal commit-failure; do
+  requested=1
+  log="$evidence/$fixture.raw.log"
+  config="$tmp/$fixture.yml"
+  case_trace="$tmp/$fixture.trace"
+  printf '%s\n' \
+    'in:' \
+    '  type:' \
+    '    source: maven' \
+    '    group: org.embulk.t0013.s05' \
+    '    name: t0013s05input' \
+    '    version: 0.0.1' \
+    'out:' \
+    '  type:' \
+    '    source: maven' \
+    '    group: org.embulk.t0013.s05' \
+    '    name: t0013s05output' \
+    '    version: 0.0.1' > "$config"
+  if T0013_FIXTURE="$fixture" T0013_TASK_COUNT="$requested" \
+    java -jar "$jarfile" "-Xembulk_home=$tmp/home" run "$config" > "$log" 2>&1; then
+    process_exit=0
+  else
+    process_exit=$?
+  fi
+  awk '/^(FAILTRACE|COMMITOUTTRACE)\|/' "$log" > "$case_trace"
+  cat "$case_trace" >> "$evidence/traces.raw"
+  digest=$(shasum -a 256 "$case_trace" | awk '{print $1}')
+  total=$(wc -l < "$case_trace" | tr -d ' ')
+  input_count=$(awk '/^FAILTRACE\|/ {count++} END {print count + 0}' "$case_trace")
+  output_count=$(awk '/^COMMITOUTTRACE\|/ {count++} END {print count + 0}' "$case_trace")
+  printf 'COMMITCASE|%s|%s|%s|%s:%s:%s:%s\n' "$fixture" "$requested" "$process_exit" \
+    "$total" "$input_count" "$output_count" "$digest" >> "$evidence/cases.raw"
+done
+cat "$evidence/cases.raw"

--- a/tools/t0013-output-commit-failure/src/T0013CommitFailureOutputPlugin.java
+++ b/tools/t0013-output-commit-failure/src/T0013CommitFailureOutputPlugin.java
@@ -1,0 +1,183 @@
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Exec;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.Page;
+import org.embulk.spi.Schema;
+import org.embulk.spi.TransactionalPageOutput;
+
+/** Local-only T-0013/S05 output commit failure observation probe. */
+public final class T0013CommitFailureOutputPlugin implements OutputPlugin {
+    private static final String INJECTED_MESSAGE = "t0013-output-commit-failure";
+    private static final String CAPTURE_ID = UUID.randomUUID().toString();
+    private static volatile int selectedCommitIndex = -1;
+    private static long sequence;
+
+    @Override
+    public ConfigDiff transaction(ConfigSource config, Schema schema, int taskCount, Control control) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace(fixture, "transaction-entry", count, columns);
+        if (taskCount <= 0) {
+            throw new InstrumentationError("output task count is not positive");
+        }
+        selectedCommitIndex = taskCount - 1;
+        trace(fixture, "commit-selection", count, Integer.toString(selectedCommitIndex));
+        TaskSource outputTaskSource = Exec.newTaskSource();
+        trace(fixture, "control-run-before", count, columns);
+        List<TaskReport> reports = runControl(fixture, "transaction-runtime-exception", control, outputTaskSource);
+        if (reports == null) {
+            throw new InstrumentationError("output control returned null reports");
+        }
+        trace(fixture, "control-run-normal-return", count, columns, Integer.toString(reports.size()));
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "transaction-normal-return", count, columns, Integer.toString(reports.size()));
+        return result;
+    }
+
+    @Override
+    public ConfigDiff resume(TaskSource taskSource, Schema schema, int taskCount, Control control) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace(fixture, "resume-entry", count, columns);
+        trace(fixture, "resume-control-run-before", count, columns);
+        List<TaskReport> reports = runControl(fixture, "resume-runtime-exception", control, taskSource);
+        if (reports == null) {
+            throw new InstrumentationError("output resume control returned null reports");
+        }
+        trace(fixture, "resume-control-run-normal-return", count, columns, Integer.toString(reports.size()));
+        ConfigDiff result = Exec.newConfigDiff();
+        trace(fixture, "resume-normal-return", count, columns, Integer.toString(reports.size()));
+        return result;
+    }
+
+    @Override
+    public void cleanup(TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> reports) {
+        String fixture = fixture();
+        String count = Integer.toString(taskCount);
+        String columns = Integer.toString(schema.getColumnCount());
+        String reportCount = Integer.toString(reports.size());
+        trace(fixture, "cleanup-entry", count, columns, reportCount);
+        trace(fixture, "cleanup-normal-return", count, columns, reportCount);
+    }
+
+    @Override
+    public TransactionalPageOutput open(TaskSource taskSource, Schema schema, int taskIndex) {
+        String fixture = fixture();
+        String index = Integer.toString(taskIndex);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace(fixture, "open-entry", index, columns);
+        TransactionalPageOutput result = new ObservedPageOutput(fixture, taskIndex, schema.getColumnCount());
+        trace(fixture, "open-normal-return", index, columns);
+        return result;
+    }
+
+    private static List<TaskReport> runControl(
+            String fixture, String exceptionEvent, Control control, TaskSource taskSource) {
+        RuntimeException operationFailure = null;
+        List<TaskReport> reports = null;
+        try {
+            reports = control.run(taskSource);
+        } catch (RuntimeException failure) {
+            operationFailure = failure;
+        }
+        if (operationFailure != null) {
+            trace(fixture, exceptionEvent, operationFailure.getClass().getName(),
+                    operationFailure.getMessage());
+            throw operationFailure;
+        }
+        return reports;
+    }
+
+    private static final class ObservedPageOutput implements TransactionalPageOutput {
+        private final String fixture;
+        private final int taskIndex;
+        private final String index;
+        private final String columns;
+
+        private ObservedPageOutput(String fixture, int taskIndex, int columnCount) {
+            this.fixture = fixture;
+            this.taskIndex = taskIndex;
+            this.index = Integer.toString(taskIndex);
+            this.columns = Integer.toString(columnCount);
+        }
+
+        @Override
+        public void add(Page page) {
+            trace(fixture, "add-entry", index, columns);
+            trace(fixture, "add-normal-return", index, columns);
+        }
+
+        @Override
+        public void finish() {
+            trace(fixture, "finish-entry", index, columns);
+            trace(fixture, "finish-normal-return", index, columns);
+        }
+
+        @Override
+        public TaskReport commit() {
+            trace(fixture, "commit-entry", index, columns);
+            if ("commit-failure".equals(fixture) && taskIndex == selectedCommitIndex) {
+                trace(fixture, "commit-injection-before", index, columns);
+                InjectedCommitFailure failure = new InjectedCommitFailure(INJECTED_MESSAGE);
+                trace(fixture, "commit-runtime-exception", index, columns,
+                        failure.getClass().getName(), failure.getMessage());
+                throw failure;
+            }
+            TaskReport result = Exec.newTaskReport();
+            trace(fixture, "commit-normal-return", index, columns);
+            return result;
+        }
+
+        @Override
+        public void abort() {
+            trace(fixture, "abort-entry", index, columns);
+            trace(fixture, "abort-normal-return", index, columns);
+        }
+
+        @Override
+        public void close() {
+            trace(fixture, "close-entry", index, columns);
+            trace(fixture, "close-normal-return", index, columns);
+        }
+    }
+
+    private static String fixture() {
+        return System.getenv("T0013_FIXTURE");
+    }
+
+    private static synchronized void trace(String fixture, String event, String... fields) {
+        StringBuilder line = new StringBuilder("COMMITOUTTRACE|").append(fixture).append('|')
+                .append(CAPTURE_ID).append('|').append(++sequence).append('|').append(event);
+        for (String field : fields) {
+            line.append('|').append(field == null ? "-" : Base64.getEncoder()
+                    .encodeToString(field.getBytes(StandardCharsets.UTF_8)));
+        }
+        System.out.println(line);
+        if (System.out.checkError()) {
+            throw new InstrumentationError("output trace failed");
+        }
+    }
+
+    /** Original exception used only by the bounded selected commit fixture. */
+    public static final class InjectedCommitFailure extends RuntimeException {
+        private InjectedCommitFailure(String message) {
+            super(message);
+        }
+    }
+
+    private static final class InstrumentationError extends Error {
+        private InstrumentationError(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
Refs #16. Implements the exact packet in docs/provenance/T-0013-output-commit-failure-probe.md. Reuses unchanged S03 input and one new original output fixture with dynamic last-index commit injection. PM interpreted first raw failure before fixing acceptance expectations. Primary and independent Tester passed at 876e861: exact Demo normal exit0/failure exit1, 21 targeted evidence controls plus 2 executable controls, separate syntax and diff checks. Failure aborts only selected handle, closes all, retains observed input1/output7 cleanup reports for local 1/8 plan. Reference Observation / Integration only; no Rust policy, durable publication, rollback, arbitrary-index or Differential claim. Includes PR #74 closeout and forecast refinement Current21/Initial8. Parent #16 remains open. Final-head acceptance precedes integration.