### PR TITLE
feat(t-0021): abort failed and unattempted output suffix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,9 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S07` is integrated; `T-0012`, `T-0013`, `T-0021` and all other unfinished
-items are `Backlog`. S05 is prepared for T-0021. No item is `Blocked`.
-Combined active WIP is zero of two until activation.
+`T-0013/S07` is integrated; `T-0021/S05` is `In Progress`. T-0012, T-0013 and
+all other unfinished items are `Backlog`. No item is `Blocked`.
+Combined active WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -44,7 +44,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
-| T-0021 | Define workspace boundaries and core traits (S01–S04 integrated; S05 abort suffix prepared) | Backlog | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
+| T-0021 | Define workspace boundaries and core traits (S05: private abort suffix) | In Progress | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
@@ -286,7 +286,7 @@ S05 full regression. Syntax, source hashes and diff checks pass. Final-head
 acceptance at `133cddb` passed and PR #78 integrated as `14cc2a6`; parent #16
 remains open and returns to Backlog for native comparison/recovery work.
 
-T-0021/S05 (3 SP) is prepared under ADR-0010 and its
+T-0021/S05 (3 SP) is In Progress under ADR-0010 and its
 [packet](docs/provenance/T-0021-commit-abort-suffix.md). Extend only the private
 coordinator's failed/unattempted abort suffix, retaining committed reports and
 all existing S04/S06 live regressions. Current SP is refined 8 to 13, Initial

--- a/TODO.md
+++ b/TODO.md
@@ -258,7 +258,7 @@ Keep S04 unchanged; no production mutation or broader failure claim. Requeue
 T-0021 to Backlog and retain a single serial implementation lane.
 
 S06 primary source acceptance at `a284f8b` passes the exact Demo: two new live
-projections, full S05 gate/23 controls, 30 raw controls, two local bridge tests,
+projections, full S05 gate/23 controls, 31 raw controls, two local bridge tests,
 and unchanged S04 two-case/13-control regression. Workspace 23 passed/four
 intentional ignores and strict checks pass. Evidence is Unit/Contract plus two
 selected Differential projections; independent Tester reproduced the same source
@@ -293,3 +293,9 @@ all existing S04/S06 live regressions. Current SP is refined 8 to 13, Initial
 stays 5: the eight accepted SP plus this three-point slice and remaining runtime
 uncertainty exceed the former forecast. No parent completion or new first/middle
 Differential claim follows.
+
+S05 primary and independent source acceptance pass at `f2d9755`: three new
+first/middle local fixtures, complete typed trace/report/cleanup assertions,
+12 focused passes, four existing live projections and 13/31 raw controls.
+Workspace 26 passed/four intentionally ignored and strict quality checks pass.
+Final-head acceptance and integration remain required; parent #18 stays open.

--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,9 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S07` is `Review` in PR #78; `T-0012`, `T-0021` and all other unfinished items
-are `Backlog`. No item is `Blocked`. Combined active WIP is one of two.
+`T-0013/S07` is integrated; `T-0012`, `T-0013`, `T-0021` and all other unfinished
+items are `Backlog`. S05 is prepared for T-0021. No item is `Blocked`.
+Combined active WIP is zero of two until activation.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -35,7 +36,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S01–S06 integrated; remaining contracts queued) | Backlog | P0 | 8 | T-0011 | Rust Core Implementer | Differential (Embulk) |
-| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S07: first/middle commit observation) | Review | P0 | 34 | T-0011 | Compatibility Host Implementer | Reference Observation / Integration (S07; parent Differential gate remains) |
+| T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S07 integrated; remaining comparisons/recovery queued) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
@@ -43,7 +44,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
-| T-0021 | Define workspace boundaries and core traits (S01–S04 integrated; remaining contracts queued) | Backlog | P1 | 8 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
+| T-0021 | Define workspace boundaries and core traits (S01–S04 integrated; S05 abort suffix prepared) | Backlog | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
@@ -282,5 +283,13 @@ independent reproduction remain required.
 S07 source acceptance at `76dbab0` passes primary and independent Tester:
 three live cases, 57 semantic controls, two artifact controls and unchanged
 S05 full regression. Syntax, source hashes and diff checks pass. Final-head
