### PR TITLE
test(t-0013): compare selected output commit failure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,8 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S06` is `Ready`; `T-0012`, `T-0021` and all other unfinished items
-are `Backlog`. No item is `Blocked`. Combined active WIP is zero of two.
+`T-0013/S06` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
+are `Backlog`. No item is `Blocked`. Combined active WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S06: selected output-commit comparison) | Ready | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S06: selected output-commit comparison) | In Progress | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -250,7 +250,7 @@ workspace 21 passed/three intentional ignores, formatting and strict Clippy.
 Evidence is Unit/Contract plus existing regression; final-head acceptance passed
 at `d885ba2` and PR #76 integrated as `b5cfb87`. Parent #18 remains open.
 
-T-0013/S06 (3 SP within unchanged Current 21/Initial 8) is Ready under its
+T-0013/S06 (3 SP within unchanged Current 21/Initial 8) is In Progress under its
 [packet](docs/provenance/T-0013-output-commit-differential.md). Compare normal
 and selected last-output-commit execution to the unchanged S05 reference gate.
 Keep S04 unchanged; no production mutation or broader failure claim. Requeue

--- a/TODO.md
+++ b/TODO.md
@@ -255,3 +255,10 @@ T-0013/S06 (3 SP within unchanged Current 21/Initial 8) is In Progress under its
 and selected last-output-commit execution to the unchanged S05 reference gate.
 Keep S04 unchanged; no production mutation or broader failure claim. Requeue
 T-0021 to Backlog and retain a single serial implementation lane.
+
+S06 primary source acceptance at `a284f8b` passes the exact Demo: two new live
+projections, full S05 gate/23 controls, 30 raw controls, two local bridge tests,
+and unchanged S04 two-case/13-control regression. Workspace 23 passed/four
+intentional ignores and strict checks pass. Evidence is Unit/Contract plus two
+selected Differential projections; independent Tester reproduced the same source
+results. Final-head acceptance and integration remain required.

--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,8 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0021/S04` is `Review` in PR #76; `T-0012`, `T-0013` and all other unfinished items
-are `Backlog`. No item is `Blocked`. Combined WIP is one of two.
+`T-0013/S06` is `Ready`; `T-0012`, `T-0021` and all other unfinished items
+are `Backlog`. No item is `Blocked`. Combined active WIP is zero of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S05 integrated; remaining contracts queued) | Backlog | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S06: selected output-commit comparison) | Ready | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -43,7 +43,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
-| T-0021 | Define workspace boundaries and core traits (S04: private last-commit failure) | Review | P1 | 8 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
+| T-0021 | Define workspace boundaries and core traits (S01–S04 integrated; remaining contracts queued) | Backlog | P1 | 8 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
@@ -247,4 +247,11 @@ or new output-failure Differential result is claimed.
 S04 source acceptance at `b8dbc77` passes primary and independent Tester checks:
 seven local tests, two existing live projections, 13 negative controls,
 workspace 21 passed/three intentional ignores, formatting and strict Clippy.
