### PR TITLE
feat(t-0021): retain reports on selected last commit failure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S05` is `Review` (PR #75); `T-0012`, `T-0021` and all other unfinished items
+`T-0021/S04` is `In Progress`; `T-0012`, `T-0013` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S05: output commit failure observation) | Review | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S05 integrated; remaining contracts queued) | Backlog | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -43,7 +43,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
-| T-0021 | Define workspace boundaries and core traits (S01–S03 integrated; remaining contracts queued) | Backlog | P1 | 5 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
+| T-0021 | Define workspace boundaries and core traits (S04: private last-commit failure) | In Progress | P1 | 8 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
@@ -232,5 +232,14 @@ points are implied. Combined WIP stays one.
 
 S05 primary acceptance at `876e861` passed both live fixtures, 21 targeted
 evidence controls and two executable controls, separate shell syntax and diff
-checks. Independent Tester reproduced these results; integration remains pending. Only selected
+checks. Independent Tester reproduced these results; final-head acceptance at
+`6508221` passed and PR #75 integrated as `2901c31`. Only selected
 last-index reference observations are claimed, not general commit handling.
+
+T-0021/S04 (3 SP) is active under ADR-0009 and its
+[packet](docs/provenance/T-0021-last-commit-failure.md): typed last-commit failure
+and retained actual reports, preserving the two existing live projections.
+Current parent SP is refined 5 to 8 for added implementation/regression work;
+Initial SP stays 5. T-0013 returns to Backlog for its next comparison and
+remaining index/recovery contracts. Combined WIP stays one; no parent completion
+or new output-failure Differential result is claimed.

--- a/TODO.md
+++ b/TODO.md
@@ -243,3 +243,8 @@ Current parent SP is refined 5 to 8 for added implementation/regression work;
 Initial SP stays 5. T-0013 returns to Backlog for its next comparison and
 remaining index/recovery contracts. Combined WIP stays one; no parent completion
 or new output-failure Differential result is claimed.
+
+S04 source acceptance at `b8dbc77` passes primary and independent Tester checks:
+seven local tests, two existing live projections, 13 negative controls,
+workspace 21 passed/three intentional ignores, formatting and strict Clippy.
+Evidence is Unit/Contract plus existing regression; PR integration is pending.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0021/S04` is `In Progress`; `T-0012`, `T-0013` and all other unfinished items
+`T-0021/S04` is `Review` in PR #76; `T-0012`, `T-0013` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -43,7 +43,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
-| T-0021 | Define workspace boundaries and core traits (S04: private last-commit failure) | In Progress | P1 | 8 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
+| T-0021 | Define workspace boundaries and core traits (S04: private last-commit failure) | Review | P1 | 8 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |

--- a/crates/emburk-core/src/empty_lifecycle.rs
+++ b/crates/emburk-core/src/empty_lifecycle.rs
@@ -1,8 +1,8 @@
-//! A deliberately small, infallible-fixture lifecycle boundary.
+//! A deliberately small, limited-fallibility fixture lifecycle boundary.
 //!