-acceptance and integration remain pending; parent #16 remains open and no
-first/middle Rust policy is added.
+acceptance at `133cddb` passed and PR #78 integrated as `14cc2a6`; parent #16
+remains open and returns to Backlog for native comparison/recovery work.
+
+T-0021/S05 (3 SP) is prepared under ADR-0010 and its
+[packet](docs/provenance/T-0021-commit-abort-suffix.md). Extend only the private
+coordinator's failed/unattempted abort suffix, retaining committed reports and
+all existing S04/S06 live regressions. Current SP is refined 8 to 13, Initial
+stays 5: the eight accepted SP plus this three-point slice and remaining runtime
+uncertainty exceed the former forecast. No parent completion or new first/middle
+Differential claim follows.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S07` is integrated; `T-0021/S05` is `In Progress`. T-0012, T-0013 and
+`T-0013/S07` is integrated; `T-0021/S05` is `Review` in PR #79. T-0012, T-0013 and
 all other unfinished items are `Backlog`. No item is `Blocked`.
 Combined active WIP is one of two.
 
@@ -44,7 +44,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
-| T-0021 | Define workspace boundaries and core traits (S05: private abort suffix) | In Progress | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
+| T-0021 | Define workspace boundaries and core traits (S05: private abort suffix) | Review | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
@@ -286,7 +286,7 @@ S05 full regression. Syntax, source hashes and diff checks pass. Final-head
 acceptance at `133cddb` passed and PR #78 integrated as `14cc2a6`; parent #16
 remains open and returns to Backlog for native comparison/recovery work.
 
-T-0021/S05 (3 SP) is In Progress under ADR-0010 and its
+T-0021/S05 (3 SP) is Review in PR #79 under ADR-0010 and its
 [packet](docs/provenance/T-0021-commit-abort-suffix.md). Extend only the private
 coordinator's failed/unattempted abort suffix, retaining committed reports and
 all existing S04/S06 live regressions. Current SP is refined 8 to 13, Initial

--- a/crates/emburk-core/src/empty_lifecycle.rs
+++ b/crates/emburk-core/src/empty_lifecycle.rs
@@ -1,8 +1,11 @@
 //! A deliberately small, limited-fallibility fixture lifecycle boundary.
 //!
-//! Only input run and the selected last output commit can fail here. Setup,
-//! other output operations, scope teardown, and cleanup are infallible by
-//! design for these test fakes; this is not a production plugin trait.
+//! Only input run and a selected output commit can fail here. Setup, other
+//! output operations, scope teardown, and cleanup are infallible by design for
+//! these test fakes; this is not a production plugin trait.
+//! Selected first, middle, and last positions cover the observed empty-fixture
+//! cases; they do not establish arbitrary-index or concurrent reference
+//! equivalence.
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct EmptyPlan {
@@ -110,13 +113,17 @@ where
         Ok(input_report) => {
             let mut output_reports = Vec::new();
             let mut output_failure = None;
-            for handle in &mut handles {
-                // This private boundary is exercised only for a fake's selected
-                // last-index failure; it does not establish earlier/middle policy.
-                match handle.commit() {
+            for index in 0..handles.len() {
+                let commit_result = handles[index].commit();
+                match commit_result {
                     Ok(report) => output_reports.push(report),
                     Err(failure) => {
-                        handle.abort();
+                        // The failing handle and every unattempted successor form
+                        // the abort suffix. Reports from the committed prefix are
+                        // retained, and no later commit is attempted.
+                        for handle in &mut handles[index..] {
+                            handle.abort();
+                        }
                         output_failure = Some(failure);
                         break;
                     }
@@ -581,6 +588,75 @@ mod tests {
             ]);
             assert_eq!(trace, expected);
         }
+    }
+    fn assert_commit_failure_suffix(output_tasks: usize, failing_commit_index: usize) {
+        let plan = EmptyPlan {
+            input_tasks: 1,
+            output_tasks,
+            output_task_cap: output_tasks,
+        };
+        let (result, input_cleanup, output_cleanup, trace) =
+            run_with_commit_failure(plan.clone(), false, Some(failing_commit_index));
+
+        assert_eq!(
+            result,
+            Err(CoordinatorError::OutputFailed(OutputFailure(
+                "selected last commit failure".to_owned()
+            )))
+        );
+        assert_eq!(input_cleanup.contexts.len(), 1);
+        assert_eq!(output_cleanup.contexts.len(), 1);
+        assert_eq!(input_cleanup.contexts[0].plan, plan);
+        assert_eq!(output_cleanup.contexts[0].plan, plan);
+        assert_eq!(
+            input_cleanup.contexts[0].reports,
+            vec![ReportToken("input-report".to_owned())]
+        );
+        assert_eq!(
+            output_cleanup.contexts[0].reports,
+            (0..failing_commit_index)
+                .map(|index| ReportToken(format!("output-report-{index}")))
+                .collect::<Vec<_>>()
+        );
+
+        let mut expected = vec![
+            Event::InputJobOpened,
+            Event::InputControlOpened,
+            Event::OutputJobOpened,
+            Event::OutputControlOpened,
+        ];
+        expected.extend((0..output_tasks).map(Event::OutputTaskOpened));
+        expected.push(Event::InputRan);
+        expected.extend((0..output_tasks).map(Event::OutputTaskFinished));
+        expected.push(Event::InputFinished);
+        expected.extend((0..failing_commit_index).map(Event::OutputTaskCommitted));
+        expected.push(Event::OutputTaskCommitFailed(
+            failing_commit_index,
+            OutputFailure("selected last commit failure".to_owned()),
+        ));
+        expected.extend((failing_commit_index..output_tasks).map(Event::OutputTaskAborted));
+        expected.extend((0..output_tasks).map(Event::OutputTaskClosed));
+        expected.extend([
+            Event::OutputControlClosed(ScopeOutcome::Failed(selected_output_failure())),
+            Event::OutputJobClosed(ScopeOutcome::Failed(selected_output_failure())),
+            Event::InputControlClosed(ScopeOutcome::Failed(selected_output_failure())),
+            Event::InputJobClosed(ScopeOutcome::Failed(selected_output_failure())),
+            Event::InputCleaned,
+            Event::OutputCleaned,
+        ]);
+        assert_eq!(trace, expected);
+    }
+    #[test]
+    fn first_commit_failure_aborts_failed_and_unattempted_suffix() {
+        assert_commit_failure_suffix(8, 0);
+    }
+    #[test]
+    fn middle_commit_failure_retains_prefix_and_aborts_suffix() {
+        assert_commit_failure_suffix(8, 4);
+    }
+    #[test]
+    fn minimum_middle_commit_failure_uses_dynamic_suffix_boundary() {
+        assert_commit_failure_suffix(3, 1);
     }
     #[test]
     fn cleanup_receivers_are_separate_from_jobs_and_handles_are_dropped() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,8 +73,10 @@ unattempted suffix, with earlier reports retained and all handles closed. This
 motivates an explicit committed-prefix boundary in a future decision; current
 Rust behavior is unchanged and remains supported only for its declared fixtures.
 Primary and independent full source acceptance at `76dbab0` corroborate the
-three reference fixtures; a separate ADR and native packet remain prerequisites
-to changing the coordinator's abort boundary.
+three reference fixtures; final-head acceptance at `133cddb` passed and PR #78
+integrated as `14cc2a6`. ADR-0010 and the T-0021/S05 packet now permit a private
+committed-prefix/uncommitted-suffix boundary. No new public/bridge type or
+production plugin boundary is introduced; implementation is still pending.
 
 T-0012 reference probes and S04's ignored live comparison are test-only tools
 outside the Emburk runtime. Their local executable retrieval and generated probe

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,7 +76,10 @@ Primary and independent full source acceptance at `76dbab0` corroborate the
 three reference fixtures; final-head acceptance at `133cddb` passed and PR #78
 integrated as `14cc2a6`. ADR-0010 and the T-0021/S05 packet now permit a private
 committed-prefix/uncommitted-suffix boundary. No new public/bridge type or
-production plugin boundary is introduced; implementation is still pending.
+production plugin boundary is introduced. The private implementation at
+`f2d9755` now aborts `handles[index..]` after an actual commit failure while
+preserving prior report tokens, all-close and separate cleanup. Primary and
+independent acceptance pass; final-head integration is pending.
 
 T-0012 reference probes and S04's ignored live comparison are test-only tools
 outside the Emburk runtime. Their local executable retrieval and generated probe

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -127,6 +127,10 @@ Final-head acceptance at `133cddb` passed and PR #78 integrated as `14cc2a6`.
 This is Reference Observation / Integration, not first/middle Rust compatibility;
 see the packet's per-index observation matrix. T-0021/S05 now prepares the
 private Unit/Contract candidate under ADR-0010 with no new Differential claim.
+Its primary and independent source acceptance pass at `f2d9755`: first/middle
+local execution retains prefix reports and aborts the uncommitted suffix, with
+existing S04/S06 live regressions unchanged. This adds no new first/middle
+Differential result or public verified plugin entry; integration is pending.
 
 ## Adding an Entry
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -123,8 +123,10 @@ coverage or Rust policy is claimed before its capture and acceptance gates.
 Its initial capture at `fb26813` records first/middle abort suffixes and retained
 report counts. Primary and independent full source acceptance pass at `76dbab0`:
 three cases, 57 semantic controls, two artifact controls and S05 regression.
-Integration remains pending. This is Reference Observation / Integration, not
-first/middle Rust compatibility; see the packet's per-index observation matrix.
+Final-head acceptance at `133cddb` passed and PR #78 integrated as `14cc2a6`.
+This is Reference Observation / Integration, not first/middle Rust compatibility;
+see the packet's per-index observation matrix. T-0021/S05 now prepares the
+private Unit/Contract candidate under ADR-0010 with no new Differential claim.
 
 ## Adding an Entry
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -103,6 +103,9 @@ at `133cddb` passed; PR #78 integrated as `14cc2a6`. This reference-only slice
 does not pass a native or phase delivery gate. ADR-0010 permits T-0021/S05's
 bounded native abort-suffix candidate; a later separate comparison is required
 for first/middle Differential evidence.
+T-0021/S05 primary and independent source acceptance now pass at `f2d9755`,
+including all local suffix cases and unchanged S04/S06 live regressions.
+Final-head acceptance and integration remain pending; phase gates stay open.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,8 +98,11 @@ capture-before-expectations gate; Rust policy remains unchanged.
 That initial capture is now reviewed at `fb26813`; Stage B validates the
 observed abort suffix and retained reports before any later native policy gate.
 Primary and independent Stage B acceptance pass at `76dbab0`, including three
-cases, 57 semantic controls and unchanged S05 regression. Integration remains
-pending; this reference-only slice does not pass a native or phase delivery gate.
+cases, 57 semantic controls and unchanged S05 regression. Final-head acceptance
+at `133cddb` passed; PR #78 integrated as `14cc2a6`. This reference-only slice
+does not pass a native or phase delivery gate. ADR-0010 permits T-0021/S05's
+bounded native abort-suffix candidate; a later separate comparison is required
+for first/middle Differential evidence.
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -279,8 +279,12 @@ cleanup reports before any wider policy decision.
 At `fb26813`, first/middle observations show that selected failure and remaining
 unattempted outputs abort, while prior successful reports survive and all handles
 close. Full S07 source acceptance now passes independently at `76dbab0`.
-Integration remains pending; the reference observations are not an accepted
-expansion of ADR-0009 or a production recovery policy.
+Final-head acceptance at `133cddb` passed and PR #78 integrated as `14cc2a6`.
+ADR-0010 now accepts only the selected private abort-suffix expansion for
+T-0021/S05. Actual successful reports precede the failure boundary; abort starts
+at the failed handle and includes unattempted handles. The separately packeted
+native candidate still requires implementation and acceptance; neither the
+observation nor this decision establishes a production recovery policy.
 
 The proposed failure fixture should throw inside input `run` before its own
 `finish` call. Calling this "before publication" would be unjustified: output

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -283,8 +283,10 @@ Final-head acceptance at `133cddb` passed and PR #78 integrated as `14cc2a6`.
 ADR-0010 now accepts only the selected private abort-suffix expansion for
 T-0021/S05. Actual successful reports precede the failure boundary; abort starts
 at the failed handle and includes unattempted handles. The separately packeted
-native candidate still requires implementation and acceptance; neither the
-observation nor this decision establishes a production recovery policy.
+native candidate is implemented and independently accepted at `f2d9755` for
+the selected local cases, with unchanged S04/S06 regressions. Integration is
+pending; neither the observation nor this private candidate establishes a
+production recovery policy or first/middle Differential evidence.
 
 The proposed failure fixture should throw inside input `run` before its own
 `finish` call. Calling this "before publication" would be unjustified: output

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -34,9 +34,9 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021/S05 is prepared for the next serial work item after S07 integration.
-Combined active WIP is zero of two; no item is `Blocked`. T-0012, T-0013 and
-T-0021 are Backlog until S05 activation; their parent contracts remain open.
+T-0021/S05 is the only serial active work item after S07 integration.
+Combined active WIP is one of two; no item is `Blocked`. T-0012 and T-0013
+remain Backlog; all three parent contracts remain open.
 
 | Item | State | Purpose |
 |---|---|---|
@@ -46,7 +46,7 @@ T-0021 are Backlog until S05 activation; their parent contracts remain open.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
 | T-0013 | Backlog | S01–S07 integrated; remaining comparisons and recovery contracts |
-| T-0021 | Backlog | S01–S04 integrated; S05 private abort suffix prepared |
+| T-0021/S05 | In Progress | Implement the private abort suffix under ADR-0010 |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -34,7 +34,7 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0021/S05 is the only serial active work item after S07 integration.
+T-0021/S05 is the only serial active work item, in Review in PR #79.
 Combined active WIP is one of two; no item is `Blocked`. T-0012 and T-0013
 remain Backlog; all three parent contracts remain open.
 
@@ -46,7 +46,7 @@ remain Backlog; all three parent contracts remain open.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
 | T-0013 | Backlog | S01–S07 integrated; remaining comparisons and recovery contracts |
-| T-0021/S05 | In Progress | Implement the private abort suffix under ADR-0010 |
+| T-0021/S05 | Review | Accept the private abort suffix in PR #79 under ADR-0010 |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -243,8 +243,8 @@ three-case Demo, 57 diagnostic-specific semantic controls, two artifact controls
 and unchanged S05 full regression. Both reproduce the observed abort suffix and
 retained report counts. Shell syntax, source hashes and diff checks pass.
 Evidence is Reference Observation / Integration only. Final-head acceptance at
-`133cddb` passed; PR #78 integrated as `14cc2a6`. First/middle Rust behavior is
-not yet implemented. ADR-0010 now permits the bounded T-0021/S05 abort-suffix
+`133cddb` passed; PR #78 integrated as `14cc2a6`. That reference slice added
+no Rust behavior. ADR-0010 now permits the bounded T-0021/S05 abort-suffix
 candidate, preserving existing live regressions. Current T-0021 SP is refined
 8 to 13; Initial stays 5. Parent completion and new Differential claims remain
 separate gates.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -22,7 +22,7 @@ Development state: `bootstrap`
 - A private synchronous empty-task coordinator executes original fake callbacks
   with separate cleanup capabilities and reports. Its Unit/Contract tests
   cover zero/one-input plans, one selected input-run failure, and selected
-  last-output-commit failure with retained actual reports. Other callback
+  first/middle/last output-commit failures with retained actual reports. Other callback
   failures and actual plugin execution are not implemented.
 - The product strategy selects a compact Rust execution core, optional
   out-of-process compatibility hosts, explicit versioned compatibility, and a
@@ -219,7 +219,7 @@ Current T-0021 SP is refined 5 to 8; Initial SP stays 5 and parent gates stay op
 T-0013/S06 now has a reviewed comparison packet for normal and selected
 last-output-commit failure. It changes only test infrastructure. Primary source
 acceptance at `a284f8b` passes both live projections (normal 44/failure 43 events,
-cleanup reports 1/8 and 1/7 in the observed 1/8 plan), 30 raw controls, two local
+cleanup reports 1/8 and 1/7 in the observed 1/8 plan), 31 raw controls, two local
 bridge tests and unchanged S04 live regression. Workspace tests pass 23 with
 four intentional ignores; formatting, strict Clippy and syntax checks pass.
 Independent Tester reproduced these results at the same source revision;
@@ -248,3 +248,12 @@ not yet implemented. ADR-0010 now permits the bounded T-0021/S05 abort-suffix
 candidate, preserving existing live regressions. Current T-0021 SP is refined
 8 to 13; Initial stays 5. Parent completion and new Differential claims remain
 separate gates.
+
+T-0021/S05 primary and independent source acceptance pass at `f2d9755`.
+The private coordinator preserves committed reports, aborts the failed and
+unattempted suffix and closes all handles. Three new local cases verify complete
+typed traces/tokens/cleanup. Exact Demo passes 12 local tests, S04/S06 four
+existing live projections and their 13/31 raw controls. Workspace tests pass
+26 with four intentional ignores, plus formatting and strict Clippy. Evidence
+is Unit/Contract plus existing Differential regression only; final-head
+acceptance and integration remain pending.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -34,9 +34,9 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S07 (`Review`, PR #78) is the only serial work item. Combined active WIP is one of
-two; no item is `Blocked`. T-0012 and T-0021 remain Backlog after
-their accepted slices; their remaining contracts/dependencies are not complete.
+T-0021/S05 is prepared for the next serial work item after S07 integration.
+Combined active WIP is zero of two; no item is `Blocked`. T-0012, T-0013 and
+T-0021 are Backlog until S05 activation; their parent contracts remain open.
 
 | Item | State | Purpose |
 |---|---|---|
@@ -45,8 +45,8 @@ their accepted slices; their remaining contracts/dependencies are not complete.
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S01–S06 integrated; remaining configuration/schema/value contracts |
-| T-0013/S07 | Review | Accept first/middle reference observations in PR #78 before Rust policy |
-| T-0021 | Backlog | S01–S04 integrated; remaining runtime contracts |
+| T-0013 | Backlog | S01–S07 integrated; remaining comparisons and recovery contracts |
+| T-0021 | Backlog | S01–S04 integrated; S05 private abort suffix prepared |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -242,5 +242,9 @@ S07 primary and independent source acceptance at `76dbab0` pass the exact
 three-case Demo, 57 diagnostic-specific semantic controls, two artifact controls
 and unchanged S05 full regression. Both reproduce the observed abort suffix and
 retained report counts. Shell syntax, source hashes and diff checks pass.
-Evidence is Reference Observation / Integration only; final-head acceptance and
-integration remain pending. First/middle Rust behavior is not yet implemented.
+Evidence is Reference Observation / Integration only. Final-head acceptance at
+`133cddb` passed; PR #78 integrated as `14cc2a6`. First/middle Rust behavior is
+not yet implemented. ADR-0010 now permits the bounded T-0021/S05 abort-suffix
+candidate, preserving existing live regressions. Current T-0021 SP is refined
+8 to 13; Initial stays 5. Parent completion and new Differential claims remain
+separate gates.

--- a/docs/decisions/ADR-0010-private-commit-abort-suffix.md
+++ b/docs/decisions/ADR-0010-private-commit-abort-suffix.md
@@ -1,0 +1,51 @@
+# ADR-0010: Private Commit Failure Aborts the Uncommitted Suffix
+
+- Status: Accepted
+- Date: 2026-09-06
+- Supersedes: ADR-0009's last-index-only supported fixture boundary
+
+## Context
+
+T-0013/S07 independently observed first and middle commit failures using
+original empty fixtures against the pinned Embulk executable. PR #78 integrated
+as `14cc2a6` after source and final-head acceptance. For observed N=8, failure
+at 0 aborted 0–7; failure at 4 retained commits 0–3 and aborted 4–7. Both closed
+all handles and cleanup received input report 1 and output reports 0/4.
+These callback observations do not establish durable publication or rollback.
+
+## Decision
+
+Permit T-0021/S05 to extend the existing private serial empty-task coordinator
+to the selected first/middle fixtures. On a commit error at k, retain actual
+reports from successful commits before k, attempt no later commit, abort each
+handle in [k,N), then close all handles. Never abort the committed prefix.
+The completed input report, original typed error through all four scopes,
+handle drop before cleanup and separate cleanup receivers remain unchanged.
+
+Actual callback Results drive the algorithm, not fixture identifiers, a
+hard-coded fan-out or a failure-index input to the coordinator. Existing fake
+selection is test instrumentation only. The original fake error text remains
+unchanged to preserve exact-payload regressions; it is not a runtime policy.
+Input-run failure retains its separate all-abort/all-close/no-reports path.
+
+The supported local fixture set includes first/middle failures in a supplied
+1/8 plan and a 1/3 middle boundary case. The latter is Unit/Contract only; it
+must not be described as an observed reference plan. Last-index 1/1 and 1/8,
+normal, zero-task and invalid-plan coverage remain unchanged. Mechanical
+generality does not establish arbitrary-index or concurrent reference coverage.
+
+## Consequences
+
+Only `crates/emburk-core/src/empty_lifecycle.rs` needs implementation/test
+changes. No public or bridge type changes, dependencies or host are authorized.
+Complete event vectors and actual report values must verify prefix retention,
+suffix abort, all-close, identical typed scope failures and separate cleanup.
+Both existing S04 and S06 live differential gates remain required regressions.
+First/middle Differential evidence requires a later separate T-0013 packet.
+
+All other ADR-0009 limitations remain: infallible fake abort/close/cleanup,
+no panic/cancellation/process-loss handling, real plugin API, Pages, data
+transfer, retry/resume, rollback, exactly-once, durability or release claim.
+No upstream implementation was inspected or translated for this decision.
+Existing artifact provenance applies; patent/FTO and redistribution gaps remain
+unreviewed, not cleared.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -13,3 +13,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0007](ADR-0007-private-ordered-logical-schema.md) | Private ordered logical schema before physical encoding | Accepted |
 | [ADR-0008](ADR-0008-private-empty-task-coordinator.md) | Private empty-task coordinator before public plugin traits | Accepted |
 | [ADR-0009](ADR-0009-private-last-commit-failure.md) | Private last-commit failure with retained reports | Accepted |
+| [ADR-0010](ADR-0010-private-commit-abort-suffix.md) | Private commit failure aborts the uncommitted suffix | Accepted; supersedes ADR-0009's last-index-only fixture boundary |

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -147,7 +147,7 @@
   output-commit projections. One serial implementation lane; no new runtime
   or Differential claim before acceptance.
 - T-0013/S06 primary frozen-source acceptance passes at `a284f8b`: two new live
-  projections, 30 raw controls, two local bridge tests and unchanged S04
+  projections, 31 raw controls, two local bridge tests and unchanged S04
   regression. Workspace 23 passed/four intentional ignores and strict checks
   pass. Review replaced a count-only scaffold with strict physical event
   equality and per-component error guards. Independent acceptance and PR
@@ -178,3 +178,12 @@
   for a one-file private abort-suffix implementation, retaining successful
   reports and existing live regressions. Current T-0021 SP is refined 8 to 13,
   Initial stays 5; no parent completion or first/middle Differential claim.
+- T-0021/S05 primary and independent frozen-source acceptance pass at `f2d9755`:
+  one-file private abort-suffix handling, three new complete trace/token/cleanup
+  cases, 12 focused passes, unchanged S04/S06 live gates, workspace 26 passed/
+  four intentionally ignored and strict quality checks. Earlier external-gate
+  exit remains retained with no unsupported root-cause claim; persistent exact
+  reruns passed. Final-head acceptance and integration remain pending.
+- Corrected S06's documented raw-control count from 30 to 31 after counting the
+  unchanged wrapper's calls and retained output markers. Bridge tests are
+  separate. No test, source gate or prior accepted behavior changed.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -173,3 +173,8 @@
   match the recorded Stage B expectations. Source identity, syntax and diff
   checks pass. Final-head acceptance and integration remain pending; evidence
   remains Reference Observation / Integration, with no Rust policy extension.
+- S07 final-head Demo passed at `133cddb`; PR #78 integrated as `14cc2a6`.
+  Parent #16 stays open and returns to Backlog. Prepared ADR-0010 and T-0021/S05
+  for a one-file private abort-suffix implementation, retaining successful
+  reports and existing live regressions. Current T-0021 SP is refined 8 to 13,
+  Initial stays 5; no parent completion or first/middle Differential claim.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -22,4 +22,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0021/S04 private last-commit failure](T-0021-last-commit-failure.md) | Done (Unit/Contract plus existing regression; PR #76) |
 | [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | Done (two selected Differential projections; PR #77) |
 | [T-0013/S07 output commit position observation](T-0013-output-commit-position-probe.md) | Done (bounded reference slice; PR #78, `14cc2a6`) |
-| [T-0021/S05 private commit abort suffix](T-0021-commit-abort-suffix.md) | Prepared under ADR-0010; implementation not started |
+| [T-0021/S05 private commit abort suffix](T-0021-commit-abort-suffix.md) | In Progress under ADR-0010; independent planning review passed |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -21,4 +21,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S05 output commit failure observation](T-0013-output-commit-failure-probe.md) | Done (Reference Observation / Integration; PR #75) |
 | [T-0021/S04 private last-commit failure](T-0021-last-commit-failure.md) | Done (Unit/Contract plus existing regression; PR #76) |
 | [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | Done (two selected Differential projections; PR #77) |
-| [T-0013/S07 output commit position observation](T-0013-output-commit-position-probe.md) | Review in PR #78 (primary and independent source acceptance passed; integration pending) |
+| [T-0013/S07 output commit position observation](T-0013-output-commit-position-probe.md) | Done (bounded reference slice; PR #78, `14cc2a6`) |
+| [T-0021/S05 private commit abort suffix](T-0021-commit-abort-suffix.md) | Prepared under ADR-0010; implementation not started |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -22,4 +22,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0021/S04 private last-commit failure](T-0021-last-commit-failure.md) | Done (Unit/Contract plus existing regression; PR #76) |
 | [T-0013/S06 selected output-commit differential](T-0013-output-commit-differential.md) | Done (two selected Differential projections; PR #77) |
 | [T-0013/S07 output commit position observation](T-0013-output-commit-position-probe.md) | Done (bounded reference slice; PR #78, `14cc2a6`) |
-| [T-0021/S05 private commit abort suffix](T-0021-commit-abort-suffix.md) | In Progress under ADR-0010; independent planning review passed |
+| [T-0021/S05 private commit abort suffix](T-0021-commit-abort-suffix.md) | Review in PR #79; primary and independent source acceptance passed |

--- a/docs/provenance/T-0013-output-commit-differential.md
+++ b/docs/provenance/T-0013-output-commit-differential.md
@@ -118,7 +118,7 @@ S06 compared exactly two live cases through one explicitly selected ignored
 Rust test. Normal execution projected 44 events and cleanup input 1/output 8
 reports; selected last-index failure projected 43 events and input 1/output 7
 reports for the observed 1/8 plan. The unchanged prerequisite S05 gate passed
-both fixtures and 23 controls. All 30 new raw controls rejected at their named
+both fixtures and 23 controls. All 31 new raw controls rejected at their named
 diagnostics. Two local bridge tests passed, including repaired event-count
 mutations, 1/1 and 1/8 local fixtures, and direct per-component/payload guards.
 The unchanged S04 regression compared two cases and rejected 13 raw controls.

--- a/docs/provenance/T-0013-output-commit-position-probe.md
+++ b/docs/provenance/T-0013-output-commit-position-probe.md
@@ -1,7 +1,7 @@
 # T-0013/S07 output commit position observation
 
 - Tracking issue: [T-0013, #16](https://github.com/bhind/emburk/issues/16)
-- State: Review in PR #78; primary and independent source acceptance passed
+- State: Done (bounded slice only); PR #78 integrated as `14cc2a6`
 - Priority: P0; parent T-0010
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0). Parent Current SP is refined 21 to 34; Initial SP remains 8.
@@ -293,8 +293,13 @@ Cases/traces SHA-256:
 Stdout/stderr SHA-256:
 `034b6734dbe07637bbcf43d2ded83f178c7290e3debf961a109d74a8e9df0eb4` /
 `4502b13c20c87f60fdeb96eaf54a0c2d63ad505cb7d0601dfc3f866e3a0b13e0`.
-No source finding remains. Final-head acceptance and integration are still
-required; the parent remains open.
+No source finding remains. Final-head exact Demo passed at
+`133cddb264b5d5d01313b938a5995b625b22adae`, including all three cases, 57 semantic
+controls, two artifact controls and unchanged S05 regression. Evidence:
+`${TMPDIR}/t0013-output-commit-position.0oDdCD/evidence`; retained logs:
+`/private/tmp/t0013-s07-final-head.QvIYg3`. Project audits passed (WIP 1/2).
+PR #78 integrated as `14cc2a677b02a86cbb4a7d51f9260b90dc83de28`.
+The bounded slice is complete; parent #16 remains open and returns to Backlog.
 
 ## Reference and reuse record
 

--- a/docs/provenance/T-0021-commit-abort-suffix.md
+++ b/docs/provenance/T-0021-commit-abort-suffix.md
@@ -83,6 +83,59 @@ It confirmed the one-file boundary, all three new local cases, full typed trace/
 token/cleanup assertions, unchanged last-failure behavior and preserved S04/S06
 live gates. This is Planning only, not implementation acceptance.
 
+### Primary frozen-source acceptance
+
+Source revision: `f2d9755cc47f2451e41559f0c13719b92118fb09`.
+Only the allowed core file changed; SHA-256:
+`489ab3301b3b5f73747c269bd4e45ff2c3f61df88322470117c71737f57050fd`.
+PM reviewed the complete diff: actual commit errors select the abort suffix,
+prior reports remain intact, all handles close and no public/bridge type or
+existing test changes. Three new tests compare complete typed event vectors,
+actual tokens, identical plans and one separate cleanup per component; the
+existing cleanup fake verifies handles have been dropped.
+
+Primary exact combined Demo at this revision exited 0: 12 local tests passed,
+two live tests intentionally ignored in the local phase and then separately
+executed through their wrappers. S04 compared two cases with 13 raw controls;
+S06 compared two cases with 31 raw controls plus its separate bridge tests and
+unchanged S05 gate. Workspace tests passed 26 with four intentional ignores.
+Format, explicit included-child Rust 2024 checks, strict workspace/all-target
+Clippy and diff checks all exited 0.
+
+Primary logs: `/private/tmp/t0021-s05-primary-acceptance.oAdVUk`.
+S04 evidence: `${TMPDIR}/t0013-s04.eWPSwK`;
+S06 evidence: `${TMPDIR}/t0013-s06.D2FaJt`.
+Combined stdout/stderr SHA-256:
+`570c2c8f9b9570bd5f3a529e81eb7c64424b0ed57367d714a5e1586000d11090` /
+`2d6d1578c0228a8b196565b8452c011b0f83880e64fbbc4c546b8ffe187acae5`.
+
+Accounting correction: prior S06 records said 30 raw controls. PM counted 31
+calls and 31 markers in the unchanged wrapper, independently confirmed by the
+implementer. The two Rust bridge tests are separate, not the extra raw control.
+Correct STATUS/TODO/S06 provenance/log to 31; no test or acceptance gate changes.
+
+The implementer's early external-gate attempt exited 4 with only the driver
+diagnostic `S03 full probe exited 1` and empty nested stdout/stderr at
+`${TMPDIR}/t0013-s04.7yUVAQ`. Its detailed cause is not established. Retain that
+attempt, not a success claim. A later persistent combined invocation and the
+post-commit invocation both passed; final implementer logs remain at
+`/private/tmp/t0021-s05-primary.shZx2H/final-combined.stdout.log` and its stderr
+peer. Primary frozen-source acceptance above passed without weakening any gate.
+
+Independent read-only Tester reproduced the exact persistent combined Demo at
+`f2d9755`: exit 0, 12 local passes/two intentional ignores, S04 two projections/
+13 raw controls and S06 two projections/31 raw controls plus separate bridge
+execution. Workspace 26 passed/four intentionally ignored, formatting, explicit
+child formatting, strict Clippy and diff checks passed. No source finding remains.
+Retained S04/S06 evidence: `${TMPDIR}/t0013-s04.qLpg8l` and
+`${TMPDIR}/t0013-s06.3TVLjw`. Final output fragment logs reside at
+`/private/tmp/t0021-s05-independent.6LtwAh`; fragment stdout SHA-256
+`aa343e2b32ceca5642111022edea5e28383a8c82331a733a85bddb9c2994bdf2`
+is not represented as the complete combined output hash.
+
+Evidence is Unit/Contract for the new cases and existing Differential regression
+only. Final-head acceptance and PR integration remain required.
+
 ## Reference and provenance
 
 Use only the already integrated S07 observed behavior and original local fakes.

--- a/docs/provenance/T-0021-commit-abort-suffix.md
+++ b/docs/provenance/T-0021-commit-abort-suffix.md
@@ -1,7 +1,7 @@
 # T-0021/S05 private commit abort suffix
 
 - Tracking issue: [T-0021, #18](https://github.com/bhind/emburk/issues/18)
-- State: In Progress; independent planning review passed
+- State: Review in PR #79; primary and independent source acceptance passed
 - Priority: P1; parent T-0020
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0). Parent Current SP is refined 8 to 13; Initial remains 5.

--- a/docs/provenance/T-0021-commit-abort-suffix.md
+++ b/docs/provenance/T-0021-commit-abort-suffix.md
@@ -1,7 +1,7 @@
 # T-0021/S05 private commit abort suffix
 
 - Tracking issue: [T-0021, #18](https://github.com/bhind/emburk/issues/18)
-- State: Prepared; implementation waits for Ready and activation
+- State: In Progress; independent planning review passed
 - Priority: P1; parent T-0020
 - Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
   environment 0). Parent Current SP is refined 8 to 13; Initial remains 5.
@@ -77,6 +77,11 @@ substituted for actual selected execution.
 
 Unit/Contract for new first/middle native behavior; regression of four existing
 S04/S06 Differential projections only. No new first/middle Differential claim.
+
+Independent read-only planning review at `a4093f1` found no blocking ambiguity.
+It confirmed the one-file boundary, all three new local cases, full typed trace/
+token/cleanup assertions, unchanged last-failure behavior and preserved S04/S06
+live gates. This is Planning only, not implementation acceptance.
 
 ## Reference and provenance
 

--- a/docs/provenance/T-0021-commit-abort-suffix.md
+++ b/docs/provenance/T-0021-commit-abort-suffix.md
@@ -1,0 +1,102 @@
+# T-0021/S05 private commit abort suffix
+
+- Tracking issue: [T-0021, #18](https://github.com/bhind/emburk/issues/18)
+- State: Prepared; implementation waits for Ready and activation
+- Priority: P1; parent T-0020
+- Slice estimate: 3 SP (implementation 1, uncertainty 1, verification 1,
+  environment 0). Parent Current SP is refined 8 to 13; Initial remains 5.
+  S01–S04 account for 8 accepted SP; this new 3 SP slice and remaining runtime
+  contract uncertainty exceed that forecast. No parent completion or duplicate
+  earned points is implied.
+
+## Authority
+
+PM owns ADR-0010, scope, canonical records, acceptance and integration. One
+Rust Core Implementer owns the exact source file below. Tester remains read-only.
+Standing owner authority permits this bounded implementation and accepted PR
+integration. Preserve the user's checkout and other worktrees.
+
+## Dependencies
+
+T-0021/S04 private last-commit handling (PR #76, `b5cfb87`), T-0013/S06 live
+normal/last comparisons (PR #77, `3b16aaf`), and T-0013/S07 independently
+accepted first/middle observations (PR #78, `14cc2a6`) are integrated.
+ADR-0010 accepts the bounded policy change. Requeue T-0013 to Backlog with its
+parent open; T-0012 stays Backlog. Use one serial active work item.
+
+## Branch and allowlist
+
+Branch: `feat/t-0021-commit-abort-suffix`.
+Mutation owner: Rust Core Implementer, exactly
+`crates/emburk-core/src/empty_lifecycle.rs` (private algorithm, comments and
+original local tests only).
+
+PM owns STATUS, TODO, ROADMAP, COMPATIBILITY, ARCHITECTURE, runtime design,
+ADR-0010/decision index, provenance/index, S07 integration closeout and dated log.
+Existing differential child files, shell/Python/Java tools, Cargo/dependencies,
+public APIs, CLI, schema/scalar files and external artifacts stay unchanged.
+
+## Artifacts
+
+Replace failed-handle-only abort with failed/unattempted suffix abort after an
+actual commit Result error. Preserve committed prefix report tokens, stop later
+commits, close all handles, propagate the same output error through four scopes,
+drop handles and invoke separate cleanup with actual input/output reports.
+Do not change normal/zero-task/input-run-failure paths or fake error text.
+Do not pass fixture selection into the coordinator or replay expected events.
+
+Add first failure N=8/k=0 and middle N=8/k=4 and N=3/k=1 local tests. Assert
+the full ordered typed trace, exact error and actual token contents, exactly one
+cleanup per component, matching plan, no live handles at cleanup, no abort on
+committed prefix and no commit after failure. Existing last failure 1/1 and 1/8
+tests remain unchanged. Update private comments to the exact approved boundary.
+
+## Acceptance criteria
+
+- Actual fake callbacks exercise all three new supplied plans/positions.
+- Complete trace and token assertions establish retained prefix, abort suffix,
+  all-close, original typed error propagation and separate cleanup.
+- Existing local normal, last-failure, input-failure, invalid-plan and handle
+  lifetime tests pass unchanged.
+- Unchanged S04 and S06 full live gates pass, including their raw controls.
+- Source stays in the one-file allowlist; no public or bridge types change.
+- Primary and independent Tester reproduce frozen-source Demo; final PR-head
+  Demo passes before integration. Parent #18 remains open.
+
+## Demo Command
+
+`cargo test -p emburk-core empty_lifecycle::tests -- --nocapture && bash tests/t0013_empty_lifecycle_differential_test.sh && bash tests/t0013_output_commit_differential_test.sh`
+
+Also require workspace tests, `cargo fmt --check`, strict workspace/all-target
+Clippy, explicit Rust 2024 format checks for the two included differential child
+files and `git diff --check`. Retain stdout/stderr and nonzero test counts,
+source revision/hash and live evidence directories. No ignored live test may be
+substituted for actual selected execution.
+
+## Evidence class
+
+Unit/Contract for new first/middle native behavior; regression of four existing
+S04/S06 Differential projections only. No new first/middle Differential claim.
+
+## Reference and provenance
+
+Use only the already integrated S07 observed behavior and original local fakes.
+Its packet records pinned Embulk 0.11.5 artifact/source identity, API provenance,
+license/notice retention and independently reviewed raw per-index traces.
+No additional upstream implementation, protocol, artifact or plugin adoption is
+authorized. Copyright/license permission is not patent/FTO clearance; existing
+patent, standards, redistribution/SBOM and jurisdiction gaps remain unreviewed.
+
+## Stop rule
+
+Repair ordinary build/test/network issues in scope. Return to PM before widening
+callback fallibility, source files, public/API/bridge types, upstream-source use
+or material security/IP exposure. Never discard unrelated edits or weaken a
+failing regression to manufacture acceptance.
+
+## Non-claims
+
+No arbitrary-index/concurrent compatibility, rollback, durable publication,
+retry/resume, exactly-once, cancellation, real plugin/host, values/Pages/data
+transfer, default fan-out, performance or release readiness. Reports remain
+opaque callback values; abort remains an infallible fake notification.


### PR DESCRIPTION
Implements bounded T-0021/S05 under ADR-0010; refs #18 (parent stays open). On actual private commit failure, retain committed prefix reports, abort failed/unattempted suffix, close all and preserve typed errors/separate cleanup. One core source file; no public/bridge or dependency changes. New complete trace/token tests cover first and middle 1/8 plus middle 1/3. Primary and independent exact Demo passed at f2d9755: 12 focused passes, unchanged S04/S06 four live projections and 13/31 raw controls; workspace 26 passed/4 intentional ignores, fmt and strict Clippy. Records include S07 integration closeout and correction of the previously undercounted S06 raw controls (no test changes). Evidence: Unit/Contract new behavior, existing Differential regression only. No new first/middle Differential, durability, rollback, resume or host claim. Final-head Demo required before integration.