-Evidence is Unit/Contract plus existing regression; PR integration is pending.
+Evidence is Unit/Contract plus existing regression; final-head acceptance passed
+at `d885ba2` and PR #76 integrated as `b5cfb87`. Parent #18 remains open.
+
+T-0013/S06 (3 SP within unchanged Current 21/Initial 8) is Ready under its
+[packet](docs/provenance/T-0013-output-commit-differential.md). Compare normal
+and selected last-output-commit execution to the unchanged S05 reference gate.
+Keep S04 unchanged; no production mutation or broader failure claim. Requeue
+T-0021 to Backlog and retain a single serial implementation lane.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S06` is `In Progress`; `T-0012`, `T-0021` and all other unfinished items
+`T-0013/S06` is `Review` in PR #77; `T-0012`, `T-0021` and all other unfinished items
 are `Backlog`. No item is `Blocked`. Combined active WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S06: selected output-commit comparison) | In Progress | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S06: selected output-commit comparison) | Review | P0 | 21 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -250,7 +250,7 @@ workspace 21 passed/three intentional ignores, formatting and strict Clippy.
 Evidence is Unit/Contract plus existing regression; final-head acceptance passed
 at `d885ba2` and PR #76 integrated as `b5cfb87`. Parent #18 remains open.
 
-T-0013/S06 (3 SP within unchanged Current 21/Initial 8) is In Progress under its
+T-0013/S06 (3 SP within unchanged Current 21/Initial 8) is Review in PR #77 under its
 [packet](docs/provenance/T-0013-output-commit-differential.md). Compare normal
 and selected last-output-commit execution to the unchanged S05 reference gate.
 Keep S04 unchanged; no production mutation or broader failure claim. Requeue

--- a/crates/emburk-core/src/empty_lifecycle.rs
+++ b/crates/emburk-core/src/empty_lifecycle.rs
@@ -637,4 +637,10 @@ mod tests {
             "/src/empty_lifecycle/differential_tests.rs"
         ));
     }
+    mod output_commit_differential_tests {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/empty_lifecycle/output_commit_differential_tests.rs"
+        ));
+    }
 }

--- a/crates/emburk-core/src/empty_lifecycle/output_commit_differential_tests.rs
+++ b/crates/emburk-core/src/empty_lifecycle/output_commit_differential_tests.rs
@@ -1,0 +1,478 @@
+use super::*;
+
+const HEADER: &str = "T0013-S06\t1";
+const OUTPUT_CAP: usize = 1024;
+const MAX_EVENTS: usize = OUTPUT_CAP * 6 + 32;
+const OUTPUT_FAILURE_MESSAGE: &str = "selected last commit failure";
+
+#[derive(Debug)]
+struct Case {
+    name: String,
+    plan: EmptyPlan,
+    failing_commit_index: Option<usize>,
+    expected_result: String,
+    input_reports: usize,
+    output_reports: usize,
+    events: Vec<String>,
+}
+
+fn parse_count(value: &str, label: &str) -> Result<usize, String> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(format!("malformed {label}"));
+    }
+    value.parse().map_err(|_| format!("malformed {label}"))
+}
+
+fn parse_manifest(manifest: &str) -> Result<Vec<Case>, String> {
+    if !manifest.ends_with('\n') || manifest.contains('\r') {
+        return Err("manifest is not canonical TSV text".into());
+    }
+    let mut lines = manifest.lines();
+    if lines.next() != Some(HEADER) {
+        return Err("unsupported manifest header".into());
+    }
+    let mut cases = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    while let Some(row) = lines.next() {
+        let fields: Vec<_> = row.split('\t').collect();
+        if fields.len() != 10 || fields[0] != "CASE" {
+            return Err("malformed case row".into());
+        }
+        let name = fields[1];
+        if !matches!(name, "normal" | "commit-failure") || !seen.insert(name.to_owned()) {
+            return Err("unknown or duplicate case".into());
+        }
+        let input_tasks = parse_count(fields[2], "input task count")?;
+        let output_tasks = parse_count(fields[3], "output task count")?;
+        let output_task_cap = parse_count(fields[4], "output task cap")?;
+        if input_tasks != 1 || output_tasks == 0 {
+            return Err("unsupported selected plan".into());
+        }
+        if output_task_cap != OUTPUT_CAP || output_tasks > OUTPUT_CAP {
+            return Err("unsupported output plan".into());
+        }
+        let failing_commit_index = match (name, fields[5]) {
+            ("normal", "normal-output") => None,
+            ("commit-failure", "fail-last-commit") => Some(output_tasks - 1),
+            _ => return Err("case scenario mismatch".into()),
+        };
+        let expected_result = fields[6];
+        match (name, expected_result) {
+            ("normal", "success") | ("commit-failure", "selected-output-commit-failure") => {}
+            _ => return Err("case result mismatch".into()),
+        }
+        let input_reports = parse_count(fields[7], "input report count")?;
+        let output_reports = parse_count(fields[8], "output report count")?;
+        let expected_output_reports = if failing_commit_index.is_some() {
+            output_tasks - 1
+        } else {
+            output_tasks
+        };
+        if input_reports != 1 || output_reports != expected_output_reports {
+            return Err("case report projection mismatch".into());
+        }
+        let event_count = parse_count(fields[9], "event count")?;
+        if event_count > MAX_EVENTS || event_count > lines.clone().count() {
+            return Err("unsupported or truncated event count".into());
+        }
+        let mut events = Vec::with_capacity(event_count);
+        for _ in 0..event_count {
+            let event = lines.next().ok_or("truncated event rows")?;
+            let event_fields: Vec<_> = event.split('\t').collect();
+            if event_fields.len() != 2 || event_fields[0] != "EVENT" || event_fields[1].is_empty() {
+                return Err("malformed event row".into());
+            }
+            events.push(event_fields[1].to_owned());
+        }
+        cases.push(Case {
+            name: name.to_owned(),
+            plan: EmptyPlan {
+                input_tasks,
+                output_tasks,
+                output_task_cap,
+            },
+            failing_commit_index,
+            expected_result: expected_result.to_owned(),
+            input_reports,
+            output_reports,
+            events,
+        });
+    }
+    if cases.len() != 2
+        || cases[0].name != "normal"
+        || cases[1].name != "commit-failure"
+        || !seen.contains("normal")
+        || !seen.contains("commit-failure")
+    {
+        return Err("case manifest is not exact and ordered".into());
+    }
+    Ok(cases)
+}
+
+fn scope_name(outcome: &ScopeOutcome) -> String {
+    match outcome {
+        ScopeOutcome::Normal => "Normal".into(),
+        ScopeOutcome::Failed(CallbackFailure::Input(InputFailure(message))) => {
+            format!("FailedInput:{message}")
+        }
+        ScopeOutcome::Failed(CallbackFailure::Output(OutputFailure(message))) => {
+            format!("FailedOutput:{message}")
+        }
+    }
+}
+
+fn event_name(event: &Event) -> String {
+    match event {
+        Event::InputJobOpened => "InputJobOpened".into(),
+        Event::InputControlOpened => "InputControlOpened".into(),
+        Event::InputRan => "InputRan".into(),
+        Event::InputFinished => "InputFinished".into(),
+        Event::InputFailed => "InputFailed".into(),
+        Event::InputControlClosed(outcome) => {
+            format!("InputControlClosed:{}", scope_name(outcome))
+        }
+        Event::InputJobClosed(outcome) => format!("InputJobClosed:{}", scope_name(outcome)),
+        Event::OutputJobOpened => "OutputJobOpened".into(),
+        Event::OutputControlOpened => "OutputControlOpened".into(),
+        Event::OutputTaskOpened(index) => format!("OutputTaskOpened:{index}"),
+        Event::OutputTaskFinished(index) => format!("OutputTaskFinished:{index}"),
+        Event::OutputTaskCommitted(index) => format!("OutputTaskCommitted:{index}"),
+        Event::OutputTaskCommitFailed(index, OutputFailure(message)) => {
+            format!("OutputTaskCommitFailed:{index}:{message}")
+        }
+        Event::OutputTaskAborted(index) => format!("OutputTaskAborted:{index}"),
+        Event::OutputTaskClosed(index) => format!("OutputTaskClosed:{index}"),
+        Event::OutputControlClosed(outcome) => {
+            format!("OutputControlClosed:{}", scope_name(outcome))
+        }
+        Event::OutputJobClosed(outcome) => format!("OutputJobClosed:{}", scope_name(outcome)),
+        Event::InputCleaned => "InputCleaned".into(),
+        Event::OutputCleaned => "OutputCleaned".into(),
+    }
+}
+
+fn selected_output_outcome(outcome: &ScopeOutcome) -> bool {
+    matches!(
+        outcome,
+        ScopeOutcome::Failed(CallbackFailure::Output(OutputFailure(message)))
+            if message == OUTPUT_FAILURE_MESSAGE
+    )
+}
+
+fn normalize_events(case: &Case, trace: &[Event]) -> Result<Vec<String>, String> {
+    if let Some(failing_index) = case.failing_commit_index {
+        let all_failed_scopes = trace
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    Event::InputControlClosed(ScopeOutcome::Failed(_))
+                        | Event::InputJobClosed(ScopeOutcome::Failed(_))
+                        | Event::OutputControlClosed(ScopeOutcome::Failed(_))
+                        | Event::OutputJobClosed(ScopeOutcome::Failed(_))
+                )
+            })
+            .count();
+        let exact_scope_counts = [
+            trace.iter().filter(|event| matches!(event, Event::InputControlClosed(outcome) if selected_output_outcome(outcome))).count(),
+            trace.iter().filter(|event| matches!(event, Event::InputJobClosed(outcome) if selected_output_outcome(outcome))).count(),
+            trace.iter().filter(|event| matches!(event, Event::OutputControlClosed(outcome) if selected_output_outcome(outcome))).count(),
+            trace.iter().filter(|event| matches!(event, Event::OutputJobClosed(outcome) if selected_output_outcome(outcome))).count(),
+        ];
+        if all_failed_scopes != 4 || exact_scope_counts != [1, 1, 1, 1] {
+            return Err(format!(
+                "Rust output failure scope payload differs for {}",
+                case.name
+            ));
+        }
+        let all_commit_failures = trace
+            .iter()
+            .filter(|event| matches!(event, Event::OutputTaskCommitFailed(_, _)))
+            .count();
+        let exact_commit_failures = trace
+            .iter()
+            .filter(|event| matches!(event, Event::OutputTaskCommitFailed(index, OutputFailure(message)) if *index == failing_index && message == OUTPUT_FAILURE_MESSAGE))
+            .count();
+        if all_commit_failures != 1 || exact_commit_failures != 1 {
+            return Err(format!(
+                "Rust failed commit payload or index differs for {}",
+                case.name
+            ));
+        }
+    } else if trace.iter().any(|event| {
+        matches!(
+            event,
+            Event::OutputTaskCommitFailed(_, _)
+                | Event::InputControlClosed(ScopeOutcome::Failed(_))
+                | Event::InputJobClosed(ScopeOutcome::Failed(_))
+                | Event::OutputControlClosed(ScopeOutcome::Failed(_))
+                | Event::OutputJobClosed(ScopeOutcome::Failed(_))
+        )
+    }) {
+        return Err("unexpected Rust failure in normal execution".into());
+    }
+
+    let mut normalized = Vec::new();
+    for event in trace {
+        match event {
+            Event::InputControlClosed(outcome) | Event::OutputControlClosed(outcome)
+                if case.failing_commit_index.is_some() && selected_output_outcome(outcome) => {}
+            Event::InputJobClosed(outcome)
+                if case.failing_commit_index.is_some() && selected_output_outcome(outcome) =>
+            {
+                normalized.push("InputJobClosed:FailedOutput".into());
+            }
+            Event::OutputJobClosed(outcome)
+                if case.failing_commit_index.is_some() && selected_output_outcome(outcome) =>
+            {
+                normalized.push("OutputJobClosed:FailedOutput".into());
+            }
+            Event::OutputTaskCommitFailed(index, OutputFailure(message))
+                if case.failing_commit_index == Some(*index)
+                    && message == OUTPUT_FAILURE_MESSAGE =>
+            {
+                normalized.push(format!("OutputTaskCommitFailed:{index}"));
+            }
+            _ => normalized.push(event_name(event)),
+        }
+    }
+    Ok(normalized)
+}
+
+fn compare_manifest(manifest: &str) -> Result<usize, String> {
+    let cases = parse_manifest(manifest)?;
+    for case in &cases {
+        let execution = match case.failing_commit_index {
+            None => run(case.plan.clone(), false),
+            Some(index) => run_with_commit_failure(case.plan.clone(), false, Some(index)),
+        };
+        let (result, input_cleanup, output_cleanup, trace) = execution;
+        let actual_result = match result {
+            Ok(()) => "success",
+            Err(CoordinatorError::OutputFailed(OutputFailure(message)))
+                if message == OUTPUT_FAILURE_MESSAGE =>
+            {
+                "selected-output-commit-failure"
+            }
+            Err(other) => {
+                return Err(format!(
+                    "unexpected Rust result for {}: {other:?}",
+                    case.name
+                ));
+            }
+        };
+        if actual_result != case.expected_result {
+            return Err(format!("Rust result differs for {}", case.name));
+        }
+        if input_cleanup.contexts.len() != 1 || output_cleanup.contexts.len() != 1 {
+            return Err(format!(
+                "Rust cleanup context count differs for {}",
+                case.name
+            ));
+        }
+        if input_cleanup.contexts[0].reports.len() != case.input_reports
+            || output_cleanup.contexts[0].reports.len() != case.output_reports
+        {
+            return Err(format!(
+                "Rust cleanup report counts differ for {}",
+                case.name
+            ));
+        }
+        let actual_events = normalize_events(case, &trace)?;
+        if actual_events != case.events {
+            return Err(format!("Rust event projection differs for {}", case.name));
+        }
+    }
+    Ok(cases.len())
+}
+
+fn fixture_events(outputs: usize, failure: bool) -> Vec<String> {
+    let mut events = vec![
+        "InputJobOpened".into(),
+        "InputControlOpened".into(),
+        "OutputJobOpened".into(),
+        "OutputControlOpened".into(),
+    ];
+    events.extend((0..outputs).map(|index| format!("OutputTaskOpened:{index}")));
+    events.push("InputRan".into());
+    events.extend((0..outputs).map(|index| format!("OutputTaskFinished:{index}")));
+    events.push("InputFinished".into());
+    if failure {
+        events.extend((0..(outputs - 1)).map(|index| format!("OutputTaskCommitted:{index}")));
+        events.push(format!("OutputTaskCommitFailed:{}", outputs - 1));
+        events.push(format!("OutputTaskAborted:{}", outputs - 1));
+    } else {
+        events.extend((0..outputs).map(|index| format!("OutputTaskCommitted:{index}")));
+    }
+    events.extend((0..outputs).map(|index| format!("OutputTaskClosed:{index}")));
+    if failure {
+        events.extend([
+            "OutputJobClosed:FailedOutput".into(),
+            "InputJobClosed:FailedOutput".into(),
+        ]);
+    } else {
+        events.extend([
+            "OutputControlClosed:Normal".into(),
+            "OutputJobClosed:Normal".into(),
+            "InputControlClosed:Normal".into(),
+            "InputJobClosed:Normal".into(),
+        ]);
+    }
+    events.extend(["InputCleaned".into(), "OutputCleaned".into()]);
+    events
+}
+
+fn valid_manifest(outputs: usize) -> String {
+    let normal = fixture_events(outputs, false);
+    let failure = fixture_events(outputs, true);
+    let mut rows = vec![HEADER.to_owned()];
+    rows.push(format!(
+        "CASE\tnormal\t1\t{outputs}\t{OUTPUT_CAP}\tnormal-output\tsuccess\t1\t{outputs}\t{}",
+        normal.len()
+    ));
+    rows.extend(normal.into_iter().map(|event| format!("EVENT\t{event}")));
+    rows.push(format!(
+        "CASE\tcommit-failure\t1\t{outputs}\t{OUTPUT_CAP}\tfail-last-commit\tselected-output-commit-failure\t1\t{}\t{}",
+        outputs - 1,
+        failure.len()
+    ));
+    rows.extend(failure.into_iter().map(|event| format!("EVENT\t{event}")));
+    rows.join("\n") + "\n"
+}
+
+fn remove_case_event(manifest: &str, case_name: &str, event: &str) -> String {
+    let mut lines: Vec<String> = manifest.lines().map(str::to_owned).collect();
+    let case_index = lines
+        .iter()
+        .position(|line| line.starts_with(&format!("CASE\t{case_name}\t")))
+        .expect("case row");
+    let mut fields: Vec<String> = lines[case_index].split('\t').map(str::to_owned).collect();
+    let event_count: usize = fields[9].parse().expect("event count");
+    let event_index = ((case_index + 1)..(case_index + 1 + event_count))
+        .find(|index| lines[*index] == format!("EVENT\t{event}"))
+        .expect("event row");
+    lines.remove(event_index);
+    fields[9] = (event_count - 1).to_string();
+    lines[case_index] = fields.join("\t");
+    lines.join("\n") + "\n"
+}
+
+#[test]
+fn rust_failure_normalization_rejects_component_and_payload_substitution() {
+    let manifest = valid_manifest(2);
+    let cases = parse_manifest(&manifest).expect("valid fixture manifest");
+    let case = &cases[1];
+    let (_, _, _, trace) = run_with_commit_failure(case.plan.clone(), false, Some(1));
+    assert!(normalize_events(case, &trace).is_ok());
+
+    let mut substituted_scope = trace.clone();
+    let output_control = substituted_scope
+        .iter()
+        .position(|event| matches!(event, Event::OutputControlClosed(_)))
+        .expect("output control close");
+    substituted_scope.remove(output_control);
+    let input_control = substituted_scope
+        .iter()
+        .find(|event| matches!(event, Event::InputControlClosed(_)))
+        .expect("input control close")
+        .clone();
+    substituted_scope.push(input_control);
+    assert!(normalize_events(case, &substituted_scope).is_err());
+
+    let mut wrong_scope_payload = trace.clone();
+    let input_job = wrong_scope_payload
+        .iter_mut()
+        .find(|event| matches!(event, Event::InputJobClosed(_)))
+        .expect("input job close");
+    *input_job = Event::InputJobClosed(ScopeOutcome::Failed(CallbackFailure::Output(
+        OutputFailure("changed".into()),
+    )));
+    assert!(normalize_events(case, &wrong_scope_payload).is_err());
+
+    for replacement in [
+        Event::OutputTaskCommitFailed(0, OutputFailure(OUTPUT_FAILURE_MESSAGE.into())),
+        Event::OutputTaskCommitFailed(1, OutputFailure("changed".into())),
+    ] {
+        let mut wrong_commit = trace.clone();
+        let failed = wrong_commit
+            .iter_mut()
+            .find(|event| matches!(event, Event::OutputTaskCommitFailed(_, _)))
+            .expect("failed commit");
+        *failed = replacement;
+        assert!(normalize_events(case, &wrong_commit).is_err());
+    }
+}
+
+#[test]
+fn output_commit_manifest_rejects_mutated_execution_contracts() {
+    for outputs in [1, 8] {
+        assert_eq!(compare_manifest(&valid_manifest(outputs)), Ok(2));
+    }
+    let valid = valid_manifest(2);
+    let bad = vec![
+        valid.replacen(HEADER, "T0013-S06\t2", 1),
+        valid.replacen("CASE\tnormal", "CASE\tunknown", 1),
+        valid.replacen("CASE\tcommit-failure", "CASE\tnormal", 1),
+        valid.replacen("\nCASE\tcommit-failure", "\nCASE\tduplicate", 1),
+        format!(
+            "{}\n",
+            valid
+                .split_once("\nCASE\tcommit-failure")
+                .expect("failure case")
+                .0
+        ),
+        valid.replacen("\t2\t1024\tnormal-output", "\t1025\t1024\tnormal-output", 1),
+        valid.replacen("\t2\t1024\tnormal-output", "\tx\t1024\tnormal-output", 1),
+        valid.replacen("\tnormal-output\t", "\tfail-last-commit\t", 1),
+        valid.replacen(
+            "\tsuccess\t1\t2\t",
+            "\tselected-output-commit-failure\t1\t2\t",
+            1,
+        ),
+        valid.replacen("\tsuccess\t1\t2\t", "\tsuccess\t0\t2\t", 1),
+        valid.replacen("\tsuccess\t1\t2\t", "\tsuccess\t1\t1\t", 1),
+        valid.replacen("OutputTaskCommitFailed:1", "OutputTaskCommitFailed:0", 1),
+        valid.replacen("OutputTaskCommitFailed:1", "OutputTaskCommitted:1", 1),
+        valid.replacen(
+            "OutputJobClosed:FailedOutput",
+            "OutputJobClosed:FailedInput",
+            1,
+        ),
+        valid.replacen(
+            "EVENT\tInputRan\nEVENT\tOutputTaskFinished:0",
+            "EVENT\tOutputTaskFinished:0\nEVENT\tInputRan",
+            1,
+        ),
+        valid.replacen("OutputTaskCommitted:0", "OutputTaskCommitFailed:0", 1),
+        remove_case_event(&valid, "commit-failure", "OutputTaskCommitted:0"),
+        remove_case_event(&valid, "commit-failure", "OutputTaskAborted:1"),
+        remove_case_event(&valid, "commit-failure", "OutputTaskClosed:1"),
+        valid.replacen(
+            "fail-last-commit\tselected-output-commit-failure\t1\t1\t19",
+            "fail-last-commit\tselected-output-commit-failure\t1\t1\t20",
+            1,
+        ),
+        format!("{valid}CASE\tnormal\t1\t1\t1024\tnormal-output\tsuccess\t1\t1\t0\n"),
+    ];
+    for manifest in bad {
+        assert!(
+            compare_manifest(&manifest).is_err(),
+            "accepted bad manifest:\n{manifest}"
+        );
+    }
+    let truncated = valid
+        .lines()
+        .take(valid.lines().count() - 1)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(compare_manifest(&truncated).is_err());
+}
+
+#[test]
+#[ignore = "requires the external T-0013/S05 live oracle driver"]
+fn live_output_commit_differential() {
+    let path =
+        std::env::var("T0013_S06_MANIFEST").expect("T0013_S06_MANIFEST must name driver output");
+    let manifest = std::fs::read_to_string(path).expect("read driver manifest");
+    assert_eq!(compare_manifest(&manifest), Ok(2));
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,14 @@ PR #76 integrated as `b5cfb87`. Its private
 fallible signature does not establish arbitrary-index recovery, publication or
 rollback semantics or authorize a public plugin boundary.
 
+T-0013/S06 adds a separate test-only bridge for normal and selected last-commit
+failure, preserving S04 and the coordinator algorithm. Strict raw validation
+precedes physical-order projection; exact errors are validated within each
+runtime before comparing category/index. Each failed Rust scope is checked
+individually before excluding the two uninstrumented control failures. Primary
+and independent acceptance pass at `a284f8b`; final-head acceptance and
+integration remain required.
+
 T-0012 reference probes and S04's ignored live comparison are test-only tools
 outside the Emburk runtime. Their local executable retrieval and generated probe
 plugin do not create an Emburk Java host, admitted plugin, runtime dependency,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,8 @@ is not a host API.
 ADR-0009 permits a private typed output-commit error and common input/output
 scope outcome, preserving actual reports on the observed last-index failure.
 T-0021/S04 implements this candidate; primary and independent Unit/Contract
-acceptance pass at `b8dbc77`, with integration pending. Its private
+acceptance pass at `b8dbc77`; final-head acceptance passed at `d885ba2` and
+PR #76 integrated as `b5cfb87`. Its private
 fallible signature does not establish arbitrary-index recovery, publication or
 rollback semantics or authorize a public plugin boundary.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -111,7 +111,12 @@ passed at `d885ba2` and PR #76 integrated as `b5cfb87`.
 Its local candidate and existing input-failure live regression do not establish
 a new output-failure Differential result or a public Native/Verified entry.
 T-0013/S06 is the next test-only comparison packet for those two selected
-output-commit scenarios; it has no runtime acceptance evidence yet.
+output-commit scenarios. Primary source acceptance at `a284f8b` now matches
+normal 44-event and selected last-failure 43-event projections, including
+cleanup reports 1/8 versus 1/7 for the observed 1/8 plan. Independent Tester
+reproduced these results; final-head acceptance and integration remain pending.
+This is two selected Differential projections,
+not general commit handling or a public plugin certification.
 
 ## Adding an Entry
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -106,9 +106,12 @@ native output-failure, partial-publication or rollback
 policy, and does not observe arbitrary failure indexes.
 
 T-0021/S04's private last-commit failure passes primary and independent
-Unit/Contract acceptance at `b8dbc77` under ADR-0009; integration is pending.
+Unit/Contract acceptance at `b8dbc77` under ADR-0009; final-head acceptance
+passed at `d885ba2` and PR #76 integrated as `b5cfb87`.
 Its local candidate and existing input-failure live regression do not establish
 a new output-failure Differential result or a public Native/Verified entry.
+T-0013/S06 is the next test-only comparison packet for those two selected
+output-commit scenarios; it has no runtime acceptance evidence yet.
 
 ## Adding an Entry
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -86,8 +86,9 @@ ADR-0009 now activates T-0021/S04's local private last-commit candidate while
 requiring both existing live projections as regression. A separate future
 T-0013 comparison must establish any new output-failure Differential evidence.
 Primary and independent S04 source acceptance passed at `b8dbc77`, including
-both unchanged live regressions; integration remains pending and phase gates
-remain open.
+both unchanged live regressions; final-head acceptance at `d885ba2` passed and
+PR #76 integrated as `b5cfb87`. Phase gates remain open. T-0013/S06 now prepares
+two selected output-commit comparisons without widening the runtime contract.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -89,6 +89,10 @@ Primary and independent S04 source acceptance passed at `b8dbc77`, including
 both unchanged live regressions; final-head acceptance at `d885ba2` passed and
 PR #76 integrated as `b5cfb87`. Phase gates remain open. T-0013/S06 now prepares
 two selected output-commit comparisons without widening the runtime contract.
+S06 primary acceptance at `a284f8b` passes both declared live projections and
+strict negative controls; independent Tester reproduced these results.
+Final-head acceptance and integration remain pending.
+This closes neither arbitrary-index failure nor phase delivery gates.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -268,6 +268,13 @@ arbitrary-index coverage. Observe first/middle
 commit failures before choosing a broader policy, and never infer publication
 or rollback from these empty fixtures.
 
+T-0013/S06 primary acceptance at `a284f8b` compares both selected S05 live
+projections to actual private Rust execution. It preserves physical event order,
+compares actual result/report counts and validates exact runtime-local errors
+before category/index normalization. Independent Tester reproduced these results;
+final-head acceptance and integration remain pending. No production algorithm
+or arbitrary-index contract is added.
+
 The proposed failure fixture should throw inside input `run` before its own
 `finish` call. Calling this "before publication" would be unjustified: output
 transaction/open could already have effects in a real plugin. Commit durability

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -260,7 +260,8 @@ available to cleanup. Primary and independent acceptance pass at `876e861`;
 PR #75 integrated as `2901c31`. ADR-0009 and the T-0021/S04 packet now authorize
 the private candidate with typed output errors, incremental report retention and
 common typed scope outcomes while preserving S04 regressions. Primary and
-independent Unit/Contract acceptance pass at `b8dbc77`; integration is pending.
+independent Unit/Contract acceptance pass at `b8dbc77`; final-head acceptance
+passed at `d885ba2` and PR #76 integrated as `b5cfb87`.
 New output-failure
 Differential evidence remains a separate gate. Last-index evidence is not
 arbitrary-index coverage. Observe first/middle

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -217,6 +217,11 @@ failure positions and general recovery remain outside its reference coverage.
 Current T-0021 SP is refined 5 to 8; Initial SP stays 5 and parent gates stay open.
 
 T-0013/S06 now has a reviewed comparison packet for normal and selected
-last-output-commit failure. It changes only test infrastructure; no new
-Differential result is claimed until live acceptance. Current/Initial SP remain
+last-output-commit failure. It changes only test infrastructure. Primary source
+acceptance at `a284f8b` passes both live projections (normal 44/failure 43 events,
+cleanup reports 1/8 and 1/7 in the observed 1/8 plan), 30 raw controls, two local
+bridge tests and unchanged S04 live regression. Workspace tests pass 23 with
+four intentional ignores; formatting, strict Clippy and syntax checks pass.
+Independent Tester reproduced these results at the same source revision;
+final-head acceptance and integration remain pending. Current/Initial SP remain
 21/8; T-0021 is requeued without closing its parent.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -34,7 +34,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S06 (`In Progress`) is the only serial work item. Combined active WIP is one of
+T-0013/S06 (`Review`, PR #77) is the only serial work item. Combined active WIP is one of
 two; no item is `Blocked`. T-0012 and T-0021 remain Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -45,7 +45,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
-| T-0013/S06 | In Progress | Two selected live output-commit projections |
+| T-0013/S06 | Review | Two selected live output-commit projections; PR #77 |
 | T-0021 | Backlog | S01–S04 integrated; remaining runtime contracts |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,8 +20,9 @@ Development state: `bootstrap`
   duplicates. Its live comparison matches three selected schema outcomes;
   values, nullability, lookup and physical encoding remain unimplemented.
 - A private synchronous empty-task coordinator executes original fake callbacks
-  with separate cleanup capabilities and reports. Its five Unit/Contract tests
-  cover zero/one-input plans and one selected input-run failure. Other callback
+  with separate cleanup capabilities and reports. Its Unit/Contract tests
+  cover zero/one-input plans, one selected input-run failure, and selected
+  last-output-commit failure with retained actual reports. Other callback
   failures and actual plugin execution are not implemented.
 - The product strategy selects a compact Rust execution core, optional
   out-of-process compatibility hosts, explicit versioned compatibility, and a
@@ -33,8 +34,8 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021/S04 (`Review`, PR #76) is the only active work item. Combined WIP is one of
-two; no item is `Ready` or `Blocked`. T-0012 and T-0013 remain Backlog after
+T-0013/S06 (`Ready`) is the next serial work item. Combined active WIP is zero of
+two; no item is `Blocked`. T-0012 and T-0021 remain Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
 | Item | State | Purpose |
@@ -44,8 +45,8 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
-| T-0013 | Backlog | S01–S05 integrated; remaining lifecycle comparison/recovery contracts |
-| T-0021/S04 | Review | Private last-commit failure and retained reports; PR #76 |
+| T-0013/S06 | Ready | Two selected live output-commit projections |
+| T-0021 | Backlog | S01–S04 integrated; remaining runtime contracts |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -209,7 +210,13 @@ typed scope errors and retained reports. Primary and independent source
 acceptance passed at `b8dbc77`: seven local tests, two existing live projections,
 13 negative controls and workspace 21 passed/three intentionally ignored;
 format, explicit included-file Rust 2024 formatting and strict Clippy passed.
-PR integration is pending. Evidence is Unit/Contract plus existing regression,
+Final-head acceptance at `d885ba2` passed; PR #76 integrated as `b5cfb87`.
+Evidence is Unit/Contract plus existing regression,
 not a new output-failure Differential result; earlier/middle
 failure positions and general recovery remain outside its reference coverage.
 Current T-0021 SP is refined 5 to 8; Initial SP stays 5 and parent gates stay open.
+
+T-0013/S06 now has a reviewed comparison packet for normal and selected
+last-output-commit failure. It changes only test infrastructure; no new
+Differential result is claimed until live acceptance. Current/Initial SP remain
+21/8; T-0021 is requeued without closing its parent.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -34,7 +34,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S06 (`Ready`) is the next serial work item. Combined active WIP is zero of
+T-0013/S06 (`In Progress`) is the only serial work item. Combined active WIP is one of
 two; no item is `Blocked`. T-0012 and T-0021 remain Backlog after
 their accepted slices; their remaining contracts/dependencies are not complete.
 
@@ -45,7 +45,7 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
-| T-0013/S06 | Ready | Two selected live output-commit projections |
+| T-0013/S06 | In Progress | Two selected live output-commit projections |
 | T-0021 | Backlog | S01–S04 integrated; remaining runtime contracts |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -141,3 +141,8 @@
   workspace 21 passed/three intentional ignores. Explicit Rust 2024 formatting
   corrected one included-file semicolon before frozen acceptance. PR integration
   remains pending; evidence is Unit/Contract plus existing regression only.
+- T-0021/S04 final-head acceptance passed at `d885ba2`; PR #76 integrated as
+  `b5cfb87`. Parent #18 remains open and returns to Backlog. Prepared reviewed
+  T-0013/S06 (3 SP, parent Current 21/Initial 8 unchanged) for two selected live
+  output-commit projections. One serial implementation lane; no new runtime
+  or Differential claim before acceptance.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -146,3 +146,12 @@
   T-0013/S06 (3 SP, parent Current 21/Initial 8 unchanged) for two selected live
   output-commit projections. One serial implementation lane; no new runtime
   or Differential claim before acceptance.
+- T-0013/S06 primary frozen-source acceptance passes at `a284f8b`: two new live
+  projections, 30 raw controls, two local bridge tests and unchanged S04
+  regression. Workspace 23 passed/four intentional ignores and strict checks
+  pass. Review replaced a count-only scaffold with strict physical event
+  equality and per-component error guards. Independent acceptance and PR
+  integration remain pending; production coordinator behavior is unchanged.
+- Independent Tester reproduced S06 at `a284f8b`, including every live, raw
+  control and strict check, with no source findings. Final-head acceptance and
+  PR integration remain required; no broader failure or runtime claim follows.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -20,4 +20,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S04 selected empty-lifecycle differential](T-0013-empty-lifecycle-differential.md) | Done (two selected Differential projections; PR #74) |
 | [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | Done (Reference Observation / Integration; PR #75) |
 | [T-0021/S04 private last-commit failure](T-0021-last-commit-failure.md) | Done (Unit/Contract plus existing regression; PR #76) |
-| [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | Ready (Planning only) |
+| [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | In Progress (acceptance pending) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -20,4 +20,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S04 selected empty-lifecycle differential](T-0013-empty-lifecycle-differential.md) | Done (two selected Differential projections; PR #74) |
 | [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | Done (Reference Observation / Integration; PR #75) |
 | [T-0021/S04 private last-commit failure](T-0021-last-commit-failure.md) | Done (Unit/Contract plus existing regression; PR #76) |
-| [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | In Progress (acceptance pending) |
+| [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | In Progress (primary and independent acceptance passed; integration pending) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -19,4 +19,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0021/S03 private empty-task coordinator](T-0021-empty-task-coordinator.md) | Done (Unit/Contract; PR #73) |
 | [T-0013/S04 selected empty-lifecycle differential](T-0013-empty-lifecycle-differential.md) | Done (two selected Differential projections; PR #74) |
 | [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | Done (Reference Observation / Integration; PR #75) |
-| [T-0021/S04 private last-commit failure](T-0021-last-commit-failure.md) | In Progress (acceptance pending) |
+| [T-0021/S04 private last-commit failure](T-0021-last-commit-failure.md) | Done (Unit/Contract plus existing regression; PR #76) |
+| [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | Ready (Planning only) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -20,4 +20,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S04 selected empty-lifecycle differential](T-0013-empty-lifecycle-differential.md) | Done (two selected Differential projections; PR #74) |
 | [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | Done (Reference Observation / Integration; PR #75) |
 | [T-0021/S04 private last-commit failure](T-0021-last-commit-failure.md) | Done (Unit/Contract plus existing regression; PR #76) |
-| [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | In Progress (primary and independent acceptance passed; integration pending) |
+| [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | Review (primary and independent acceptance passed; PR #77) |

--- a/docs/provenance/T-0013-output-commit-differential.md
+++ b/docs/provenance/T-0013-output-commit-differential.md
@@ -1,7 +1,7 @@
 # T-0013/S06 selected output-commit differential
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: In Progress; primary and independent source acceptance passed, integration pending
+- State: Review; primary and independent source acceptance passed, [PR #77](https://github.com/bhind/emburk/pull/77) integration pending
 - Priority: P0; parent T-0010
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0). Parent Current SP remains 21; Initial SP remains 8.

--- a/docs/provenance/T-0013-output-commit-differential.md
+++ b/docs/provenance/T-0013-output-commit-differential.md
@@ -1,0 +1,133 @@
+# T-0013/S06 selected output-commit differential
+
+- Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
+- State: Ready; implementation has not started
+- Priority: P0; parent T-0010
+- Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
+  environment 0). Parent Current SP remains 21; Initial SP remains 8.
+
+## Authority
+
+PM owns scope, canonical records, acceptance and integration. One implementer
+owns the entire four-file test slice serially; the independent Tester is
+read-only. Standing owner authority permits implementation and integration
+after acceptance. No parent completion follows from this bounded slice.
+
+## Dependencies
+
+T-0013/S05 reference observation, PR #75 (`2901c31`), and T-0021/S04 private
+last-commit implementation, PR #76 (`b5cfb87`), are integrated. The latter's
+final-head Demo passed at `d885ba2`. T-0013/S04 comparison remains unchanged.
+T-0021 returns to Backlog for remaining contracts. Combined WIP stays one.
+
+## Branch and allowlist
+
+Branch: `test/t-0013-output-commit-differential`.
+One implementer owns exactly:
+
+- `tools/t0013-output-commit-differential` (new Python test driver)
+- `tests/t0013_output_commit_differential_test.sh` (new wrapper/controls)
+- `crates/emburk-core/src/empty_lifecycle/output_commit_differential_tests.rs`
+  (new private test bridge)
+- `crates/emburk-core/src/empty_lifecycle.rs` (test-child registration only)
+
+PM owns STATUS, TODO, ROADMAP, COMPATIBILITY, ARCHITECTURE, runtime design,
+provenance/index and dated log. No production algorithm, public API, dependency,
+Java fixture, existing S03/S04/S05 driver/wrapper/bridge, CLI, schema or scalar
+change is permitted. Do not refactor accepted probes to share validators here.
+
+## Artifacts
+
+Run the full unchanged S05 gate and require its unique final
+`T0013_COMMIT_FULL_PROBE=passed|evidence=...` marker. Retain raw evidence,
+stdout/stderr, executable identity and digests. Strictly validate raw cases,
+trace grammar, sequence/capture identity, logs, phases, scope propagation,
+callback pairs, selection and cleanup before any normalization. Fail closed on
+missing, duplicate, unknown, malformed or contradictory evidence.
+
+Produce a canonical versioned `T0013-S06\t1` manifest with exactly `normal`
+and `commit-failure`. Pass the observed positive output task count N as an
+explicit Rust 1/N plan, with test-harness cap 1024 checked before allocations.
+Do not compare or assume default fan-out. The independently configured Rust
+failure input selects N-1; do not derive execution behavior from expected
+result/events. Validate the Java selection marker agrees with N-1.
+
+Compare actual Rust execution, not expected-trace replay: input/output job and
+control entry; input run/finish; output open/finish and successful commit
+returns; selected commit exception; abort/close returns; control/job normal
+returns or failed-output job outcomes; separate cleanup. Preserve physical
+cross-component order. Compare actual result category and separate report
+counts (normal input 1/output N; failure input 1/output N-1).
+
+Validate exact Java exception class
+`T0013CommitFailureOutputPlugin$InjectedCommitFailure` and message
+`t0013-output-commit-failure` at selected commit and both transaction failures.
+Validate exact Rust `OutputFailure("selected last commit failure")` at failed
+commit, result and all four scope outcomes. Only then normalize to the selected
+output-failure category/index. Unknown origins/payloads fail.
+
+Validate but exclude capture UUIDs, digests, output operation entry markers,
+input finish-before/run-normal-return, selection/injection instrumentation and
+cleanup-entry from equality. Java has no failed-control marker: assert exactly
+one failed-output control closure per Rust component with exact payload before
+excluding those two markers. Never filter unexpected output failures in normal
+execution. Report contents remain Unit/Contract, not cross-runtime equality.
+
+## Acceptance criteria
+
+- Full unchanged S05 gate passes both fixtures and its 23 controls.
+- Exactly two live projections pass through a nonzero selected ignored Rust
+  test count. Zero-task and 1/1 remain local-only, not new live claims.
+- Raw controls reject missing/duplicate/unknown/malformed cases/events,
+  bad capture/sequence/hash/log, selection/index/cap/schema errors, wrong exact
+  exception, missing successful commit, fabricated selected success, missing
+  selected failure/abort/close and invalid phase/scope/cleanup ordering.
+- Semantic raw mutations repair sequence, digest and raw-log envelope first;
+  assert intended rejection diagnostics, not incidental transport failures.
+- Bridge controls reject wrong result/report counts, changed failure category
+  or index, mutated order and unexpected failure in normal execution.
+- Existing S04 live regression and all offline workspace tests still pass.
+- Primary source review, independent frozen-source Tester reproduction and
+  exact final-head Demo precede integration; parents remain open.
+
+## Demo Command
+
+`bash tests/t0013_output_commit_differential_test.sh && bash tests/t0013_empty_lifecycle_differential_test.sh`
+
+Also run `cargo test --workspace`, `cargo fmt --check`, explicit
+`rustfmt --edition 2024 --check` on the new included child, strict
+`cargo clippy --workspace --all-targets -- -D warnings`, separate shell syntax,
+Python syntax compilation without tracked artifacts, and `git diff --check`.
+
+## Evidence class
+
+Planning only until executed. Intended acceptance: Unit/Contract for validators
+and two selected Differential (Embulk) projections. Independent read-only
+planning review supports this scope. PM fixes the cap at 1024 (not N), preserving
+the existing harness safety policy; N remains observed, not a planner claim.
+
+## Reference and reuse record
+
+Access/review date: 2026-09-06. Reuse only repository-owned original test
+infrastructure and pinned S05 observations. Embulk 0.11.5 executable SHA-256
+`e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`;
+core `c5ac2d471edac465b45088669d376a7e2a525f8f`, SPI 0.11
+`576e98033a14ba8ac994ed581d3c9d8fcdda2749`. Exact official URL/API/license
+locators are retained in S05 and T-0011 records. No new upstream implementation
+inspection, translation, external artifact or admitted plugin is needed.
+Transitive notices/SBOM, redistribution, patents/standards/trademark and freedom
+to operate remain unreviewed, not cleared.
+
+## Stop rule
+
+Repair ordinary implementation/test/network failures in scope. Return to PM
+before changing raw observations, exclusions, production behavior, dependency,
+public API or materially uncertain security/IP boundaries. Never weaken S05/S04
+gates, silently accept zero comparisons, or modify the user's checkout.
+
+## Non-claims
+
+No general/first/middle-index failure policy, concurrent commit ordering,
+unattempted-handle abort policy, rollback, durable publication, retry/resume,
+exactly-once, public plugin API, real host, Pages/data transfer, default
+scheduling, performance or release claim. UUIDs are instrumentation only.

--- a/docs/provenance/T-0013-output-commit-differential.md
+++ b/docs/provenance/T-0013-output-commit-differential.md
@@ -1,7 +1,7 @@
 # T-0013/S06 selected output-commit differential
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: In Progress; runtime acceptance pending
+- State: In Progress; primary and independent source acceptance passed, integration pending
 - Priority: P0; parent T-0010
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0). Parent Current SP remains 21; Initial SP remains 8.
@@ -105,6 +105,82 @@ Planning only until executed. Intended acceptance: Unit/Contract for validators
 and two selected Differential (Embulk) projections. Independent read-only
 planning review supports this scope. PM fixes the cap at 1024 (not N), preserving
 the existing harness safety policy; N remains observed, not a planner claim.
+Independent read-only packet review at `935878e` found no missing material
+condition. It specifically requires `COMMITCASE` (not S03's `CASE`) envelopes,
+the main-capture selection marker, complete callback/phase validation before
+exclusion, four exact Rust output-error scope payloads and diagnostic-specific
+negative controls. This is Planning evidence, not frozen-source acceptance.
+
+### Primary frozen-source acceptance
+
+The exact Demo passed at `a284f8bf0f14c2f01a5cf1c196514fcc586f7660`.
+S06 compared exactly two live cases through one explicitly selected ignored
+Rust test. Normal execution projected 44 events and cleanup input 1/output 8
+reports; selected last-index failure projected 43 events and input 1/output 7
+reports for the observed 1/8 plan. The unchanged prerequisite S05 gate passed
+both fixtures and 23 controls. All 30 new raw controls rejected at their named
+diagnostics. Two local bridge tests passed, including repaired event-count
+mutations, 1/1 and 1/8 local fixtures, and direct per-component/payload guards.
+The unchanged S04 regression compared two cases and rejected 13 raw controls.
+
+Primary S06 evidence: `${TMPDIR}/t0013-s06.B5smPC`; reference:
+`${TMPDIR}/t0013-output-commit-failure.SOR3zQ/evidence`.
+Primary S04 evidence: `${TMPDIR}/t0013-s04.zQVUFu`.
+Raw cases/traces SHA-256:
+`03d0c5e33683d91c391e2992e3c314cbe6f6f10dcadec2c01e10e431ab6d6c4c` /
+`b8e505aceb03bdfea097650529db3245841b806342c497e03fc353fd15e32224`.
+Normalized manifest SHA-256:
+`045dd55a4282a560052aa77c3ec9b28ea2be4b23177478f58fe4580d6a9f70ce`.
+These hashes identify evidence, not hard-coded acceptance expectations.
+
+Workspace tests passed 23 with four intentional live ignores. Cargo formatting,
+explicit Rust 2024 included-file formatting, strict all-target Clippy, separate
+shell syntax checks, Python compilation with an external cache, and diff checks
+all exited 0. Environment: macOS 26.5.1 ARM64, Rust/Cargo 1.98.1,
+Temurin 17.0.20+8, Python 3.14.6 and Bash 3.2.57.
+
+Frozen source SHA-256:
+
+- Registration-only `empty_lifecycle.rs`:
+  `5b77d1820982196c13cacb45e46bdb01c79244493129327fdaae50a2eced255a`
+- Rust child:
+  `a58579549d58069725c0fb4149303cdaa291802505e47868c012c5a420fd922d`
+- Shell wrapper:
+  `62ac4f75f1e243a3390a1e2bfd27a4580c700c8ef68e61a0f19874110e42357a`
+- Python driver:
+  `10b0b4c91ae035501df41fb10ba9dcc2f8b1a40c892b7debfb84d6c781fe929d`
+
+Review rejected the initial count-only scaffold. The accepted candidate uses
+the repository-owned S05 validator and repaired-transport controls, preserves
+the original raw-size check while adding the 1024 cap, and explicitly classifies
+every event before exclusion. Review also required raw-derived cleanup/result
+fields, category/index-only comparison, and one exact failure per scope variant
+rather than aggregate counts. No production coordinator algorithm changed.
+Evidence is Unit/Contract plus only these two selected Differential projections.
+Independent acceptance, final PR-head Demo and integration remain required.
+
+### Independent acceptance
+
+Read-only Tester reproduced the exact Demo and every strict check at the same
+`a284f8b` source revision, with the same counts and no unresolved findings.
+The initial sandbox DNS failure passed on approved network retry; no gate was
+weakened. Manual review confirmed the four-file allowlist, actual Rust execution,
+strict raw validation, individual scope guards and repaired-transport controls.
+
+Tester S06 root: `${TMPDIR}/t0013-s06.ahDEQp`; S05 raw root:
+`${TMPDIR}/t0013-output-commit-failure.Wjamwc/evidence`; S04 regression root:
+`${TMPDIR}/t0013-s04.5l6zHR`.
+Tester cases/traces SHA-256:
+`4e7c5b6a090d3211fcaad6c29c8ba726de4c867b8a7a3abb32492f44cc51a4dd` /
+`311a8e295f15abdbd86fdce5a37a85c5d5bdb0e16124e85ed7599a95969c9778`.
+The normalized manifest hash matches primary acceptance. Tester selected-live
+log SHA-256:
+`642e0781ac220b3e8f3148f3402785cdd94ad3501c40bfb64c7d17cf2451c640`;
+driver evidence-manifest SHA-256:
+`3db9d97094a45bd65c2add81908e110e5c33b9e40e3da13f5c246c31e677b5f4`.
+Platform is the same macOS 26.5.1 build 25F80 / Darwin 25.5.0 ARM64.
+All source hashes remained unchanged. Final PR-head acceptance and integration
+remain required; parent #16 remains open.
 
 ## Reference and reuse record
 

--- a/docs/provenance/T-0013-output-commit-differential.md
+++ b/docs/provenance/T-0013-output-commit-differential.md
@@ -1,7 +1,7 @@
 # T-0013/S06 selected output-commit differential
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: Ready; implementation has not started
+- State: In Progress; runtime acceptance pending
 - Priority: P0; parent T-0010
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0). Parent Current SP remains 21; Initial SP remains 8.

--- a/docs/provenance/T-0021-last-commit-failure.md
+++ b/docs/provenance/T-0021-last-commit-failure.md
@@ -1,7 +1,7 @@
 # T-0021/S04 private last-commit failure
 
 - Tracking issue: [T-0021, #18](https://github.com/bhind/emburk/issues/18)
-- State: Review; source acceptance passed, [PR #76](https://github.com/bhind/emburk/pull/76) integration pending
+- State: Done (bounded slice only); [PR #76](https://github.com/bhind/emburk/pull/76) integrated as `b5cfb87`
 - Priority: P1; parent T-0020
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0; raw 3 maps to 3 SP)
@@ -146,8 +146,10 @@ Environment: macOS 26.5.1 ARM64, Rust/Cargo 1.98.1, Temurin 17.0.20+8,
 Python 3.14.6 and Bash 3.2.57. The initially restricted reference download
 passed on approved network retry; no acceptance gate was weakened.
 Evidence remains Unit/Contract plus existing S04 regression, not a new
-output-failure Differential claim. Final PR-head acceptance and integration
-remain required; parent #18 stays open.
+output-failure Differential claim. Final PR-head acceptance at
+`d885ba2e4b394f5b8b204c2983827915fee93dfe` passed the same exact Demo and strict
+checks; evidence root `${TMPDIR}/t0013-s04.IYWEO3`. PR #76 integrated as
+`b5cfb8722aea4c0abff3b41b1e73597dd3691738`; parent #18 stays open and is requeued.
 
 ## Reference and reuse record
 

--- a/tests/t0013_output_commit_differential_test.sh
+++ b/tests/t0013_output_commit_differential_test.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+driver="$root/tools/t0013-output-commit-differential"
+evidence_dir=${T0013_S06_EVIDENCE_DIR:-$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-s06.XXXXXX")}
+mkdir -p -- "$evidence_dir"
+printf 'T0013_S06_EVIDENCE_DIR=%s\n' "$evidence_dir"
+[[ -x "$driver" ]] || exit 2
+
+cargo test --manifest-path "$root/Cargo.toml" -p emburk-core \
+  empty_lifecycle::tests::output_commit_differential_tests \
+  > "$evidence_dir/rust-negative-controls.log" 2>&1
+grep -Fqx 'test empty_lifecycle::tests::output_commit_differential_tests::output_commit_manifest_rejects_mutated_execution_contracts ... ok' \
+  "$evidence_dir/rust-negative-controls.log"
+grep -Fqx 'test empty_lifecycle::tests::output_commit_differential_tests::rust_failure_normalization_rejects_component_and_payload_substitution ... ok' \
+  "$evidence_dir/rust-negative-controls.log"
+grep -Eq '^test result: ok\. 2 passed; 0 failed; 1 ignored; .* filtered out;' \
+  "$evidence_dir/rust-negative-controls.log"
+
+"$driver" --manifest "$evidence_dir/live.tsv" \
+  --probe-stdout "$evidence_dir/s05-full-probe.stdout.log" \
+  --probe-stderr "$evidence_dir/s05-full-probe.stderr.log" \
+  --evidence-manifest "$evidence_dir/driver-evidence-manifest.txt" \
+  --raw-hashes "$evidence_dir/raw-evidence-hashes.txt" \
+  > "$evidence_dir/driver.stdout.log" 2> "$evidence_dir/driver.stderr.log"
+grep -Fqx 'T0013_S06_PROJECTED_CASES=2' "$evidence_dir/driver.stdout.log"
+[[ ! -s "$evidence_dir/driver.stderr.log" ]]
+[[ $(grep -c '^T0013_COMMIT_FULL_PROBE=passed|evidence=' "$evidence_dir/s05-full-probe.stdout.log") == 1 ]]
+[[ $(grep -c $'^CASE\t' "$evidence_dir/live.tsv") == 2 ]]
+grep -Fqx $'T0013-S06\t1' "$evidence_dir/live.tsv"
+for file in cases.raw traces.raw normal.raw.log commit-failure.raw.log; do
+  grep -Eq "^${file//./\\.}=[0-9a-f]{64}$" "$evidence_dir/raw-evidence-hashes.txt"
+done
+for key in executable.sha256 executable-url.txt input-source.sha256 input-source-path.txt \
+  output-source.sha256 input-jar.sha256 output-jar.sha256; do
+  grep -Eq "^$key=.+" "$evidence_dir/driver-evidence-manifest.txt"
+done
+reference=$(sed -n 's/^evidence=//p' "$evidence_dir/driver-evidence-manifest.txt")
+[[ -n "$reference" && -d "$reference" ]]
+
+mutated_copy() {
+  local mutation=$1 copy
+  copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0013-s06-validator.XXXXXX")
+  cp "$reference/cases.raw" "$reference/traces.raw" "$reference/normal.raw.log" \
+    "$reference/commit-failure.raw.log" "$copy/"
+  python3 - "$mutation" "$copy" <<'PY'
+import base64
+import hashlib
+import pathlib
+import sys
+
+action, directory = sys.argv[1:]
+root = pathlib.Path(directory)
+cases = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+traces = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+
+def find(fixture, tag, event):
+    return next(index for index, row in enumerate(traces)
+                if row.startswith(f"{tag}|{fixture}|") and row.split("|")[4] == event)
+
+def renumber(fixture, tag, capture):
+    sequence = 0
+    for index, row in enumerate(traces):
+        fields = row.split("|")
+        if len(fields) >= 5 and fields[0] == tag and fields[1] == fixture and fields[2] == capture:
+            sequence += 1
+            fields[3] = str(sequence)
+            traces[index] = "|".join(fields)
+
+def remove(fixture, tag, event):
+    index = find(fixture, tag, event)
+    capture = traces[index].split("|")[2]
+    traces.pop(index)
+    renumber(fixture, tag, capture)
+
+def insert_after(fixture, tag, event, row):
+    index = find(fixture, tag, event)
+    capture = traces[index].split("|")[2]
+    traces.insert(index + 1, row)
+    renumber(fixture, tag, capture)
+
+def encoded(text):
+    return base64.b64encode(text.encode()).decode()
+
+if action == "missing-injection":
+    remove("commit-failure", "COMMITOUTTRACE", "commit-injection-before")
+elif action == "duplicate-injection":
+    index = find("commit-failure", "COMMITOUTTRACE", "commit-injection-before")
+    insert_after("commit-failure", "COMMITOUTTRACE", "commit-injection-before", traces[index])
+elif action == "wrong-selection":
+    index = find("commit-failure", "COMMITOUTTRACE", "commit-selection")
+    fields = traces[index].split("|"); fields[6] = fields[5]; traces[index] = "|".join(fields)
+elif action in {"wrong-class", "wrong-message"}:
+    for event in ("commit-runtime-exception", "transaction-runtime-exception"):
+        tags = ("COMMITOUTTRACE",) if event == "commit-runtime-exception" else ("COMMITOUTTRACE", "FAILTRACE")
+        for tag in tags:
+            index = find("commit-failure", tag, event)
+            fields = traces[index].split("|")
+            target = -2 if action == "wrong-class" else -1
+            fields[target] = encoded("java.lang.RuntimeException" if action == "wrong-class" else "changed")
+            traces[index] = "|".join(fields)
+elif action == "fabricated-normal-return":
+    failure = traces[find("commit-failure", "COMMITOUTTRACE", "commit-runtime-exception")].split("|")
+    row = "|".join(failure[:4] + ["commit-normal-return"] + failure[5:7])
+    insert_after("commit-failure", "COMMITOUTTRACE", "commit-runtime-exception", row)
+elif action == "missing-terminal":
+    remove("commit-failure", "COMMITOUTTRACE", "commit-runtime-exception")
+elif action == "missing-abort":
+    remove("commit-failure", "COMMITOUTTRACE", "abort-normal-return")
+elif action == "missing-close":
+    remove("commit-failure", "COMMITOUTTRACE", "close-normal-return")
+elif action == "reversed-successful-commit":
+    entry = find("commit-failure", "COMMITOUTTRACE", "commit-entry")
+    returned = find("commit-failure", "COMMITOUTTRACE", "commit-normal-return")
+    row = traces.pop(returned)
+    if returned < entry:
+        entry -= 1
+    traces.insert(entry, row)
+    renumber("commit-failure", "COMMITOUTTRACE", row.split("|")[2])
+elif action == "early-cleanup":
+    entry = find("commit-failure", "FAILTRACE", "cleanup-entry")
+    returned = find("commit-failure", "FAILTRACE", "cleanup-normal-return")
+    pair = [traces[entry], traces[returned]]
+    for index in sorted((entry, returned), reverse=True):
+        traces.pop(index)
+    target = find("commit-failure", "FAILTRACE", "transaction-runtime-exception")
+    traces[target:target] = pair
+elif action == "reordered-scope":
+    control = find("normal", "COMMITOUTTRACE", "control-run-normal-return")
+    transaction = find("normal", "COMMITOUTTRACE", "transaction-normal-return")
+    row = traces.pop(transaction)
+    if transaction < control:
+        control -= 1
+    traces.insert(control, row)
+    renumber("normal", "COMMITOUTTRACE", row.split("|")[2])
+elif action == "sequence":
+    index = find("commit-failure", "COMMITOUTTRACE", "commit-entry")
+    fields = traces[index].split("|"); fields[3] = "1"; traces[index] = "|".join(fields)
+elif action == "capture":
+    index = find("commit-failure", "COMMITOUTTRACE", "commit-injection-before")
+    fields = traces[index].split("|"); fields[2] = "not-a-uuid"; traces[index] = "|".join(fields)
+elif action == "malformed":
+    index = find("normal", "COMMITOUTTRACE", "commit-entry")
+    fields = traces[index].split("|"); fields[5] = "!"; traces[index] = "|".join(fields)
+elif action == "unknown":
+    index = find("normal", "COMMITOUTTRACE", "commit-entry")
+    fields = traces[index].split("|"); fields[4] = "invented"; traces[index] = "|".join(fields)
+elif action in {"add", "resume"}:
+    transaction = traces[find("normal", "COMMITOUTTRACE", "transaction-entry")].split("|")
+    event = "add-entry" if action == "add" else "resume-entry"
+    row = "|".join(transaction[:4] + [event, encoded("0"), encoded("0")])
+    insert_after("normal", "COMMITOUTTRACE", "transaction-entry", row)
+elif action == "contradictory-transaction":
+    error = traces[find("commit-failure", "COMMITOUTTRACE", "transaction-runtime-exception")].split("|")
+    selection = traces[find("commit-failure", "COMMITOUTTRACE", "commit-selection")].split("|")
+    cleanup = traces[find("commit-failure", "COMMITOUTTRACE", "cleanup-entry")].split("|")
+    row = "|".join(error[:4] + ["transaction-normal-return", selection[5], encoded("0"), cleanup[-1]])
+    insert_after("commit-failure", "COMMITOUTTRACE", "transaction-runtime-exception", row)
+
+elif action == "missing-case":
+    cases.pop(0)
+elif action == "duplicate-case":
+    cases.append(cases[0])
+elif action == "unknown-case":
+    fields = cases[0].split("|"); fields[1] = "unknown"; cases[0] = "|".join(fields)
+elif action == "malformed-case":
+    fields = cases[0].split("|"); cases[0] = "|".join(fields[:-1])
+elif action == "count":
+    fields = cases[0].split("|"); summary = fields[4].split(":")
+    summary[0] = str(int(summary[0]) + 1); fields[4] = ":".join(summary)
+    cases[0] = "|".join(fields)
+elif action in {"schema", "cap"}:
+    index = find("normal", "COMMITOUTTRACE", "transaction-entry")
+    fields = traces[index].split("|")
+    fields[6 if action == "schema" else 5] = encoded("1" if action == "schema" else "1025")
+    traces[index] = "|".join(fields)
+elif action == "index":
+    index = find("normal", "COMMITOUTTRACE", "open-normal-return")
+    transaction = traces[find("normal", "COMMITOUTTRACE", "transaction-entry")].split("|")
+    fields = traces[index].split("|"); fields[5] = transaction[5]; traces[index] = "|".join(fields)
+elif action in {"missing-successful-commit", "missing-normal-commit"}:
+    remove("commit-failure" if action == "missing-successful-commit" else "normal",
+           "COMMITOUTTRACE", "commit-normal-return")
+
+def synchronize():
+    for fixture in ("normal", "commit-failure"):
+        rows = [row for row in traces if row.split("|")[1] == fixture]
+        log = root / f"{fixture}.raw.log"
+        other = [line for line in log.read_text(encoding="utf-8").splitlines()
+                 if not line.startswith("FAILTRACE|") and not line.startswith("COMMITOUTTRACE|")]
+        log.write_text("\n".join(rows + other) + "\n", encoding="utf-8")
+        index = next(i for i, row in enumerate(cases) if row.startswith(f"COMMITCASE|{fixture}|"))
+        fields = cases[index].split("|")
+        input_count = sum(row.startswith("FAILTRACE|") for row in rows)
+        output_count = sum(row.startswith("COMMITOUTTRACE|") for row in rows)
+        digest = hashlib.sha256(("\n".join(rows) + "\n").encode()).hexdigest()
+        fields[4] = f"{len(rows)}:{input_count}:{output_count}:{digest}"
+        cases[index] = "|".join(fields)
+
+if action == "hash":
+    fields = cases[0].split("|"); summary = fields[4].split(":"); summary[3] = "0" * 64
+    fields[4] = ":".join(summary); cases[0] = "|".join(fields)
+elif action == "raw-log":
+    log = root / "commit-failure.raw.log"
+    log.write_text(log.read_text(encoding="utf-8").replace("COMMITOUTTRACE|", "BROKEN|", 1), encoding="utf-8")
+elif action not in {"missing-case", "duplicate-case", "unknown-case", "malformed-case", "count"}:
+    synchronize()
+
+root.joinpath("cases.raw").write_text("\n".join(cases) + "\n", encoding="utf-8")
+root.joinpath("traces.raw").write_text("\n".join(traces) + "\n", encoding="utf-8")
+PY
+  printf '%s\n' "$copy"
+}
+
+
+validator_fails() {
+  local mutation=$1 expected=$2 copy result_code
+  copy=$(mutated_copy "$mutation")
+  printf 'T0013_S06_RAW_MUTATION=%s|evidence=%s\n' "$mutation" "$copy"
+  if "$driver" --validate-only "$copy" --manifest "$copy/rejected.tsv" \
+      > "$copy/driver.stdout.log" 2> "$copy/driver.stderr.log"; then
+    printf 'mutation unexpectedly accepted: %s\n' "$mutation" >&2
+    exit 1
+  else
+    result_code=$?
+  fi
+  [[ "$result_code" == 4 ]] || exit 1
+  grep -Fqx "T0013/S06 driver rejected evidence: $expected" "$copy/driver.stderr.log"
+}
+
+validator_fails missing-injection failure-injection
+validator_fails duplicate-injection failure-injection
+validator_fails wrong-selection selection-index
+validator_fails wrong-class failure-exact-error
+validator_fails wrong-message failure-exact-error
+validator_fails fabricated-normal-return failure-other-commit-returns
+validator_fails missing-terminal commit-exception
+validator_fails missing-abort abort-return-indexes
+validator_fails missing-close close-return-indexes
+validator_fails reversed-successful-commit failure-other-commit-pair
+validator_fails early-cleanup cleanup-physical-order
+validator_fails reordered-scope output-main-order
+validator_fails sequence output-sequence-contiguous
+validator_fails capture capture-id
+validator_fails malformed output-canonical-field
+validator_fails hash case-digest-match
+validator_fails raw-log raw-log-trace-match
+validator_fails unknown output-event-known
+validator_fails add unexpected-callback
+validator_fails resume unexpected-callback
+validator_fails contradictory-transaction failure-no-normal-scopes
+validator_fails missing-case case-count
+validator_fails duplicate-case case-count
+validator_fails unknown-case case-fixture
+validator_fails malformed-case case-arity
+validator_fails count case-total-count-match
+validator_fails schema empty-output-schema
+validator_fails cap output-task-cap
+validator_fails index output-index-range
+validator_fails missing-successful-commit failure-other-commit-returns
+validator_fails missing-normal-commit commit-return-indexes
+
+T0013_S06_MANIFEST="$evidence_dir/live.tsv" cargo test --manifest-path "$root/Cargo.toml" \
+  -p emburk-core empty_lifecycle::tests::output_commit_differential_tests::live_output_commit_differential \
+  -- --ignored --exact > "$evidence_dir/live-rust-test.log" 2>&1
+grep -Fqx 'test empty_lifecycle::tests::output_commit_differential_tests::live_output_commit_differential ... ok' \
+  "$evidence_dir/live-rust-test.log"
+grep -Eq '^test result: ok\. 1 passed; 0 failed; 0 ignored; .* filtered out;' \
+  "$evidence_dir/live-rust-test.log"
+printf '%s\n' 'T0013_S06_COMPARED_CASES=2'
+printf 'T0013/S06: compared exactly 2 live output-commit projections; raw and bridge controls passed|evidence=%s\n' "$evidence_dir"

--- a/tools/t0013-output-commit-differential
+++ b/tools/t0013-output-commit-differential
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""Validate S05 evidence and project two ordered S06 lifecycle cases."""
+
+import argparse
+import base64
+import subprocess
+import sys
+import binascii
+import hashlib
+import pathlib
+import uuid
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PROBE = ROOT / "tests/t0013_output_commit_failure_probe_test.sh"
+OUTPUT_CAP = 1024
+HEADER = "T0013-S06\t1"
+
+fixtures = ("normal", "commit-failure")
+injected_class = "T0013CommitFailureOutputPlugin$InjectedCommitFailure"
+injected_message = "t0013-output-commit-failure"
+
+class InvalidEvidence(Exception):
+    pass
+
+def require(label, condition):
+    if not condition:
+        raise InvalidEvidence(label)
+
+def decimal(label, value):
+    require(label, value and value.isascii() and value.isdigit())
+    return int(value)
+
+def decode(label, value, *, numeric=False, nonempty=False):
+    require(label, value != "-")
+    try:
+        raw = base64.b64decode(value, validate=True)
+        text = raw.decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        raise InvalidEvidence(label)
+    require(label, base64.b64encode(raw).decode("ascii") == value)
+    if numeric:
+        decimal(label, text)
+    if nonempty:
+        require(label, text != "")
+    return text
+
+input_arity = {
+    "transaction-entry": 1, "control-run-before": 1, "control-run-normal-return": 1,
+    "transaction-normal-return": 1, "transaction-runtime-exception": 2,
+    "run-entry": 1, "injection-before": 1, "finish-before": 1,
+    "finish-normal-return": 1, "run-normal-return": 1, "run-runtime-exception": 2,
+    "cleanup-entry": 2, "cleanup-normal-return": 1, "resume-entry": 1,
+    "resume-normal-return": 1, "guess-entry": 0, "guess-normal-return": 0,
+}
+input_numeric = {
+    "transaction-entry": {0}, "control-run-before": {0}, "control-run-normal-return": {0},
+    "transaction-normal-return": {0}, "run-entry": {0}, "injection-before": {0},
+    "finish-before": {0}, "finish-normal-return": {0}, "run-normal-return": {0},
+    "cleanup-entry": {0, 1}, "cleanup-normal-return": {0}, "resume-entry": {0},
+    "resume-normal-return": {0},
+}
+output_arity = {
+    "transaction-entry": 2, "commit-selection": 2, "control-run-before": 2,
+    "control-run-normal-return": 3, "transaction-normal-return": 3,
+    "transaction-runtime-exception": 2, "resume-entry": 2,
+    "resume-control-run-before": 2, "resume-control-run-normal-return": 3,
+    "resume-normal-return": 3, "resume-runtime-exception": 2,
+    "cleanup-entry": 3, "cleanup-normal-return": 3,
+    "open-entry": 2, "open-normal-return": 2, "add-entry": 2,
+    "add-normal-return": 2, "finish-entry": 2, "finish-normal-return": 2,
+    "commit-entry": 2, "commit-injection-before": 2,
+    "commit-normal-return": 2, "commit-runtime-exception": 4,
+    "abort-entry": 2, "abort-normal-return": 2,
+    "close-entry": 2, "close-normal-return": 2,
+}
+output_numeric = {event: set(range(arity)) for event, arity in output_arity.items()
+                  if not event.endswith("runtime-exception")}
+output_numeric["commit-runtime-exception"] = {0, 1}
+
+def only(rows, component, event, label):
+    found = [row for row in rows if row[0] == component and row[1] == event]
+    require(label, len(found) == 1)
+    return found[0]
+
+def positions(rows, component, event):
+    return [row[5] for row in rows if row[0] == component and row[1] == event]
+
+def validate(root):
+    case_lines = root.joinpath("cases.raw").read_text(encoding="utf-8").splitlines()
+    trace_lines = root.joinpath("traces.raw").read_text(encoding="utf-8").splitlines()
+    require("case-count", len(case_lines) == 2)
+    cases = {}
+    for expected_fixture, line in zip(fixtures, case_lines, strict=True):
+        fields = line.split("|")
+        require("case-arity", len(fields) == 5 and fields[0] == "COMMITCASE")
+        _, fixture, requested_text, exit_text, summary = fields
+        require("case-fixture", fixture == expected_fixture and fixture not in cases)
+        values = summary.split(":")
+        require("case-summary-arity", len(values) == 4)
+        total, input_count, output_count = [decimal("case-count-field", value) for value in values[:3]]
+        digest = values[3]
+        require("case-digest-format", len(digest) == 64 and all(char in "0123456789abcdef" for char in digest))
+        cases[fixture] = (decimal("requested-count", requested_text), decimal("process-exit", exit_text),
+                          total, input_count, output_count, digest)
+    require("requested-count", all(case[0] == 1 for case in cases.values()))
+
+    grouped = {fixture: [] for fixture in fixtures}
+    decoded = {fixture: [] for fixture in fixtures}
+    sequences = {}
+    for physical, line in enumerate(trace_lines):
+        fields = line.split("|")
+        require("trace-minimum-arity", len(fields) >= 5)
+        tag, fixture, capture, sequence_text, event = fields[:5]
+        require("trace-component", tag in {"FAILTRACE", "COMMITOUTTRACE"})
+        require("trace-fixture", fixture in grouped)
+        try:
+            parsed_capture = uuid.UUID(capture)
+        except ValueError:
+            raise InvalidEvidence("capture-id")
+        require("capture-id", str(parsed_capture) == capture and parsed_capture.version == 4)
+        component = "input" if tag == "FAILTRACE" else "output"
+        sequence = decimal("capture-sequence", sequence_text)
+        key = (fixture, component, capture)
+        require(f"{component}-sequence-contiguous", sequence == sequences.get(key, 0) + 1)
+        sequences[key] = sequence
+        grammar = input_arity if component == "input" else output_arity
+        numeric = input_numeric if component == "input" else output_numeric
+        require(f"{component}-event-known", event in grammar)
+        require(f"{component}-event-arity", len(fields) == 5 + grammar[event])
+        values = []
+        for index, encoded in enumerate(fields[5:]):
+            if encoded == "-":
+                is_message = event.endswith("runtime-exception") and index == grammar[event] - 1
+                require(f"{component}-null-position", is_message)
+                values.append(None)
+            else:
+                exception_field = event.endswith("runtime-exception") and index >= grammar[event] - 2
+                values.append(decode(f"{component}-canonical-field", encoded,
+                                     numeric=index in numeric.get(event, set()),
+                                     nonempty=exception_field and index == grammar[event] - 2))
+        require("unexpected-callback", not (event.startswith("resume") or event.startswith("guess")
+                                             or event.startswith("add")))
+        grouped[fixture].append(line)
+        decoded[fixture].append((component, event, values, capture, sequence, physical))
+
+    for fixture in fixtures:
+        requested, process_exit, total, input_count, output_count, digest = cases[fixture]
+        raw_rows = grouped[fixture]
+        require("case-total-count-match", len(raw_rows) == total)
+        require("case-component-count-match",
+                sum(row.startswith("FAILTRACE|") for row in raw_rows) == input_count
+                and sum(row.startswith("COMMITOUTTRACE|") for row in raw_rows) == output_count
+                and input_count + output_count == total)
+        material = ("\n".join(raw_rows) + "\n").encode("utf-8")
+        require("case-digest-match", hashlib.sha256(material).hexdigest() == digest)
+        raw_log = root / f"{fixture}.raw.log"
+        require("raw-log-required", raw_log.is_file())
+        extracted = [line for line in raw_log.read_text(encoding="utf-8").splitlines()
+                     if line.startswith("FAILTRACE|") or line.startswith("COMMITOUTTRACE|")]
+        require("raw-log-trace-match", extracted == raw_rows)
+
+        rows = decoded[fixture]
+        input_transaction = only(rows, "input", "transaction-entry", "input-transaction-entry")
+        output_transaction = only(rows, "output", "transaction-entry", "output-transaction-entry")
+        selection = only(rows, "output", "commit-selection", "commit-selection")
+        input_main_capture = input_transaction[3]
+        output_main_capture = output_transaction[3]
+        task_count = decimal("output-task-count", output_transaction[2][0])
+        schema_count = decimal("output-schema-count", output_transaction[2][1])
+        require("positive-output-task-count", task_count > 0)
+        require("output-task-cap", task_count <= OUTPUT_CAP)
+        require("bounded-output-task-count", task_count <= len(rows))
+        require("empty-output-schema", schema_count == 0)
+        selected = decimal("selected-index", selection[2][1])
+        require("selection-count", decimal("selection-count", selection[2][0]) == task_count)
+        require("selection-index", selected == task_count - 1)
+        require("selection-capture", selection[3] == output_main_capture)
+        output_chain = ["transaction-entry", "commit-selection", "control-run-before"]
+        output_chain += (["control-run-normal-return", "transaction-normal-return"]
+                         if fixture == "normal" else ["transaction-runtime-exception"])
+        output_chain_rows = [only(rows, "output", event, f"output-{event}") for event in output_chain]
+        require("output-main-capture", all(row[3] == output_main_capture for row in output_chain_rows))
+        require("output-main-order", [row[4] for row in output_chain_rows]
+                == sorted(row[4] for row in output_chain_rows))
+
+        indexed = {"open-entry", "open-normal-return", "finish-entry", "finish-normal-return",
+                   "commit-entry", "commit-injection-before", "commit-normal-return",
+                   "commit-runtime-exception", "abort-entry", "abort-normal-return",
+                   "close-entry", "close-normal-return"}
+        counted = {"transaction-entry", "control-run-before", "control-run-normal-return",
+                   "transaction-normal-return", "cleanup-entry", "cleanup-normal-return"}
+        for component, event, values, capture, sequence, physical in rows:
+            if component == "input" and event in {"transaction-entry", "control-run-before",
+                    "control-run-normal-return", "transaction-normal-return", "cleanup-entry",
+                    "cleanup-normal-return"}:
+                require("input-count-consistency", decimal("input-count", values[0]) == requested)
+            if component == "input" and event in {"run-entry", "finish-before", "finish-normal-return",
+                                                   "run-normal-return", "injection-before"}:
+                require("input-index", decimal("input-index", values[0]) == 0)
+            if component == "output" and event in indexed:
+                require("output-index-range", decimal("output-index", values[0]) < task_count)
+                require("output-schema-consistency", decimal("output-schema", values[1]) == schema_count)
+            if component == "output" and event in counted:
+                require("output-count-consistency", decimal("output-count", values[0]) == task_count)
+                require("output-schema-consistency", decimal("output-schema", values[1]) == schema_count)
+
+        expected_indices = set(range(task_count))
+        opened = {}
+        for row in rows:
+            component, event, values, capture, sequence, physical = row
+            if component != "output" or event not in indexed:
+                continue
+            index = decimal("output-index", values[0])
+            key = (capture, index)
+            if event == "open-normal-return":
+                opened[key] = sequence
+            elif not event.startswith("open"):
+                require("output-prior-open", key in opened and opened[key] < sequence)
+
+        def pair(event, indices):
+            entries = [row for row in rows if row[0] == "output" and row[1] == f"{event}-entry"]
+            returns = [row for row in rows if row[0] == "output" and row[1] == f"{event}-normal-return"]
+            require(f"{event}-entry-indexes", len(entries) == len(indices)
+                    and {decimal("pair-index", row[2][0]) for row in entries} == indices)
+            require(f"{event}-return-indexes", len(returns) == len(indices)
+                    and {decimal("pair-index", row[2][0]) for row in returns} == indices)
+            for entry in entries:
+                index = decimal("pair-index", entry[2][0])
+                returned = next(row for row in returns if decimal("pair-index", row[2][0]) == index)
+                require(f"{event}-callback-pair", entry[2] == returned[2]
+                        and entry[3] == returned[3] and entry[4] < returned[4])
+
+        pair("open", expected_indices)
+        pair("finish", expected_indices)
+        pair("close", expected_indices)
+        for component in ("input", "output"):
+            cleanup_entry = only(rows, component, "cleanup-entry", f"{component}-cleanup-entry")
+            cleanup_return = only(rows, component, "cleanup-normal-return", f"{component}-cleanup-return")
+            require(f"{component}-cleanup-pair", cleanup_entry[3] == cleanup_return[3]
+                    and cleanup_entry[4] < cleanup_return[4])
+            if component == "output":
+                require("output-cleanup-fields", cleanup_entry[2] == cleanup_return[2])
+
+        input_required = {"transaction-entry", "control-run-before", "run-entry", "finish-before",
+                          "finish-normal-return", "run-normal-return", "cleanup-entry", "cleanup-normal-return"}
+        input_names = [row[1] for row in rows if row[0] == "input"]
+        output_names = [row[1] for row in rows if row[0] == "output"]
+        require("input-failure-branch-inactive", "injection-before" not in input_names
+                and "run-runtime-exception" not in input_names)
+        require("input-required", input_required.issubset(input_names))
+        require("input-singletons", all(input_names.count(name) == 1 for name in input_required))
+        input_chain = ["transaction-entry", "control-run-before", "run-entry", "finish-before",
+                       "finish-normal-return", "run-normal-return"]
+        input_chain += (["control-run-normal-return", "transaction-normal-return"]
+                        if fixture == "normal" else ["transaction-runtime-exception"])
+        input_chain_rows = [only(rows, "input", event, f"input-{event}") for event in input_chain]
+        require("input-main-capture", all(row[3] == input_main_capture for row in input_chain_rows))
+        require("input-main-order", [row[4] for row in input_chain_rows]
+                == sorted(row[4] for row in input_chain_rows))
+        commit_entry_positions = positions(rows, "output", "commit-entry")
+        require("commit-entry-required", bool(commit_entry_positions))
+        require("input-finish-before-commit", only(rows, "input", "run-normal-return", "input-run-return")[5]
+                < min(commit_entry_positions))
+        input_run_position = only(rows, "input", "run-entry", "input-run-entry")[5]
+        input_finish_before = only(rows, "input", "finish-before", "input-finish-before")[5]
+        input_finish_return = only(rows, "input", "finish-normal-return", "input-finish-return")[5]
+        require("open-before-input-run", max(positions(rows, "output", "open-normal-return"))
+                < input_run_position)
+        require("output-control-before-open", only(rows, "output", "control-run-before",
+                "output-control-before")[5] < min(positions(rows, "output", "open-entry")))
+        require("output-finish-inside-input-finish", input_finish_before
+                < min(positions(rows, "output", "finish-entry"))
+                and max(positions(rows, "output", "finish-normal-return")) < input_finish_return)
+
+        if fixture == "normal":
+            require("normal-process-success", process_exit == 0)
+            require("normal-no-exception", not any(name.endswith("runtime-exception") for name in input_names + output_names))
+            require("normal-no-injection", "commit-injection-before" not in output_names)
+            pair("commit", expected_indices)
+            pair("abort", set())
+            require("normal-output-scope", output_names.count("control-run-normal-return") == 1
+                    and output_names.count("transaction-normal-return") == 1)
+            require("normal-input-scope", input_names.count("control-run-normal-return") == 1
+                    and input_names.count("transaction-normal-return") == 1)
+            output_reports = only(rows, "output", "cleanup-entry", "output-cleanup-entry")[2][2]
+            input_reports = only(rows, "input", "cleanup-entry", "input-cleanup-entry")[2][1]
+            require("normal-cleanup-reports", decimal("input-reports", input_reports) == 1
+                    and decimal("output-reports", output_reports) == task_count)
+            require("normal-control-reports",
+                    decimal("control-reports", only(rows, "output", "control-run-normal-return",
+                            "output-control-return")[2][2]) == task_count
+                    and decimal("transaction-reports", only(rows, "output", "transaction-normal-return",
+                            "output-transaction-return")[2][2]) == task_count)
+            require("normal-close-after-commit",
+                    max(positions(rows, "output", "commit-normal-return"))
+                    < min(positions(rows, "output", "close-entry")))
+            output_scope = only(rows, "output", "transaction-normal-return", "output-scope-return")
+            output_control = only(rows, "output", "control-run-normal-return", "output-control-return-order")
+            input_control = only(rows, "input", "control-run-normal-return", "input-control-return")
+            input_scope = only(rows, "input", "transaction-normal-return", "input-scope-return")
+            require("normal-scope-physical-order",
+                    max(positions(rows, "output", "close-normal-return")) < output_control[5]
+                    < output_scope[5] < input_control[5] < input_scope[5])
+        else:
+            require("failure-process-nonzero", process_exit != 0)
+            require("failure-no-normal-scopes", "control-run-normal-return" not in input_names
+                    and "transaction-normal-return" not in input_names
+                    and "control-run-normal-return" not in output_names
+                    and "transaction-normal-return" not in output_names)
+            injection = only(rows, "output", "commit-injection-before", "failure-injection")
+            commit_failure = only(rows, "output", "commit-runtime-exception", "commit-exception")
+            require("failure-selected-index", decimal("injection-index", injection[2][0]) == selected
+                    and decimal("exception-index", commit_failure[2][0]) == selected)
+            require("failure-exact-error", commit_failure[2][2:] == [injected_class, injected_message])
+            commit_entries = [decimal("commit-index", row[2][0]) for row in rows
+                              if row[0] == "output" and row[1] == "commit-entry"]
+            commit_returns = [decimal("commit-index", row[2][0]) for row in rows
+                              if row[0] == "output" and row[1] == "commit-normal-return"]
+            require("failure-commit-entries", len(commit_entries) == task_count and set(commit_entries) == expected_indices)
+            require("failure-other-commit-returns", len(commit_returns) == task_count - 1
+                    and set(commit_returns) == expected_indices - {selected})
+            require("failure-selected-no-normal-return", selected not in commit_returns)
+            for index in expected_indices - {selected}:
+                entries = [row for row in rows if row[0] == "output" and row[1] == "commit-entry"
+                           and decimal("commit-index", row[2][0]) == index]
+                returns = [row for row in rows if row[0] == "output" and row[1] == "commit-normal-return"
+                           and decimal("commit-index", row[2][0]) == index]
+                require("failure-other-commit-pair", len(entries) == 1 and len(returns) == 1
+                        and entries[0][2] == returns[0][2] and entries[0][3] == returns[0][3]
+                        and entries[0][4] < returns[0][4])
+            commit_entry = next(row for row in rows if row[0] == "output" and row[1] == "commit-entry"
+                                and decimal("commit-index", row[2][0]) == selected)
+            require("failure-commit-terminal", commit_entry[3] == injection[3] == commit_failure[3]
+                    and commit_entry[4] < injection[4] < commit_failure[4])
+            pair("abort", {selected})
+            output_error = only(rows, "output", "transaction-runtime-exception", "output-transaction-error")
+            input_error = only(rows, "input", "transaction-runtime-exception", "input-transaction-error")
+            require("failure-outer-errors", output_error[2] == [injected_class, injected_message]
+                    and input_error[2] == [injected_class, injected_message])
+            require("failure-physical-order", commit_failure[5]
+                    < only(rows, "output", "abort-entry", "abort-entry")[5]
+                    < only(rows, "output", "abort-normal-return", "abort-return")[5]
+                    < min(positions(rows, "output", "close-entry"))
+                    and max(positions(rows, "output", "close-normal-return")) < output_error[5] < input_error[5])
+            input_cleanup = only(rows, "input", "cleanup-entry", "input-cleanup-entry")
+            output_cleanup = only(rows, "output", "cleanup-entry", "output-cleanup-entry")
+            require("failure-fresh-cleanup-captures", input_cleanup[3] != input_main_capture
+                    and output_cleanup[3] != output_main_capture)
+            require("failure-cleanup-reports", decimal("input-reports", input_cleanup[2][1]) == 1
+                    and decimal("output-reports", output_cleanup[2][2]) == task_count - 1)
+            successful_commit_positions = positions(rows, "output", "commit-normal-return")
+            require("failure-other-commits-before-selected", not successful_commit_positions
+                    or max(successful_commit_positions) < commit_entry[5])
+            output_scope, input_scope = output_error, input_error
+        input_cleanup = only(rows, "input", "cleanup-entry", "input-cleanup-order")
+        input_cleanup_return = only(rows, "input", "cleanup-normal-return", "input-cleanup-return-order")
+        output_cleanup = only(rows, "output", "cleanup-entry", "output-cleanup-order")
+        output_cleanup_return = only(rows, "output", "cleanup-normal-return", "output-cleanup-return-order")
+        require("cleanup-physical-order", output_scope[5] < input_scope[5] < input_cleanup[5]
+                < input_cleanup_return[5] < output_cleanup[5] < output_cleanup_return[5])
+    return cases, decoded
+
+
+def event_projection(rows, fixture):
+    excluded_input = {"finish-before", "run-normal-return", "cleanup-entry"}
+    excluded_output = {
+        "commit-selection", "commit-injection-before", "cleanup-entry",
+        "open-entry", "finish-entry", "commit-entry", "abort-entry", "close-entry",
+    }
+    events = []
+    for component, event, values, _capture, _sequence, _physical in rows:
+        projected = None
+        if component == "input":
+            if event == "transaction-entry":
+                projected = "InputJobOpened"
+            elif event == "control-run-before":
+                projected = "InputControlOpened"
+            elif event == "run-entry":
+                projected = "InputRan"
+            elif event == "finish-normal-return":
+                projected = "InputFinished"
+            elif event == "control-run-normal-return":
+                projected = "InputControlClosed:Normal"
+            elif event == "transaction-normal-return":
+                projected = "InputJobClosed:Normal"
+            elif event == "transaction-runtime-exception":
+                projected = "InputJobClosed:FailedOutput"
+            elif event == "cleanup-normal-return":
+                projected = "InputCleaned"
+        else:
+            if event == "transaction-entry":
+                projected = "OutputJobOpened"
+            elif event == "control-run-before":
+                projected = "OutputControlOpened"
+            elif event == "open-normal-return":
+                projected = f"OutputTaskOpened:{decimal('output-index', values[0])}"
+            elif event == "finish-normal-return":
+                projected = f"OutputTaskFinished:{decimal('output-index', values[0])}"
+            elif event == "commit-normal-return":
+                projected = f"OutputTaskCommitted:{decimal('output-index', values[0])}"
+            elif event == "commit-runtime-exception":
+                projected = f"OutputTaskCommitFailed:{decimal('output-index', values[0])}"
+            elif event == "abort-normal-return":
+                projected = f"OutputTaskAborted:{decimal('output-index', values[0])}"
+            elif event == "close-normal-return":
+                projected = f"OutputTaskClosed:{decimal('output-index', values[0])}"
+            elif event == "control-run-normal-return":
+                projected = "OutputControlClosed:Normal"
+            elif event == "transaction-normal-return":
+                projected = "OutputJobClosed:Normal"
+            elif event == "transaction-runtime-exception":
+                projected = "OutputJobClosed:FailedOutput"
+            elif event == "cleanup-normal-return":
+                projected = "OutputCleaned"
+        excluded = excluded_input if component == "input" else excluded_output
+        require(f"{component}-event-projected-or-excluded",
+                projected is not None or event in excluded)
+        if projected is not None:
+            events.append(projected)
+    require(f"{fixture}-projected-events", bool(events))
+    return events
+
+
+def project(root):
+    cases, decoded = validate(root)
+    rows = [HEADER]
+    for fixture in fixtures:
+        task_count = decimal("output-task-count", only(
+            decoded[fixture], "output", "transaction-entry",
+            "output-transaction-entry")[2][0])
+        require("bounded-output-task-count", 0 < task_count <= OUTPUT_CAP)
+        scenario = "normal-output" if fixture == "normal" else "fail-last-commit"
+        process_exit = cases[fixture][1]
+        result = ("success" if process_exit == 0
+                  else "selected-output-commit-failure")
+        input_reports = decimal("input-reports", only(
+            decoded[fixture], "input", "cleanup-entry", "input-cleanup-entry")[2][1])
+        output_reports = decimal("output-reports", only(
+            decoded[fixture], "output", "cleanup-entry", "output-cleanup-entry")[2][2])
+        events = event_projection(decoded[fixture], fixture)
+        rows.append(
+            f"CASE\t{fixture}\t1\t{task_count}\t{OUTPUT_CAP}\t{scenario}\t"
+            f"{result}\t{input_reports}\t{output_reports}\t{len(events)}"
+        )
+        rows.extend(f"EVENT\t{event}" for event in events)
+    return "\n".join(rows) + "\n"
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def run_probe(stdout_path, stderr_path):
+    process = subprocess.run(
+        [str(PROBE)], cwd=ROOT, text=True, capture_output=True, check=False
+    )
+    stdout_path.write_text(process.stdout, encoding="utf-8")
+    stderr_path.write_text(process.stderr, encoding="utf-8")
+    if process.returncode != 0:
+        raise RuntimeError(f"unchanged S05 gate exited {process.returncode}")
+    markers = [line for line in process.stdout.splitlines()
+               if line.startswith("T0013_COMMIT_FULL_PROBE=passed|evidence=")]
+    require("unique-s05-final-marker", len(markers) == 1)
+    evidence = pathlib.Path(markers[0].split("=", 2)[2])
+    require("s05-evidence-directory", evidence.is_dir())
+    return evidence
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--validate-only")
+    parser.add_argument("--probe-stdout")
+    parser.add_argument("--probe-stderr")
+    parser.add_argument("--evidence-manifest")
+    parser.add_argument("--raw-hashes")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        if args.validate_only:
+            evidence = pathlib.Path(args.validate_only)
+        else:
+            require("probe-stdout-path", args.probe_stdout is not None)
+            require("probe-stderr-path", args.probe_stderr is not None)
+            evidence = run_probe(pathlib.Path(args.probe_stdout), pathlib.Path(args.probe_stderr))
+        manifest = project(evidence)
+        pathlib.Path(args.manifest).write_text(manifest, encoding="utf-8")
+        if args.evidence_manifest:
+            identity_files = (
+                "executable.sha256", "executable-url.txt", "input-source.sha256",
+                "input-source-path.txt", "output-source.sha256", "input-jar.sha256",
+                "output-jar.sha256",
+            )
+            identity = [f"evidence={evidence}"]
+            for name in identity_files:
+                path = evidence / name
+                require(f"retained-{name}", path.is_file() and path.stat().st_size > 0)
+                identity.append(f"{name}={path.read_text(encoding='utf-8').strip()}")
+            pathlib.Path(args.evidence_manifest).write_text(
+                "\n".join(identity) + "\n", encoding="utf-8"
+            )
+        if args.raw_hashes:
+            raw_files = ("cases.raw", "traces.raw", "normal.raw.log",
+                         "commit-failure.raw.log")
+            pathlib.Path(args.raw_hashes).write_text(
+                "\n".join(f"{name}={sha256(evidence / name)}" for name in raw_files)
+                + "\n", encoding="utf-8"
+            )
+        print("T0013_S06_PROJECTED_CASES=2")
+    except (InvalidEvidence, OSError, UnicodeError, RuntimeError) as error:
+        label = error.args[0] if error.args else "unclassified"
+        print(f"T0013/S06 driver rejected evidence: {label}", file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope
Refs #16 — T-0013/S06, 3 SP within unchanged Current 21/Initial 8. Keep the parent open.

Four test-only paths: strict S05 raw validator/projection driver, diagnostic-specific wrapper controls, private Rust bridge and test-child registration. No production algorithm, dependency, public API or existing S04/S05 change.

## Acceptance
Primary and independent Tester passed at a284f8b: exact Demo compares normal 44-event and last-commit-failure 43-event projections (observed plan 1/8; reports 1/8 and 1/7); full S05/23 controls; 30 new raw controls; two local bridge validators; unchanged S04 two-case/13-control regression. Workspace 23 passed/4 intentional live ignores; formatting, explicit Rust 2024 included-file formatting, strict Clippy, shell/Python syntax and diff checks passed.

Evidence: Unit/Contract plus only two selected Differential projections. No first/middle/general commit, rollback, publication, recovery, data transfer or release claim. Packet and canonical records reconciled. Final-head Demo will run before integration.

Packet: docs/provenance/T-0013-output-commit-differential.md.