-//! Only the input callback can fail here. Setup, output operations, scope
-//! teardown, and cleanup are infallible by design for these test fakes; this
-//! is not a production plugin trait.
+//! Only input run and the selected last output commit can fail here. Setup,
+//! other output operations, scope teardown, and cleanup are infallible by
+//! design for these test fakes; this is not a production plugin trait.
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct EmptyPlan {
@@ -32,9 +32,17 @@ struct ReportToken(String);
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct InputFailure(String);
 #[derive(Clone, Debug, Eq, PartialEq)]
+struct OutputFailure(String);
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CallbackFailure {
+    Input(InputFailure),
+    Output(OutputFailure),
+}
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum CoordinatorError {
     InvalidPlan(PlanError),
     InputFailed(InputFailure),
+    OutputFailed(OutputFailure),
 }
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct CleanupContext {
@@ -44,7 +52,7 @@ struct CleanupContext {
 
 trait EmptyOutputHandle {
     fn finish(&mut self);
-    fn commit(&mut self) -> ReportToken;
+    fn commit(&mut self) -> Result<ReportToken, OutputFailure>;
     fn abort(&mut self);
     fn close(&mut self);
 }
@@ -53,15 +61,15 @@ trait EmptyOutput {
     fn open_job(&mut self);
     fn open_control(&mut self);
     fn open_task(&self, task_index: usize) -> Self::Handle;
-    fn close_control(&mut self, outcome: &Result<(), InputFailure>);
-    fn close_job(&mut self, outcome: &Result<(), InputFailure>);
+    fn close_control(&mut self, outcome: &Result<(), CallbackFailure>);
+    fn close_job(&mut self, outcome: &Result<(), CallbackFailure>);
 }
 trait EmptyInput<H: EmptyOutputHandle> {
     fn open_job(&mut self);
     fn open_control(&mut self);
     fn run(&mut self, outputs: &mut [H]) -> Result<ReportToken, InputFailure>;
-    fn close_control(&mut self, outcome: &Result<(), InputFailure>);
-    fn close_job(&mut self, outcome: &Result<(), InputFailure>);
+    fn close_control(&mut self, outcome: &Result<(), CallbackFailure>);
+    fn close_job(&mut self, outcome: &Result<(), CallbackFailure>);
 }
 /// Cleanup is intentionally a distinct capability from either live job.
 trait EmptyInputCleanup {
@@ -100,11 +108,31 @@ where
     };
     let (outcome, input_reports, output_reports) = match input_result {
         Ok(input_report) => {
-            let output_reports = handles.iter_mut().map(EmptyOutputHandle::commit).collect();
+            let mut output_reports = Vec::new();
+            let mut output_failure = None;
+            for handle in &mut handles {
+                // This private boundary is exercised only for a fake's selected
+                // last-index failure; it does not establish earlier/middle policy.
+                match handle.commit() {
+                    Ok(report) => output_reports.push(report),
+                    Err(failure) => {
+                        handle.abort();
+                        output_failure = Some(failure);
+                        break;
+                    }
+                }
+            }
             for handle in &mut handles {
                 handle.close();
             }
-            (Ok(()), input_report.into_iter().collect(), output_reports)
+            match output_failure {
+                Some(failure) => (
+                    Err(CallbackFailure::Output(failure)),
+                    input_report.into_iter().collect(),
+                    output_reports,
+                ),
+                None => (Ok(()), input_report.into_iter().collect(), output_reports),
+            }
         }
         Err(failure) => {
             for handle in &mut handles {
@@ -113,7 +141,7 @@ where
             for handle in &mut handles {
                 handle.close();
             }
-            (Err(failure), Vec::new(), Vec::new())
+            (Err(CallbackFailure::Input(failure)), Vec::new(), Vec::new())
         }
     };
     // No live task handles or transaction mutable state enter cleanup.
@@ -130,7 +158,10 @@ where
         plan,
         reports: output_reports,
     });
-    outcome.map_err(CoordinatorError::InputFailed)
+    outcome.map_err(|failure| match failure {
+        CallbackFailure::Input(failure) => CoordinatorError::InputFailed(failure),
+        CallbackFailure::Output(failure) => CoordinatorError::OutputFailed(failure),
+    })
 }
 
 #[cfg(test)]
@@ -140,7 +171,7 @@ mod tests {
     #[derive(Clone, Debug, Eq, PartialEq)]
     enum ScopeOutcome {
         Normal,
-        Failed,
+        Failed(CallbackFailure),
     }
     #[derive(Clone, Debug, Eq, PartialEq)]
     enum Event {
@@ -156,6 +187,7 @@ mod tests {
         OutputTaskOpened(usize),
         OutputTaskFinished(usize),
         OutputTaskCommitted(usize),
+        OutputTaskCommitFailed(usize, OutputFailure),
         OutputTaskAborted(usize),
         OutputTaskClosed(usize),
         OutputControlClosed(ScopeOutcome),
@@ -163,12 +195,17 @@ mod tests {
         InputCleaned,
         OutputCleaned,
     }
-    fn outcome_event(outcome: &Result<(), InputFailure>) -> ScopeOutcome {
-        if outcome.is_ok() {
-            ScopeOutcome::Normal
-        } else {
-            ScopeOutcome::Failed
+    fn outcome_event(outcome: &Result<(), CallbackFailure>) -> ScopeOutcome {
+        match outcome {
+            Ok(()) => ScopeOutcome::Normal,
+            Err(failure) => ScopeOutcome::Failed(failure.clone()),
         }
+    }
+    fn selected_input_failure() -> CallbackFailure {
+        CallbackFailure::Input(InputFailure("selected input failure".to_owned()))
+    }
+    fn selected_output_failure() -> CallbackFailure {
+        CallbackFailure::Output(OutputFailure("selected last commit failure".to_owned()))
     }
 
     struct InputFake {
@@ -205,22 +242,28 @@ mod tests {
             self.event(Event::InputFinished);
             Ok(ReportToken("input-report".to_owned()))
         }
-        fn close_control(&mut self, outcome: &Result<(), InputFailure>) {
+        fn close_control(&mut self, outcome: &Result<(), CallbackFailure>) {
             self.event(Event::InputControlClosed(outcome_event(outcome)));
         }
-        fn close_job(&mut self, outcome: &Result<(), InputFailure>) {
+        fn close_job(&mut self, outcome: &Result<(), CallbackFailure>) {
             self.event(Event::InputJobClosed(outcome_event(outcome)));
         }
     }
     struct OutputFake {
         events: Rc<RefCell<Vec<Event>>>,
         live_handles: Rc<RefCell<usize>>,
+        failing_commit_index: Option<usize>,
     }
     impl OutputFake {
-        fn new(events: Rc<RefCell<Vec<Event>>>, live_handles: Rc<RefCell<usize>>) -> Self {
+        fn new(
+            events: Rc<RefCell<Vec<Event>>>,
+            live_handles: Rc<RefCell<usize>>,
+            failing_commit_index: Option<usize>,
+        ) -> Self {
             Self {
                 events,
                 live_handles,
+                failing_commit_index,
             }
         }
         fn event(&self, event: Event) {
@@ -231,6 +274,7 @@ mod tests {
         id: usize,
         events: Rc<RefCell<Vec<Event>>>,
         live_handles: Rc<RefCell<usize>>,
+        fail_commit: bool,
     }
     impl OutputHandle {
         fn event(&self, event: Event) {
@@ -246,9 +290,15 @@ mod tests {
         fn finish(&mut self) {
             self.event(Event::OutputTaskFinished(self.id));
         }
-        fn commit(&mut self) -> ReportToken {
-            self.event(Event::OutputTaskCommitted(self.id));
-            ReportToken(format!("output-report-{}", self.id))
+        fn commit(&mut self) -> Result<ReportToken, OutputFailure> {
+            if self.fail_commit {
+                let failure = OutputFailure("selected last commit failure".to_owned());
+                self.event(Event::OutputTaskCommitFailed(self.id, failure.clone()));
+                Err(failure)
+            } else {
+                self.event(Event::OutputTaskCommitted(self.id));
+                Ok(ReportToken(format!("output-report-{}", self.id)))
+            }
         }
         fn abort(&mut self) {
             self.event(Event::OutputTaskAborted(self.id));
@@ -272,12 +322,13 @@ mod tests {
                 id: task_index,
                 events: Rc::clone(&self.events),
                 live_handles: Rc::clone(&self.live_handles),
+                fail_commit: self.failing_commit_index == Some(task_index),
             }
         }
-        fn close_control(&mut self, outcome: &Result<(), InputFailure>) {
+        fn close_control(&mut self, outcome: &Result<(), CallbackFailure>) {
             self.event(Event::OutputControlClosed(outcome_event(outcome)));
         }
-        fn close_job(&mut self, outcome: &Result<(), InputFailure>) {
+        fn close_job(&mut self, outcome: &Result<(), CallbackFailure>) {
             self.event(Event::OutputJobClosed(outcome_event(outcome)));
         }
     }
@@ -322,10 +373,26 @@ mod tests {
         OutputCleanupFake,
         Vec<Event>,
     ) {
+        run_with_commit_failure(plan, fail_before_finish, None)
+    }
+    fn run_with_commit_failure(
+        plan: EmptyPlan,
+        fail_before_finish: bool,
+        failing_commit_index: Option<usize>,
+    ) -> (
+        Result<(), CoordinatorError>,
+        InputCleanupFake,
+        OutputCleanupFake,
+        Vec<Event>,
+    ) {
         let events = Rc::new(RefCell::new(Vec::new()));
         let live_handles = Rc::new(RefCell::new(0));
         let mut input = InputFake::new(Rc::clone(&events), fail_before_finish);
-        let mut output = OutputFake::new(Rc::clone(&events), Rc::clone(&live_handles));
+        let mut output = OutputFake::new(
+            Rc::clone(&events),
+            Rc::clone(&live_handles),
+            failing_commit_index,
+        );
         // These receivers are newly constructed and share no job state.
         let mut input_cleanup = InputCleanupFake {
             events: Rc::clone(&events),
@@ -451,10 +518,64 @@ mod tests {
             expected.extend((0..outputs).map(Event::OutputTaskAborted));
             expected.extend((0..outputs).map(Event::OutputTaskClosed));
             expected.extend([
-                Event::OutputControlClosed(ScopeOutcome::Failed),
-                Event::OutputJobClosed(ScopeOutcome::Failed),
-                Event::InputControlClosed(ScopeOutcome::Failed),
-                Event::InputJobClosed(ScopeOutcome::Failed),
+                Event::OutputControlClosed(ScopeOutcome::Failed(selected_input_failure())),
+                Event::OutputJobClosed(ScopeOutcome::Failed(selected_input_failure())),
+                Event::InputControlClosed(ScopeOutcome::Failed(selected_input_failure())),
+                Event::InputJobClosed(ScopeOutcome::Failed(selected_input_failure())),
+                Event::InputCleaned,
+                Event::OutputCleaned,
+            ]);
+            assert_eq!(trace, expected);
+        }
+    }
+    #[test]
+    fn last_commit_failure_retains_prior_tokens_and_propagates_output_payload() {
+        for outputs in [1, 8] {
+            let plan = EmptyPlan {
+                input_tasks: 1,
+                output_tasks: outputs,
+                output_task_cap: outputs,
+            };
+            let (result, input_cleanup, output_cleanup, trace) =
+                run_with_commit_failure(plan, false, Some(outputs - 1));
+            assert_eq!(
+                result,
+                Err(CoordinatorError::OutputFailed(OutputFailure(
+                    "selected last commit failure".to_owned()
+                )))
+            );
+            assert_eq!(
+                input_cleanup.contexts[0].reports,
+                vec![ReportToken("input-report".to_owned())]
+            );
+            assert_eq!(
+                output_cleanup.contexts[0].reports,
+                (0..(outputs - 1))
+                    .map(|index| ReportToken(format!("output-report-{index}")))
+                    .collect::<Vec<_>>()
+            );
+            let mut expected = vec![
+                Event::InputJobOpened,
+                Event::InputControlOpened,
+                Event::OutputJobOpened,
+                Event::OutputControlOpened,
+            ];
+            expected.extend((0..outputs).map(Event::OutputTaskOpened));
+            expected.push(Event::InputRan);
+            expected.extend((0..outputs).map(Event::OutputTaskFinished));
+            expected.push(Event::InputFinished);
+            expected.extend((0..(outputs - 1)).map(Event::OutputTaskCommitted));
+            expected.push(Event::OutputTaskCommitFailed(
+                outputs - 1,
+                OutputFailure("selected last commit failure".to_owned()),
+            ));
+            expected.push(Event::OutputTaskAborted(outputs - 1));
+            expected.extend((0..outputs).map(Event::OutputTaskClosed));
+            expected.extend([
+                Event::OutputControlClosed(ScopeOutcome::Failed(selected_output_failure())),
+                Event::OutputJobClosed(ScopeOutcome::Failed(selected_output_failure())),
+                Event::InputControlClosed(ScopeOutcome::Failed(selected_output_failure())),
+                Event::InputJobClosed(ScopeOutcome::Failed(selected_output_failure())),
                 Event::InputCleaned,
                 Event::OutputCleaned,
             ]);

--- a/crates/emburk-core/src/empty_lifecycle/differential_tests.rs
+++ b/crates/emburk-core/src/empty_lifecycle/differential_tests.rs
@@ -155,7 +155,7 @@ fn compare_manifest(manifest: &str) -> Result<usize, String> {
                 return Err(format!(
                     "unexpected Rust result for {}: {other:?}",
                     case.name
-                ))
+                ));
             }
         };
         if actual_result != case.expected_result {

--- a/crates/emburk-core/src/empty_lifecycle/differential_tests.rs
+++ b/crates/emburk-core/src/empty_lifecycle/differential_tests.rs
@@ -108,16 +108,23 @@ fn event_name(event: &Event) -> String {
         Event::InputRan => "InputRan".into(),
         Event::InputFinished => "InputFinished".into(),
         Event::InputFailed => "InputFailed".into(),
-        Event::InputControlClosed(outcome) => format!("InputControlClosed:{}", outcome_name(outcome)),
+        Event::InputControlClosed(outcome) => {
+            format!("InputControlClosed:{}", outcome_name(outcome))
+        }
         Event::InputJobClosed(outcome) => format!("InputJobClosed:{}", outcome_name(outcome)),
         Event::OutputJobOpened => "OutputJobOpened".into(),
         Event::OutputControlOpened => "OutputControlOpened".into(),
         Event::OutputTaskOpened(index) => format!("OutputTaskOpened:{index}"),
         Event::OutputTaskFinished(index) => format!("OutputTaskFinished:{index}"),
         Event::OutputTaskCommitted(index) => format!("OutputTaskCommitted:{index}"),
+        Event::OutputTaskCommitFailed(index, failure) => {
+            format!("OutputTaskCommitFailed:{index}:{}", failure.0)
+        }
         Event::OutputTaskAborted(index) => format!("OutputTaskAborted:{index}"),
         Event::OutputTaskClosed(index) => format!("OutputTaskClosed:{index}"),
-        Event::OutputControlClosed(outcome) => format!("OutputControlClosed:{}", outcome_name(outcome)),
+        Event::OutputControlClosed(outcome) => {
+            format!("OutputControlClosed:{}", outcome_name(outcome))
+        }
         Event::OutputJobClosed(outcome) => format!("OutputJobClosed:{}", outcome_name(outcome)),
         Event::InputCleaned => "InputCleaned".into(),
         Event::OutputCleaned => "OutputCleaned".into(),
@@ -127,7 +134,8 @@ fn event_name(event: &Event) -> String {
 fn outcome_name(outcome: &ScopeOutcome) -> &'static str {
     match outcome {
         ScopeOutcome::Normal => "Normal",
-        ScopeOutcome::Failed => "Failed",
+        ScopeOutcome::Failed(CallbackFailure::Input(_)) => "Failed",
+        ScopeOutcome::Failed(CallbackFailure::Output(_)) => "FailedOutput",
     }
 }
 
@@ -143,7 +151,12 @@ fn compare_manifest(manifest: &str) -> Result<usize, String> {
             {
                 "selected-input-failure"
             }
-            Err(other) => return Err(format!("unexpected Rust result for {}: {other:?}", case.name)),
+            Err(other) => {
+                return Err(format!(
+                    "unexpected Rust result for {}: {other:?}",
+                    case.name
+                ))
+            }
         };
         if actual_result != case.expected_result {
             return Err(format!("result differs for {}", case.name));
@@ -171,11 +184,21 @@ fn compare_manifest(manifest: &str) -> Result<usize, String> {
         if case.fail_before_finish {
             let input_failed_controls = trace
                 .iter()
-                .filter(|event| matches!(event, Event::InputControlClosed(ScopeOutcome::Failed)))
+                .filter(|event| {
+                    matches!(
+                        event,
+                        Event::InputControlClosed(ScopeOutcome::Failed(CallbackFailure::Input(_)))
+                    )
+                })
                 .count();
             let output_failed_controls = trace
                 .iter()
-                .filter(|event| matches!(event, Event::OutputControlClosed(ScopeOutcome::Failed)))
+                .filter(|event| {
+                    matches!(
+                        event,
+                        Event::OutputControlClosed(ScopeOutcome::Failed(CallbackFailure::Input(_)))
+                    )
+                })
                 .count();
             if input_failed_controls != 1 || output_failed_controls != 1 {
                 return Err(format!("failed control outcomes differ for {}", case.name));
@@ -193,22 +216,48 @@ fn compare_manifest(manifest: &str) -> Result<usize, String> {
 
 fn valid_manifest() -> String {
     let normal_events = [
-        "InputJobOpened", "InputControlOpened", "OutputJobOpened", "OutputControlOpened",
-        "OutputTaskOpened:0", "InputRan", "OutputTaskFinished:0", "InputFinished",
-        "OutputTaskCommitted:0", "OutputTaskClosed:0", "OutputControlClosed:Normal",
-        "OutputJobClosed:Normal", "InputControlClosed:Normal", "InputJobClosed:Normal",
-        "InputCleaned", "OutputCleaned",
+        "InputJobOpened",
+        "InputControlOpened",
+        "OutputJobOpened",
+        "OutputControlOpened",
+        "OutputTaskOpened:0",
+        "InputRan",
+        "OutputTaskFinished:0",
+        "InputFinished",
+        "OutputTaskCommitted:0",
+        "OutputTaskClosed:0",
+        "OutputControlClosed:Normal",
+        "OutputJobClosed:Normal",
+        "InputControlClosed:Normal",
+        "InputJobClosed:Normal",
+        "InputCleaned",
+        "OutputCleaned",
     ];
     let failure_events = [
-        "InputJobOpened", "InputControlOpened", "OutputJobOpened", "OutputControlOpened",
-        "OutputTaskOpened:0", "InputRan", "InputFailed", "OutputTaskAborted:0",
-        "OutputTaskClosed:0", "OutputJobClosed:Failed", "InputJobClosed:Failed",
-        "InputCleaned", "OutputCleaned",
+        "InputJobOpened",
+        "InputControlOpened",
+        "OutputJobOpened",
+        "OutputControlOpened",
+        "OutputTaskOpened:0",
+        "InputRan",
+        "InputFailed",
+        "OutputTaskAborted:0",
+        "OutputTaskClosed:0",
+        "OutputJobClosed:Failed",
+        "InputJobClosed:Failed",
+        "InputCleaned",
+        "OutputCleaned",
     ];
     let mut rows = vec![HEADER.to_owned()];
-    rows.push(format!("CASE\tnormal\t1\t1\t1024\tnormal-input\tsuccess\t1\t1\t{}", normal_events.len()));
+    rows.push(format!(
+        "CASE\tnormal\t1\t1\t1024\tnormal-input\tsuccess\t1\t1\t{}",
+        normal_events.len()
+    ));
     rows.extend(normal_events.map(|event| format!("EVENT\t{event}")));
-    rows.push(format!("CASE\tfailure\t1\t1\t1024\tfail-before-finish\tselected-input-failure\t0\t0\t{}", failure_events.len()));
+    rows.push(format!(
+        "CASE\tfailure\t1\t1\t1024\tfail-before-finish\tselected-input-failure\t0\t0\t{}",
+        failure_events.len()
+    ));
     rows.extend(failure_events.map(|event| format!("EVENT\t{event}")));
     rows.join("\n") + "\n"
 }
@@ -227,22 +276,33 @@ fn differential_manifest_rejects_invalid_or_mutated_outcomes() {
         valid.replacen("\tsuccess\t1\t1\t", "\tsuccess\t0\t1\t", 1),
         valid.replacen("\tsuccess\t1\t1\t", "\tsuccess\t1\t0\t", 1),
         valid.replacen("OutputTaskOpened:0", "OutputTaskOpened:1", 1),
-        valid.replacen("InputRan\nEVENT\tOutputTaskFinished:0", "OutputTaskFinished:0\nEVENT\tInputRan", 1),
+        valid.replacen(
+            "InputRan\nEVENT\tOutputTaskFinished:0",
+            "OutputTaskFinished:0\nEVENT\tInputRan",
+            1,
+        ),
         valid.replacen("CASE\tnormal\t1\t1\t1024", "CASE\tnormal\t1\t0\t1024", 1),
         format!("{valid}CASE\tnormal\t1\t1\t1024\tnormal-input\tsuccess\t1\t1\t0\n"),
         valid.replacen("EVENT\tInputJobOpened", "EVENT", 1),
     ] {
-        assert!(compare_manifest(&bad).is_err(), "accepted bad manifest:\n{bad}");
+        assert!(
+            compare_manifest(&bad).is_err(),
+            "accepted bad manifest:\n{bad}"
+        );
     }
-    let truncated = valid.lines().take(valid.lines().count() - 1).collect::<Vec<_>>().join("\n");
+    let truncated = valid
+        .lines()
+        .take(valid.lines().count() - 1)
+        .collect::<Vec<_>>()
+        .join("\n");
     assert!(compare_manifest(&truncated).is_err());
 }
 
 #[test]
 #[ignore = "requires the external T-0013/S03 live oracle driver"]
 fn live_empty_lifecycle_differential() {
-    let path = std::env::var("T0013_S04_MANIFEST")
-        .expect("T0013_S04_MANIFEST must name driver output");
+    let path =
+        std::env::var("T0013_S04_MANIFEST").expect("T0013_S04_MANIFEST must name driver output");
     let manifest = std::fs::read_to_string(path).expect("read driver manifest");
     assert_eq!(compare_manifest(&manifest), Ok(2));
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,6 +51,12 @@ supplied Rust plan. Primary and independent acceptance pass at `98b6cac`;
 final-head acceptance passed and PR #74 integrated as `68d848c`. The test adapter
 is not a host API.
 
+ADR-0009 permits a private typed output-commit error and common input/output
+scope outcome, preserving actual reports on the observed last-index failure.
+T-0021/S04 is implementing this candidate; acceptance is pending. Its private
+fallible signature does not establish arbitrary-index recovery, publication or
+rollback semantics or authorize a public plugin boundary.
+
 T-0012 reference probes and S04's ignored live comparison are test-only tools
 outside the Emburk runtime. Their local executable retrieval and generated probe
 plugin do not create an Emburk Java host, admitted plugin, runtime dependency,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,8 @@ is not a host API.
 
 ADR-0009 permits a private typed output-commit error and common input/output
 scope outcome, preserving actual reports on the observed last-index failure.
-T-0021/S04 is implementing this candidate; acceptance is pending. Its private
+T-0021/S04 implements this candidate; primary and independent Unit/Contract
+acceptance pass at `b8dbc77`, with integration pending. Its private
 fallible signature does not establish arbitrary-index recovery, publication or
 rollback semantics or authorize a public plugin boundary.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -105,7 +105,8 @@ final-head acceptance passed and PR #75 integrated as `2901c31`. It adds no
 native output-failure, partial-publication or rollback
 policy, and does not observe arbitrary failure indexes.
 
-T-0021/S04's private last-commit failure implementation is pending under ADR-0009.
+T-0021/S04's private last-commit failure passes primary and independent
+Unit/Contract acceptance at `b8dbc77` under ADR-0009; integration is pending.
 Its local candidate and existing input-failure live regression do not establish
 a new output-failure Differential result or a public Native/Verified entry.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -101,8 +101,13 @@ coverage; no generalized lifecycle claim follows from activation.
 S05's selected output commit failure observation passes primary acceptance at
 `876e861`: only the failed handle aborts, all close, and cleanup receives input
 1/output 7 reports for the observed 1/8 plan. Independent acceptance passes;
-integration remains pending. It adds no native output-failure, partial-publication or rollback
+final-head acceptance passed and PR #75 integrated as `2901c31`. It adds no
+native output-failure, partial-publication or rollback
 policy, and does not observe arbitrary failure indexes.
+
+T-0021/S04's private last-commit failure implementation is pending under ADR-0009.
+Its local candidate and existing input-failure live regression do not establish
+a new output-failure Differential result or a public Native/Verified entry.
 
 ## Adding an Entry
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,6 +85,9 @@ output commit failure from input-run failure without completing parent gates.
 ADR-0009 now activates T-0021/S04's local private last-commit candidate while
 requiring both existing live projections as regression. A separate future
 T-0013 comparison must establish any new output-failure Differential evidence.
+Primary and independent S04 source acceptance passed at `b8dbc77`, including
+both unchanged live regressions; integration remains pending and phase gates
+remain open.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,8 +79,12 @@ S05 now observes selected output commit failure before expanding Rust output
 fallibility. This reference-only gate cannot establish partial publication,
 rollback, retry or resume behavior.
 S05 primary acceptance at `876e861` passes the two live fixtures and 23 controls;
-independent Tester reproduced these results, with integration pending. It distinguishes selected
+independent Tester reproduced these results. Final-head acceptance at `6508221`
+passed and PR #75 integrated as `2901c31`. It distinguishes selected
 output commit failure from input-run failure without completing parent gates.
+ADR-0009 now activates T-0021/S04's local private last-commit candidate while
+requiring both existing live projections as regression. A separate future
+T-0013 comparison must establish any new output-failure Differential evidence.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -251,16 +251,17 @@ and a complete lifecycle contract are not approved by this internal slice.
 | Empty successful orchestration | Accepted S01 input and S02 output observations with actual component traces | A bounded normal-path candidate; not inferred failure handling |
 | Failure before the input's finish call | Same-runtime positive control and an original input-run exception fixture, retaining propagation and all actual output callbacks | A candidate for that exact failure boundary; not pre-publication, rollback, retry or recovery guarantees |
 | Private coordinator acceptance | Independently authored fake plugins and explicit input/output plans (T-0021/S03 Unit); two live declared projections pass T-0013/S04 primary and independent acceptance at `98b6cac`, integrated by PR #74 (`68d848c`) | Private execution of those supplied plans; not default executor fan-out, identical instrumentation or a public plugin API |
-| Output commit callback exception | S05 original normal control plus one selected output commit exception; primary and independent acceptance pass at `876e861`, integration pending | Evidence to review before output fallibility; not durable publication, rollback or recovery guarantees |
+| Output commit callback exception | S05 original normal control plus one selected output commit exception; primary and independent acceptance pass at `876e861`, integrated by PR #75 (`2901c31`) | ADR-0009 permits the private last-index candidate only; not durable publication, rollback or recovery guarantees |
 | Expansion beyond empty tasks | New fixtures for values, output mapping, concurrency and resource bounds | A separately reviewed execution slice; not a silent extension of empty-task evidence |
 
 S05's initial last-index observation differs from input-run failure: only the
 failed output is aborted, all handles close, and earlier returned reports remain
 available to cleanup. Primary and independent acceptance pass at `876e861`;
-integration is pending. A future private candidate
-would need typed output errors, incremental report retention and common typed
-scope outcomes while preserving S04 regressions; no such mutation is authorized
-here. Last-index evidence is not arbitrary-index coverage. Observe first/middle
+PR #75 integrated as `2901c31`. ADR-0009 and the T-0021/S04 packet now authorize
+the private candidate with typed output errors, incremental report retention and
+common typed scope outcomes while preserving S04 regressions. New output-failure
+Differential evidence remains a separate gate. Last-index evidence is not
+arbitrary-index coverage. Observe first/middle
 commit failures before choosing a broader policy, and never infer publication
 or rollback from these empty fixtures.
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -259,7 +259,9 @@ failed output is aborted, all handles close, and earlier returned reports remain
 available to cleanup. Primary and independent acceptance pass at `876e861`;
 PR #75 integrated as `2901c31`. ADR-0009 and the T-0021/S04 packet now authorize
 the private candidate with typed output errors, incremental report retention and
-common typed scope outcomes while preserving S04 regressions. New output-failure
+common typed scope outcomes while preserving S04 regressions. Primary and
+independent Unit/Contract acceptance pass at `b8dbc77`; integration is pending.
+New output-failure
 Differential evidence remains a separate gate. Last-index evidence is not
 arbitrary-index coverage. Observe first/middle
 commit failures before choosing a broader policy, and never infer publication

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -205,6 +205,11 @@ plan. Independent Tester reproduced these results. This is Reference Observation
 integrated as `2901c31`, with no Rust output-failure policy added by that slice.
 
 ADR-0009 now permits T-0021/S04's private last-commit failure candidate with
-typed scope errors and retained reports. Acceptance is pending; earlier/middle
+typed scope errors and retained reports. Primary and independent source
+acceptance passed at `b8dbc77`: seven local tests, two existing live projections,
+13 negative controls and workspace 21 passed/three intentionally ignored;
+format, explicit included-file Rust 2024 formatting and strict Clippy passed.
+PR integration is pending. Evidence is Unit/Contract plus existing regression,
+not a new output-failure Differential result; earlier/middle
 failure positions and general recovery remain outside its reference coverage.
 Current T-0021 SP is refined 5 to 8; Initial SP stays 5 and parent gates stay open.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -33,8 +33,8 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S05 (`Review`, PR #75) is the only active work item. Combined WIP is one of
-two; no item is `Ready` or `Blocked`. T-0012 and T-0021 remain Backlog after
+T-0021/S04 (`In Progress`) is the only active work item. Combined WIP is one of
+two; no item is `Ready` or `Blocked`. T-0012 and T-0013 remain Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
 | Item | State | Purpose |
@@ -44,8 +44,8 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
-| T-0013/S05 | Review | Selected output commit failure observation; PR #75 |
-| T-0021 | Backlog | S01–S03 integrated; remaining core contracts |
+| T-0013 | Backlog | S01–S05 integrated; remaining lifecycle comparison/recovery contracts |
+| T-0021/S04 | In Progress | Private last-commit failure and retained reports |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -201,5 +201,10 @@ S05 primary acceptance at `876e861` passed the normal/selected commit-failure
 Demo and 23 controls. Failure aborted only the failed handle, closed all, and
 fresh cleanup captures received input 1/output 7 reports in the observed 1/8
 plan. Independent Tester reproduced these results. This is Reference Observation
-/ Integration only; final-head acceptance and integration remain pending, with
-no Rust output-failure policy added.
+/ Integration only; final-head acceptance at `6508221` passed and PR #75
+integrated as `2901c31`, with no Rust output-failure policy added by that slice.
+
+ADR-0009 now permits T-0021/S04's private last-commit failure candidate with
+typed scope errors and retained reports. Acceptance is pending; earlier/middle
+failure positions and general recovery remain outside its reference coverage.
+Current T-0021 SP is refined 5 to 8; Initial SP stays 5 and parent gates stay open.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -33,7 +33,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021/S04 (`In Progress`) is the only active work item. Combined WIP is one of
+T-0021/S04 (`Review`, PR #76) is the only active work item. Combined WIP is one of
 two; no item is `Ready` or `Blocked`. T-0012 and T-0013 remain Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -45,7 +45,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
 | T-0013 | Backlog | S01–S05 integrated; remaining lifecycle comparison/recovery contracts |
-| T-0021/S04 | In Progress | Private last-commit failure and retained reports |
+| T-0021/S04 | Review | Private last-commit failure and retained reports; PR #76 |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)

--- a/docs/decisions/ADR-0009-private-last-commit-failure.md
+++ b/docs/decisions/ADR-0009-private-last-commit-failure.md
@@ -1,0 +1,50 @@
+# ADR-0009: Private Last-Commit Failure With Retained Reports
+
+- Status: Accepted
+- Date: 2026-09-06
+- Extends: ADR-0008's selected private callback fallibility only
+
+## Context
+
+T-0013/S05 independently observed the original last-index commit exception and
+integrated through PR #75 (`2901c31`). Unlike input-run failure, the selected
+output failure followed normal input completion and earlier output commit
+returns. Only the failed handle was aborted, all handles closed, and cleanup
+received the input report and earlier output reports. These are empty-fixture
+observations, not durable publication, rollback or arbitrary-index evidence.
+
+## Decision
+
+Permit T-0021/S04 to extend the existing private coordinator with typed output
+commit failure, incremental report retention and a typed common input/output
+failure outcome through all job/control scopes. Preserve the original callback
+error payload and distinguish its input/output origin. Keep plan rejection
+before effects, separate cleanup receivers and dropped handles before cleanup.
+
+Only original fake last-index output commit failure is added to the supported
+fixture contract. For that case, retain the completed input report and each
+returned output token, abort the failed handle only, close all handles, propagate
+the same output failure through both components' scopes and clean up with the
+separate retained reports. Preserve the input-run failure path's all-abort then
+all-close and empty reports; do not merge these into a generic abort-all policy.
+
+Actual callback Results drive execution. The coordinator cannot inspect fixture
+IDs or fabricate events/reports. A fallible private commit signature is
+mechanically broader than current evidence: earlier/middle commit failures have
+no supported reference coverage here. Do not present this candidate as general
+commit recovery or expose it to real plugins. Additional index observations are
+required before adopting a broader policy. Other output operations, setup,
+cleanup, panics, cancellation and process loss remain outside this boundary.
+
+## Consequences
+
+Local tests cover last-index failure in explicit 1/1 and 1/8 plans, full typed
+error propagation, actual event order, retained token values and fresh cleanup.
+The 1/1 case is Unit/Contract evidence only, not a new upstream observation.
+Existing S04 normal/input-failure live projections must still pass unchanged.
+A separate T-0013 packet must compare the newly added output-failure projection
+before making any new Differential claim.
+
+No public API, loader, plugin admission, default planner, values/Pages, scheduler,
+new dependency, storage format, retry/resume or delivery guarantee is authorized.
+Opaque reports remain non-durable callback values; abort is not rollback.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -12,3 +12,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0006](ADR-0006-private-raw-scalar-resolution-before-parser.md) | Private raw scalar resolution before parser adoption | Accepted |
 | [ADR-0007](ADR-0007-private-ordered-logical-schema.md) | Private ordered logical schema before physical encoding | Accepted |
 | [ADR-0008](ADR-0008-private-empty-task-coordinator.md) | Private empty-task coordinator before public plugin traits | Accepted |
+| [ADR-0009](ADR-0009-private-last-commit-failure.md) | Private last-commit failure with retained reports | Accepted |

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -128,5 +128,11 @@
   (21 targeted evidence mutations plus two executable controls). PM required
   successful-commit pairing, strict phase/scope/cleanup order and targeted
   repaired-transport controls. Independent Tester reproduced the frozen source;
-  integration remains pending. No Rust behavior or broader commit/rollback
+  final-head acceptance at `6508221` passed and PR #75 integrated as `2901c31`.
+  No Rust behavior or broader commit/rollback
   guarantee is added.
+- Accepted ADR-0009 and activated T-0021/S04 (3 SP) for private last-commit
+  failure, typed scope outcomes and retained reports. Current T-0021 SP changes
+  5 to 8, Initial stays 5. Existing input-failure live projections remain required
+  regressions; no new output-failure Differential claim yet. T-0013 returns to
+  Backlog for remaining comparisons/index/recovery work; combined WIP stays one.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -136,3 +136,8 @@
   5 to 8, Initial stays 5. Existing input-failure live projections remain required
   regressions; no new output-failure Differential claim yet. T-0013 returns to
   Backlog for remaining comparisons/index/recovery work; combined WIP stays one.
+- T-0021/S04 primary and independent source acceptance pass at `b8dbc77`:
+  seven local tests, two existing live projections, 13 negative controls and
+  workspace 21 passed/three intentional ignores. Explicit Rust 2024 formatting
+  corrected one included-file semicolon before frozen acceptance. PR integration
+  remains pending; evidence is Unit/Contract plus existing regression only.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -18,4 +18,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S03 input-run failure observation](T-0013-input-failure-probe.md) | Done (Reference Observation / Integration; PR #72) |
 | [T-0021/S03 private empty-task coordinator](T-0021-empty-task-coordinator.md) | Done (Unit/Contract; PR #73) |
 | [T-0013/S04 selected empty-lifecycle differential](T-0013-empty-lifecycle-differential.md) | Done (two selected Differential projections; PR #74) |
-| [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | Review (Reference Observation / Integration; PR #75) |
+| [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | Done (Reference Observation / Integration; PR #75) |
+| [T-0021/S04 private last-commit failure](T-0021-last-commit-failure.md) | In Progress (acceptance pending) |

--- a/docs/provenance/T-0013-output-commit-failure-probe.md
+++ b/docs/provenance/T-0013-output-commit-failure-probe.md
@@ -1,7 +1,9 @@
 # T-0013/S05 output commit failure observation
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: Review; PR #75, final-head acceptance and integration pending
+- State: Done (bounded Reference Observation / Integration); PR #75 integrated
+- Parent queue: Backlog for remaining comparisons/index/recovery contracts;
+  Issue #16 remains open
 - Priority: P0; parent T-0010
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0; raw 3 maps to 3 SP)
@@ -220,7 +222,10 @@ Independent reference root is
 `38acff4e916c0fbd18d193390b652f4c3e9d423242986c15b66a785721c714e8`;
 `traces.raw` SHA-256:
 `1b4048b0b32450e0b910fdc7bdeb1fc08776037cf8c1193299e6fa6b84f28114`.
-Final-head acceptance and integration remain pending.
+Final-head acceptance at `6508221c49449950096593f6cd21c0517d0dc7bd` passed the
+exact Demo and separate syntax/diff checks, with local evidence at
+`${TMPDIR}/t0013-output-commit-failure.sXmgK4/evidence`. PR #75 integrated as
+`2901c3134eba5b45da5a7c5bcebf1af0a4334705`; parent Issue #16 remains open.
 Evidence is Reference Observation / Integration only. Other commit positions,
 general output-error semantics, publication and rollback remain unverified.
 

--- a/docs/provenance/T-0021-last-commit-failure.md
+++ b/docs/provenance/T-0021-last-commit-failure.md
@@ -1,7 +1,7 @@
 # T-0021/S04 private last-commit failure
 
 - Tracking issue: [T-0021, #18](https://github.com/bhind/emburk/issues/18)
-- State: In Progress; source acceptance passed, PR integration pending
+- State: Review; source acceptance passed, [PR #76](https://github.com/bhind/emburk/pull/76) integration pending
 - Priority: P1; parent T-0020
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0; raw 3 maps to 3 SP)

--- a/docs/provenance/T-0021-last-commit-failure.md
+++ b/docs/provenance/T-0021-last-commit-failure.md
@@ -1,0 +1,137 @@
+# T-0021/S04 private last-commit failure
+
+- Tracking issue: [T-0021, #18](https://github.com/bhind/emburk/issues/18)
+- State: In Progress; acceptance pending
+- Priority: P1; parent T-0020
+- Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
+  environment 0; raw 3 maps to 3 SP)
+- Parent Current SP: 8, refined from 5; Initial SP remains 5. S01–S03 account
+  for the original 5 SP; this separately accepted failure boundary requires
+  additional implementation/regression verification. No parent completion or
+  duplicated earned points follows.
+
+## Authority
+
+PM owns ADR-0009, records, scope, acceptance and integration. Rust Core
+Implementer owns the two exact source paths; Tester is read-only. Standing owner
+authority permits bounded implementation and PR integration after acceptance.
+
+## Dependencies
+
+T-0021/S03 private coordinator (PR #73, `14d5fb5`); T-0013/S04 two selected live
+projections (PR #74, `68d848c`); independently accepted T-0013/S05 last-index
+commit observation (PR #75, `2901c31`); accepted ADR-0009. Requeue T-0013 for
+remaining comparisons/index/recovery contracts, not Done or Blocked. Combined
+WIP stays one; neither parent's original semantic dependencies are complete.
+
+## Branch and allowlist
+
+Branch: `feat/t-0021-last-commit-failure`.
+Rust Core Implementer owns exactly:
+
+- `crates/emburk-core/src/empty_lifecycle.rs`
+- `crates/emburk-core/src/empty_lifecycle/differential_tests.rs`
+  (typed error/event adaptation and unchanged S04 regression only)
+
+PM owns STATUS, TODO, ROADMAP, COMPATIBILITY, ARCHITECTURE, runtime design,
+ADR-0009/index, provenance/index and dated log. No new module, public export,
+Cargo/dependency, Java fixture, existing shell/Python probe/comparator, schema,
+scalar, CLI, upstream implementation or external artifact change is authorized.
+
+## Artifacts
+
+Extend the private output handle commit callback to return a typed output
+failure or an actual report token. Add an output-origin coordinator error and
+common typed callback outcome for input/output job and control scope completion.
+Preserve original payloads, not just a Boolean failed flag. Keep input run's
+typed input failure and all existing plan rejection behavior.
+
+Replace collect-all commit handling with incremental retention of actual
+successful reports. On the supported final-handle commit failure, abort that
+handle only, close all owned handles, drop them before scope completion/cleanup,
+and pass the same output error through output then input scopes. Retain the
+already returned input token and each earlier output token in their separate
+cleanup contexts. Do not turn prior callback success into a durability claim,
+discard actual returned tokens, or create reports for the failed commit.
+
+The existing selected input-run failure still aborts every opened handle before
+closing every handle, never commits, propagates its exact input failure and
+passes empty report collections to cleanup. Normal zero/one-input execution
+remains unchanged. Cleanup receivers must remain newly constructed capabilities
+that need no live handles, original transaction fields or failure-selection state.
+
+Add a test-owned fake last-index commit failure configuration. The fake callback
+actually returns the failure; the core must not branch on fixture ID or fake
+selection flag. Record a typed commit-failure event and full typed scope outcomes
+so tests can distinguish input from output error payloads at all four scopes.
+Update S04 bridge's exhaustive event/outcome mapping without changing its two
+scenario inputs, existing projection, driver or acceptance expectations. An
+unexpected new output-failure event in those scenarios must not be normalized
+away or accepted.
+
+A fallible method is mechanically broader than the selected fixture contract.
+Do not add claims/tests implying reference coverage for earlier/middle failures,
+unattempted-output abort policy or concurrent commit ordering. The current
+private module has no real plugin caller. A separately observed/packet-reviewed
+slice is required before a broader policy or public exposure. Other callback
+fallibility and panics remain explicitly unimplemented.
+
+## Acceptance criteria
+
+- Execute actual fake last-index commit failures for 1/1 and 1/8 supplied plans.
+- Assert complete typed traces: normal input finish/run, successful earlier
+  commits, failed last commit, abort only failed handle, close all, exact typed
+  failure through both components' control/job scopes, then separate cleanup.
+- Assert original full input/output token values and the exact output failure;
+  the one-output case retains one input token and no output token.
+- Fresh cleanup receives the explicit plan/reports only; Drop counters still
+  assert no live handles. No synthetic cleanup IDs or retained job state.
+- Preserve existing normal, input-error, invalid-plan, token and cleanup tests;
+  preserve both S04 live normal/input-failure comparisons and malformed controls.
+- No fixture-name execution table, fixed fan-out, expected-trace replay, new
+  dependency/API or source/probe change outside the allowlist.
+
+## Demo Command
+
+`cargo test -p emburk-core empty_lifecycle::tests -- --nocapture && bash tests/t0013_empty_lifecycle_differential_test.sh`
+
+Require a nonzero passing local test count and exactly two existing live
+comparisons with nonzero ignored-test selection. Also run workspace tests,
+`cargo fmt --check`, strict workspace/all-target Clippy, explicit formatting
+check for the included child Rust file if Cargo fmt does not discover it, and
+`git diff --check`. Tester independently reproduces frozen source; PM reruns
+the exact Demo at final PR head. Existing shell/Python/Java tools stay unchanged.
+
+## Evidence class
+
+Unit/Contract for new last-commit behavior; regression of the existing two S04
+Differential projections only. No new output-failure Differential result until
+a separate T-0013 comparison packet passes. Parent #18 remains open.
+
+## Reference and reuse record
+
+Access/review date: 2026-09-06. Independently authored from repository-owned
+design, original fakes and the bounded S05 observations. Exact official Embulk
+0.11.5 executable SHA-256:
+`e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`;
+core `c5ac2d471edac465b45088669d376a7e2a525f8f`, SPI 0.11
+`576e98033a14ba8ac994ed581d3c9d8fcdda2749`. Exact URL/API/license locators and
+Apache-2.0 classification remain in T-0011/S05. No upstream implementation or
+tests are copied/translated, and no new artifact/dependency/plugin is admitted.
+Existing pinned probes run only as test regression. Transitive SBOM/notices,
+redistribution, patent/standards/trademark, jurisdiction and freedom to operate
+remain unreviewed, not cleared.
+
+## Stop rule
+
+Repair ordinary compile/test/network issues in scope. Return to PM before
+changing observed projections, unsupported callback/index policy, public API,
+artifacts or materially uncertain IP/security boundaries. Do not weaken existing
+regressions to accommodate new error handling or silently change the user checkout.
+
+## Non-claims
+
+No general commit failure/recovery, first/middle-index reference coverage,
+rollback, durable publication, retry/resume, exactly-once, default scheduling,
+values/Pages/data transfer, real plugin API/host, performance or release claim.
+The supplied count cap bounds handles, not total bytes or CPU.

--- a/docs/provenance/T-0021-last-commit-failure.md
+++ b/docs/provenance/T-0021-last-commit-failure.md
@@ -1,7 +1,7 @@
 # T-0021/S04 private last-commit failure
 
 - Tracking issue: [T-0021, #18](https://github.com/bhind/emburk/issues/18)
-- State: In Progress; acceptance pending
+- State: In Progress; source acceptance passed, PR integration pending
 - Priority: P1; parent T-0020
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0; raw 3 maps to 3 SP)
@@ -107,6 +107,47 @@ the exact Demo at final PR head. Existing shell/Python/Java tools stay unchanged
 Unit/Contract for new last-commit behavior; regression of the existing two S04
 Differential projections only. No new output-failure Differential result until
 a separate T-0013 comparison packet passes. Parent #18 remains open.
+
+Independent read-only Planning review at `7ade007` found no material ambiguity.
+It confirmed the last-index-only fixture, typed input/output scope payloads,
+incremental reports, unchanged S04 projections and sufficient two-file allowlist.
+This is not source acceptance or a new runtime claim.
+
+### Source acceptance
+
+Primary and independent read-only Tester acceptance passed at
+`b8dbc77c1f2ef48e9c02be43bba0f29a8a1edd79`. The exact Demo exited 0:
+seven local tests passed with one intentional live ignore, then the two existing
+S04 live projections passed with 13 rejected raw negative controls. Workspace
+tests passed 21 with three intentional live ignores. Cargo formatting,
+`rustfmt --edition 2024 --check crates/emburk-core/src/empty_lifecycle/differential_tests.rs`,
+strict workspace/all-target Clippy and diff checks all exited 0.
+
+Review corrected an initially ambiguous failed-commit event to a distinct typed
+failure event. An explicit Rust 2024 included-file formatting check then found
+one semicolon adjustment; `0832928` is not the final accepted source revision.
+Full typed error payloads, actual report tokens, failed-handle-only abort,
+all-handle close, and drop-before-fresh-cleanup were independently verified.
+
+Source SHA-256 values:
+
+- `empty_lifecycle.rs`: `0a02985f9d6a8be3c17f3ba81ee090327f0ce3c3df6b1aa9396ffa9a8290eb9a`
+- `differential_tests.rs`: `39ddca6e262c366de5d5140d8c815d226e348004dbb06d7d5787ee6c3f0e87e5`
+
+Primary regression evidence: `${TMPDIR}/t0013-s04.uDqHFy`.
+Tester evidence: `${TMPDIR}/t0013-s04.1MsCRi`; logs:
+`/private/tmp/emburk-t0021-s04-acceptance.zIYDft`.
+Tester Demo log SHA-256:
+`c3cba0714dca600f6eceafbae9483ce150999581a30cdf93ef9ef71fc0756742`.
+Tester cases/traces SHA-256:
+`25de9bc1388920b2bb9615fb02bd7a33480f136f4fb30835efbafcbd59a06817` /
+`fd2bfd78f299089d4e72e5773579580a3fdff8172b3e18651a184c923ca1fd73`.
+Environment: macOS 26.5.1 ARM64, Rust/Cargo 1.98.1, Temurin 17.0.20+8,
+Python 3.14.6 and Bash 3.2.57. The initially restricted reference download
+passed on approved network retry; no acceptance gate was weakened.
+Evidence remains Unit/Contract plus existing S04 regression, not a new
+output-failure Differential claim. Final PR-head acceptance and integration
+remain required; parent #18 stays open.
 
 ## Reference and reuse record
 


### PR DESCRIPTION
## Scope
Refs #18 — T-0021/S04 (3 SP). Keep the parent open.

Private typed output failure, incremental actual report retention, failed-last-handle abort and all-handle close; preserve input failure and separate cleanup capabilities. No public API or general commit/recovery claim.

## Acceptance
Primary and independent Tester passed at b8dbc77: exact packet Demo (seven local tests, two existing live projections and 13 negative controls); workspace 21 passed with three intentional live ignores; Cargo fmt, explicit Rust 2024 included-file formatting, strict Clippy and diff checks.

Evidence: Unit/Contract plus existing S04 regression only. No new output-failure Differential result. Final-head Demo will run before integration.

Packet: docs/provenance/T-0021-last-commit-failure.md. ADR-0009 and canonical records reconciled. No upstream implementation copied; existing IP non-claims remain.