### PR TITLE
feat(core): add private record values and selected live comparison

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -343,5 +343,8 @@ S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
 T-0012/S08 (5 SP within unchanged Current 34 / Initial 5) is prepared under
 ADR-0011 and its [packet](docs/provenance/T-0012-private-record-values.md).
 Only private values-only records and two selected live getter projections are
-in scope; schema/physical/public coupling remain excluded. Known accepted
-S03–S07 slice estimates total 15 SP; parent #15 remains open.
+in scope; schema/physical/public coupling remain excluded. Primary source
+acceptance at `914ad2e` passes both projections, 18 raw controls, six local tests,
+unchanged S06 regression and strict checks. Independent acceptance and PR
+integration remain pending. Known accepted S03–S07 slice estimates total 15 SP;
+no S08 points are awarded yet and parent #15 remains open.

--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,9 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S08` and `T-0021/S05` are integrated. T-0012/S07 is `Review` in PR #81;
-T-0013, T-0021 and all other unfinished items are `Backlog`. No item is
-`Blocked`. Combined active WIP is one of two.
+`T-0013/S08`, `T-0012/S07` and `T-0021/S05` are integrated. T-0012/S08 is being
+prepared; T-0012, T-0013, T-0021 and all other unfinished items are `Backlog`.
+No item is `Blocked`. Combined active WIP is zero of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S07: bounded Page value observation) | Review | P0 | 34 | T-0011 | Compatibility Host Implementer | Integration |
+| T-0012 | Specify configuration, schema, and value semantics (S08: private record values and comparison) | Ready | P0 | 34 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -338,3 +338,10 @@ fixtures, 39 raw controls, two artifact controls, unchanged three-schema
 regression and strict quality gates. Final-head acceptance and PR integration
 remain required. Parent #15 remains open; no Rust values or new Differential
 claim follows from this bounded reference observation.
+
+S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
+T-0012/S08 (5 SP within unchanged Current 34 / Initial 5) is prepared under
+ADR-0011 and its [packet](docs/provenance/T-0012-private-record-values.md).
+Only private values-only records and two selected live getter projections are
+in scope; schema/physical/public coupling remain excluded. Known accepted
+S03–S07 slice estimates total 15 SP; parent #15 remains open.

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 `T-0013/S08`, `T-0012/S07` and `T-0021/S05` are integrated. T-0012/S08 is
-`In Progress`; T-0013, T-0021 and all other unfinished items are `Backlog`.
+`Review` in PR #82; T-0013, T-0021 and all other unfinished items are `Backlog`.
 No item is `Blocked`. Combined active WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S08: private record values and comparison) | In Progress | P0 | 34 | T-0011 | Rust Core Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S08: private record values and comparison) | Review | P0 | 34 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -345,6 +345,7 @@ ADR-0011 and its [packet](docs/provenance/T-0012-private-record-values.md).
 Only private values-only records and two selected live getter projections are
 in scope; schema/physical/public coupling remain excluded. Primary source
 acceptance at `914ad2e` passes both projections, 18 raw controls, six local tests,
-unchanged S06 regression and strict checks. Independent acceptance and PR
-integration remain pending. Known accepted S03–S07 slice estimates total 15 SP;
+unchanged S06 regression and strict checks. Independent Tester reproduced the
+frozen source. Final PR-head acceptance and integration remain pending.
+Known accepted S03–S07 slice estimates total 15 SP;
 no S08 points are awarded yet and parent #15 remains open.

--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,9 @@ are intentionally unpointed; Story Points belong to independently acceptable
 tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
-`T-0013/S08`, `T-0012/S07` and `T-0021/S05` are integrated. T-0012/S08 is being
-prepared; T-0012, T-0013, T-0021 and all other unfinished items are `Backlog`.
-No item is `Blocked`. Combined active WIP is zero of two.
+`T-0013/S08`, `T-0012/S07` and `T-0021/S05` are integrated. T-0012/S08 is
+`In Progress`; T-0013, T-0021 and all other unfinished items are `Backlog`.
+No item is `Blocked`. Combined active WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -35,7 +35,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S08: private record values and comparison) | Ready | P0 | 34 | T-0011 | Rust Core Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S08: private record values and comparison) | In Progress | P0 | 34 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -14,6 +14,13 @@ mod scalar_resolution;
 )]
 mod logical_schema;
 
+// This is deliberately private until a later packet authorizes a record API.
+#[allow(
+    dead_code,
+    reason = "T-0012/S08 is private values-only storage without a public consumer"
+)]
+mod logical_record;
+
 // This is deliberately private: it is a bounded fake-fixture coordinator, not
 // a public plugin API or a production lifecycle contract.
 #[allow(

--- a/crates/emburk-core/src/logical_record.rs
+++ b/crates/emburk-core/src/logical_record.rs
@@ -1,0 +1,462 @@
+//! Private owned logical record values with no schema or physical encoding policy.
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum LogicalValue {
+    Null,
+    Boolean(bool),
+    Signed64(i64),
+    Text(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LogicalRecord {
+    cells: Vec<LogicalValue>,
+}
+
+impl LogicalRecord {
+    fn new(cells: Vec<LogicalValue>) -> Self {
+        Self { cells }
+    }
+
+    fn cells(&self) -> impl ExactSizeIterator<Item = &LogicalValue> {
+        self.cells.iter()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LogicalRecords {
+    records: Vec<LogicalRecord>,
+}
+
+impl LogicalRecords {
+    fn new(records: Vec<LogicalRecord>) -> Self {
+        Self { records }
+    }
+
+    fn records(&self) -> impl ExactSizeIterator<Item = &LogicalRecord> {
+        self.records.iter()
+    }
+}
+
+#[cfg(test)]
+const HEADER: &str = "T0012-S08\t1";
+#[cfg(test)]
+const CAP: usize = 1024;
+#[cfg(test)]
+const CASES: [&str; 2] = ["empty", "typed-null"];
+
+#[cfg(test)]
+fn parse_count(value: &str, label: &str) -> Result<usize, String> {
+    if value.is_empty()
+        || !value.bytes().all(|byte| byte.is_ascii_digit())
+        || (value.len() > 1 && value.starts_with('0'))
+    {
+        return Err(format!("malformed {label}"));
+    }
+    value.parse().map_err(|_| format!("malformed {label}"))
+}
+
+#[cfg(test)]
+fn parse_value(tag: &str, payload: &str) -> Result<LogicalValue, String> {
+    match tag {
+        "N" if payload == "-" => Ok(LogicalValue::Null),
+        "B" if matches!(payload, "true" | "false") => Ok(LogicalValue::Boolean(payload == "true")),
+        "L" => {
+            let value: i64 = payload.parse().map_err(|_| "malformed signed64 payload")?;
+            if value.to_string() != payload {
+                return Err("noncanonical signed64 payload".into());
+            }
+            Ok(LogicalValue::Signed64(value))
+        }
+        "S" => Ok(LogicalValue::Text(decode_hex(payload)?)),
+        "N" => Err("null payload must be -".into()),
+        "B" => Err("malformed boolean payload".into()),
+        _ => Err("unknown value tag".into()),
+    }
+}
+
+#[cfg(test)]
+fn decode_hex(value: &str) -> Result<String, String> {
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        || !value.len().is_multiple_of(2)
+    {
+        return Err("malformed lowercase hex payload".into());
+    }
+    let mut bytes = Vec::with_capacity(value.len() / 2);
+    for pair in value.as_bytes().as_chunks::<2>().0 {
+        let nibble = |byte| match byte {
+            b'0'..=b'9' => Ok(byte - b'0'),
+            b'a'..=b'f' => Ok(byte - b'a' + 10),
+            _ => Err("malformed lowercase hex payload"),
+        };
+        bytes.push(nibble(pair[0])? << 4 | nibble(pair[1])?);
+    }
+    String::from_utf8(bytes).map_err(|_| "non-UTF-8 text payload".into())
+}
+
+#[cfg(test)]
+type ParsedCase = (String, LogicalRecords, LogicalRecords);
+
+#[cfg(test)]
+fn parse_live_tsv(tsv: &str) -> Result<Vec<ParsedCase>, String> {
+    if !tsv.ends_with('\n') || tsv.contains('\r') {
+        return Err("manifest is not canonical TSV".into());
+    }
+    let mut lines = tsv.lines();
+    if lines.next() != Some(HEADER) {
+        return Err("unsupported manifest header".into());
+    }
+    let mut cases = Vec::new();
+    for expected_case in CASES {
+        let fields: Vec<_> = lines
+            .next()
+            .ok_or("missing case row")?
+            .split('\t')
+            .collect();
+        if fields.len() != 4 || fields[0] != "CASE" || fields[1] != expected_case {
+            return Err("case manifest is not exact and ordered".into());
+        }
+        let row_count = parse_count(fields[2], "row count")?;
+        let cells_per_row = parse_count(fields[3], "cells per row")?;
+        if row_count > CAP
+            || cells_per_row > CAP
+            || cells_per_row != 3
+            || (expected_case == "empty" && row_count != 0)
+            || (expected_case == "typed-null" && row_count != 3)
+        {
+            return Err("unsupported selected dimensions".into());
+        }
+        let mut input_records = Vec::with_capacity(row_count);
+        let mut expected_records = Vec::with_capacity(row_count);
+        for row_index in 0..row_count {
+            let row: Vec<_> = lines.next().ok_or("truncated row")?.split('\t').collect();
+            if row.len() != 2 || row[0] != "ROW" || row[1] != row_index.to_string() {
+                return Err("row order or index mismatch".into());
+            }
+            let mut input = Vec::with_capacity(cells_per_row);
+            let mut expected = Vec::with_capacity(cells_per_row);
+            for cell_index in 0..cells_per_row {
+                let cell: Vec<_> = lines.next().ok_or("truncated cell")?.split('\t').collect();
+                if cell.len() != 6 || cell[0] != "CELL" || cell[1] != cell_index.to_string() {
+                    return Err("cell order or index mismatch".into());
+                }
+                input.push(parse_value(cell[2], cell[3])?);
+                expected.push(parse_value(cell[4], cell[5])?);
+            }
+            input_records.push(LogicalRecord::new(input));
+            expected_records.push(LogicalRecord::new(expected));
+        }
+        cases.push((
+            expected_case.to_owned(),
+            LogicalRecords::new(input_records),
+            LogicalRecords::new(expected_records),
+        ));
+    }
+    if lines.next().is_some() || cases.len() != CASES.len() {
+        return Err("trailing or missing case records".into());
+    }
+    Ok(cases)
+}
+
+#[cfg(test)]
+fn compare_cases(cases: &[ParsedCase]) -> Result<(), String> {
+    for (name, actual, expected) in cases {
+        let actual_cells: Vec<_> = actual
+            .records()
+            .map(|record| record.cells().cloned().collect::<Vec<_>>())
+            .collect();
+        let expected_cells: Vec<_> = expected
+            .records()
+            .map(|record| record.cells().cloned().collect::<Vec<_>>())
+            .collect();
+        if actual_cells != expected_cells {
+            return Err(format!(
+                "oracle differs from private record storage for {name}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn assert_live_tsv(tsv: &str) -> Result<(), String> {
+    compare_cases(&parse_live_tsv(tsv)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell(
+        index: usize,
+        input_tag: &str,
+        input: &str,
+        reference_tag: &str,
+        reference: &str,
+    ) -> String {
+        format!("CELL\t{index}\t{input_tag}\t{input}\t{reference_tag}\t{reference}")
+    }
+
+    fn valid_tsv() -> String {
+        let rows = [
+            vec![
+                cell(0, "B", "true", "B", "true"),
+                cell(1, "L", "9223372036854775807", "L", "9223372036854775807"),
+                cell(2, "S", "", "S", ""),
+            ],
+            vec![
+                cell(0, "B", "false", "B", "false"),
+                cell(1, "L", "-9223372036854775808", "L", "-9223372036854775808"),
+                cell(2, "S", "417c420acebb", "S", "417c420acebb"),
+            ],
+            vec![
+                cell(0, "N", "-", "N", "-"),
+                cell(1, "N", "-", "N", "-"),
+                cell(2, "N", "-", "N", "-"),
+            ],
+        ];
+        let mut output = format!("{HEADER}\nCASE\tempty\t0\t3\nCASE\ttyped-null\t3\t3\n");
+        for (index, cells) in rows.iter().enumerate() {
+            output.push_str(&format!("ROW\t{index}\n{}\n", cells.join("\n")));
+        }
+        output
+    }
+
+    #[test]
+    fn preserves_order_nulls_bounds_and_owned_text() {
+        let mut text = String::from("crab 🦀\n");
+        let records = LogicalRecords::new(vec![LogicalRecord::new(vec![
+            LogicalValue::Null,
+            LogicalValue::Boolean(false),
+            LogicalValue::Signed64(i64::MIN),
+            LogicalValue::Text(text.clone()),
+            LogicalValue::Signed64(i64::MAX),
+            LogicalValue::Signed64(0),
+            LogicalValue::Text(String::new()),
+        ])]);
+        text.push_str("changed outside record");
+        assert_eq!(records.records().len(), 1);
+        assert_eq!(records.records().next().unwrap().cells().count(), 7);
+        assert_eq!(
+            records.records().next().unwrap().cells().nth(3),
+            Some(&LogicalValue::Text("crab 🦀\n".into()))
+        );
+        assert_eq!(
+            records
+                .records()
+                .next()
+                .unwrap()
+                .cells()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                LogicalValue::Null,
+                LogicalValue::Boolean(false),
+                LogicalValue::Signed64(i64::MIN),
+                LogicalValue::Text("crab 🦀\n".into()),
+                LogicalValue::Signed64(i64::MAX),
+                LogicalValue::Signed64(0),
+                LogicalValue::Text(String::new()),
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_empty_record_and_record_stream() {
+        let empty_stream = LogicalRecords::new(Vec::new());
+        assert_eq!(empty_stream.records().len(), 0);
+        let records = LogicalRecords::new(vec![LogicalRecord::new(Vec::new())]);
+        assert_eq!(records.records().len(), 1);
+        assert_eq!(records.records().next().unwrap().cells().len(), 0);
+    }
+
+    #[test]
+    fn live_tsv_bridge_stores_every_selected_row_and_cell() {
+        let valid = valid_tsv();
+        assert!(assert_live_tsv(&valid).is_ok());
+        let cases = parse_live_tsv(&valid).unwrap();
+        assert_eq!(cases[0].0, "empty");
+        assert_eq!(cases[0].1.records().len(), 0);
+        assert_eq!(cases[0].2.records().len(), 0);
+        assert_eq!(cases[1].0, "typed-null");
+        let actual: Vec<Vec<_>> = cases[1]
+            .1
+            .records()
+            .map(|record| record.cells().cloned().collect())
+            .collect();
+        assert_eq!(
+            actual,
+            vec![
+                vec![
+                    LogicalValue::Boolean(true),
+                    LogicalValue::Signed64(i64::MAX),
+                    LogicalValue::Text(String::new()),
+                ],
+                vec![
+                    LogicalValue::Boolean(false),
+                    LogicalValue::Signed64(i64::MIN),
+                    LogicalValue::Text("A|B\nλ".into()),
+                ],
+                vec![LogicalValue::Null, LogicalValue::Null, LogicalValue::Null],
+            ]
+        );
+    }
+
+    fn rejects(tsv: String, diagnostic: &str) {
+        assert_eq!(assert_live_tsv(&tsv), Err(diagnostic.into()), "{tsv}");
+    }
+
+    #[test]
+    fn live_tsv_bridge_rejects_header_case_dimension_and_order_errors() {
+        let valid = valid_tsv();
+        rejects(
+            valid.replacen(HEADER, "T0012-S08\t2", 1),
+            "unsupported manifest header",
+        );
+        rejects(valid.trim_end().into(), "manifest is not canonical TSV");
+        rejects(valid.replace('\n', "\r\n"), "manifest is not canonical TSV");
+        rejects(
+            valid.replacen("CASE\tempty", "BROKEN\tempty", 1),
+            "case manifest is not exact and ordered",
+        );
+        rejects(
+            valid.replacen("CASE\tempty", "CASE\tunknown", 1),
+            "case manifest is not exact and ordered",
+        );
+        rejects(
+            valid.replacen("CASE\ttyped-null", "CASE\tempty", 1),
+            "case manifest is not exact and ordered",
+        );
+        rejects(
+            valid.replacen("CASE\ttyped-null\t3\t3\n", "", 1),
+            "case manifest is not exact and ordered",
+        );
+        let reordered = valid.replacen(
+            "CASE\tempty\t0\t3\nCASE\ttyped-null\t3\t3",
+            "CASE\ttyped-null\t0\t3\nCASE\tempty\t3\t3",
+            1,
+        );
+        rejects(reordered, "case manifest is not exact and ordered");
+        for replacement in ["01", "x", "1025"] {
+            let diagnostic = if replacement == "1025" {
+                "unsupported selected dimensions"
+            } else {
+                "malformed row count"
+            };
+            rejects(
+                valid.replacen(
+                    "CASE\tempty\t0\t3",
+                    &format!("CASE\tempty\t{replacement}\t3"),
+                    1,
+                ),
+                diagnostic,
+            );
+        }
+        rejects(
+            valid.replacen("CASE\tempty\t0\t3", "CASE\tempty\t0\t1025", 1),
+            "unsupported selected dimensions",
+        );
+        rejects(
+            valid.replacen("CASE\ttyped-null\t3\t3", "CASE\ttyped-null\t2\t3", 1),
+            "unsupported selected dimensions",
+        );
+        rejects(
+            valid.replacen("CASE\ttyped-null\t3\t3", "CASE\ttyped-null\t3\t2", 1),
+            "unsupported selected dimensions",
+        );
+        rejects(
+            valid.replacen("ROW\t0", "ROW\t1", 1),
+            "row order or index mismatch",
+        );
+        rejects(
+            valid.replacen("ROW\t0", "ROW\t0\textra", 1),
+            "row order or index mismatch",
+        );
+        rejects(
+            valid.replacen("CELL\t0", "CELL\t1", 1),
+            "cell order or index mismatch",
+        );
+        rejects(
+            valid.replacen("CELL\t0", "CELL\t0\textra", 1),
+            "cell order or index mismatch",
+        );
+        rejects(
+            format!("{valid}ROW\t0\n"),
+            "trailing or missing case records",
+        );
+        rejects(
+            valid.replacen("CELL\t2\tN\t-\tN\t-\n", "", 1),
+            "truncated cell",
+        );
+    }
+
+    #[test]
+    fn live_tsv_bridge_rejects_type_payload_and_text_errors() {
+        let valid = valid_tsv();
+        rejects(
+            valid.replacen("\tB\ttrue\tB\ttrue", "\tB\tTRUE\tB\ttrue", 1),
+            "malformed boolean payload",
+        );
+        rejects(
+            valid.replacen("\tB\ttrue\tB\ttrue", "\tX\ttrue\tB\ttrue", 1),
+            "unknown value tag",
+        );
+        rejects(
+            valid.replacen("\tB\ttrue\tB\ttrue", "\tB\ttrue\tL\ttrue", 1),
+            "malformed signed64 payload",
+        );
+        rejects(
+            valid.replacen("9223372036854775807", "01", 1),
+            "noncanonical signed64 payload",
+        );
+        rejects(
+            valid.replacen("9223372036854775807", "9223372036854775808", 1),
+            "malformed signed64 payload",
+        );
+        rejects(
+            valid.replacen("417c420acebb", "417C420acebb", 1),
+            "malformed lowercase hex payload",
+        );
+        rejects(
+            valid.replacen("417c420acebb", "f", 1),
+            "malformed lowercase hex payload",
+        );
+        rejects(
+            valid.replacen("417c420acebb", "ff", 1),
+            "non-UTF-8 text payload",
+        );
+        rejects(
+            valid.replacen("\tN\t-\tN\t-", "\tN\tempty\tN\t-", 1),
+            "null payload must be -",
+        );
+        rejects(
+            valid.replacen("\tN\t-\tN\t-", "\tS\t-\tN\t-", 1),
+            "malformed lowercase hex payload",
+        );
+    }
+
+    #[test]
+    fn expected_only_mutation_fails_comparison_without_changing_inputs() {
+        let valid = valid_tsv();
+        let changed_reference =
+            valid.replacen("CELL\t0\tB\ttrue\tB\ttrue", "CELL\t0\tB\ttrue\tB\tfalse", 1);
+        let baseline = parse_live_tsv(&valid).unwrap();
+        let cases = parse_live_tsv(&changed_reference).unwrap();
+        assert_eq!(cases[1].1, baseline[1].1);
+        assert_eq!(
+            compare_cases(&cases),
+            Err("oracle differs from private record storage for typed-null".into())
+        );
+    }
+
+    #[test]
+    #[ignore = "requires the external T-0012/S08 oracle driver"]
+    fn live_page_value_differential() {
+        let path = std::env::var("T0012_S08_MANIFEST")
+            .expect("T0012_S08_MANIFEST must name driver output");
+        assert_live_tsv(&std::fs::read_to_string(path).expect("read manifest"))
+            .expect("live manifest must match private records");
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,10 +116,10 @@ acceptance and integration remain required; parent and phase gates stay open.
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
 Its two bounded reference observations are accepted. T-0012/S08 implements
 private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
-`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+`914ad2e`, primary and independent acceptance pass two selected getter-result comparisons,
 18 raw controls, six local storage/transport tests and the unchanged three-schema
 regression. Workspace 35 passed/six intentionally ignored, formatting and strict
-Clippy pass. Independent acceptance and PR integration remain required.
+Clippy pass. Final PR-head acceptance and integration remain required.
 Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,11 +114,14 @@ no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
-Its two bounded reference observations are accepted. T-0012/S08 now prepares
-private Null/Boolean/Signed64/Text records and selected getter-result comparison
-under ADR-0011. Schema coupling, physical encoding and public API remain outside
-this packet. No new native value or Differential claim before source acceptance;
-parent and phase delivery gates remain open.
+Its two bounded reference observations are accepted. T-0012/S08 implements
+private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
+`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+18 raw controls, six local storage/transport tests and the unchanged three-schema
+regression. Workspace 35 passed/six intentionally ignored, formatting and strict
+Clippy pass. Independent acceptance and PR integration remain required.
+Schema coupling, physical encoding, public API and production transfer remain
+outside this slice; parent and phase delivery gates stay open.
 
 
 T-0012 reference probes and S04's ignored live comparison are test-only tools

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,6 +113,13 @@ is selected Reference Observation / Integration plus validator Unit/Contract;
 no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
+S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
+Its two bounded reference observations are accepted. T-0012/S08 now prepares
+private Null/Boolean/Signed64/Text records and selected getter-result comparison
+under ADR-0011. Schema coupling, physical encoding and public API remain outside
+this packet. No new native value or Differential claim before source acceptance;
+parent and phase delivery gates remain open.
+
 
 T-0012 reference probes and S04's ignored live comparison are test-only tools
 outside the Emburk runtime. Their local executable retrieval and generated probe

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -170,10 +170,10 @@ acceptance and integration remain required; parent and phase gates stay open.
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
 Its two bounded reference observations are accepted. T-0012/S08 implements
 private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
-`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+`914ad2e`, primary and independent acceptance pass two selected getter-result comparisons,
 18 raw controls, six local storage/transport tests and the unchanged three-schema
 regression. Workspace 35 passed/six intentionally ignored, formatting and strict
-Clippy pass. Independent acceptance and PR integration remain required.
+Clippy pass. Final PR-head acceptance and integration remain required.
 Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -167,6 +167,13 @@ is selected Reference Observation / Integration plus validator Unit/Contract;
 no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
+S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
+Its two bounded reference observations are accepted. T-0012/S08 now prepares
+private Null/Boolean/Signed64/Text records and selected getter-result comparison
+under ADR-0011. Schema coupling, physical encoding and public API remain outside
+this packet. No new native value or Differential claim before source acceptance;
+parent and phase delivery gates remain open.
+
 
 ## Adding an Entry
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -168,11 +168,14 @@ no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
-Its two bounded reference observations are accepted. T-0012/S08 now prepares
-private Null/Boolean/Signed64/Text records and selected getter-result comparison
-under ADR-0011. Schema coupling, physical encoding and public API remain outside
-this packet. No new native value or Differential claim before source acceptance;
-parent and phase delivery gates remain open.
+Its two bounded reference observations are accepted. T-0012/S08 implements
+private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
+`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+18 raw controls, six local storage/transport tests and the unchanged three-schema
+regression. Workspace 35 passed/six intentionally ignored, formatting and strict
+Clippy pass. Independent acceptance and PR integration remain required.
+Schema coupling, physical encoding, public API and production transfer remain
+outside this slice; parent and phase delivery gates stay open.
 
 
 ## Adding an Entry

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -141,10 +141,10 @@ acceptance and integration remain required; parent and phase gates stay open.
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
 Its two bounded reference observations are accepted. T-0012/S08 implements
 private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
-`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+`914ad2e`, primary and independent acceptance pass two selected getter-result comparisons,
 18 raw controls, six local storage/transport tests and the unchanged three-schema
 regression. Workspace 35 passed/six intentionally ignored, formatting and strict
-Clippy pass. Independent acceptance and PR integration remain required.
+Clippy pass. Final PR-head acceptance and integration remain required.
 Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -139,11 +139,14 @@ no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
-Its two bounded reference observations are accepted. T-0012/S08 now prepares
-private Null/Boolean/Signed64/Text records and selected getter-result comparison
-under ADR-0011. Schema coupling, physical encoding and public API remain outside
-this packet. No new native value or Differential claim before source acceptance;
-parent and phase delivery gates remain open.
+Its two bounded reference observations are accepted. T-0012/S08 implements
+private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
+`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+18 raw controls, six local storage/transport tests and the unchanged three-schema
+regression. Workspace 35 passed/six intentionally ignored, formatting and strict
+Clippy pass. Independent acceptance and PR integration remain required.
+Schema coupling, physical encoding, public API and production transfer remain
+outside this slice; parent and phase delivery gates stay open.
 
 
 ## Phase 1: Native File-to-File MVP

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -138,6 +138,13 @@ is selected Reference Observation / Integration plus validator Unit/Contract;
 no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
+S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
+Its two bounded reference observations are accepted. T-0012/S08 now prepares
+private Null/Boolean/Signed64/Text records and selected getter-result comparison
+under ADR-0011. Schema coupling, physical encoding and public API remain outside
+this packet. No new native value or Differential claim before source acceptance;
+parent and phase delivery gates remain open.
+
 
 ## Phase 1: Native File-to-File MVP
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -323,6 +323,13 @@ is selected Reference Observation / Integration plus validator Unit/Contract;
 no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
+S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
+Its two bounded reference observations are accepted. T-0012/S08 now prepares
+private Null/Boolean/Signed64/Text records and selected getter-result comparison
+under ADR-0011. Schema coupling, physical encoding and public API remain outside
+this packet. No new native value or Differential claim before source acceptance;
+parent and phase delivery gates remain open.
+
 
 The proposed failure fixture should throw inside input `run` before its own
 `finish` call. Calling this "before publication" would be unjustified: output

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -326,10 +326,10 @@ acceptance and integration remain required; parent and phase gates stay open.
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
 Its two bounded reference observations are accepted. T-0012/S08 implements
 private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
-`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+`914ad2e`, primary and independent acceptance pass two selected getter-result comparisons,
 18 raw controls, six local storage/transport tests and the unchanged three-schema
 regression. Workspace 35 passed/six intentionally ignored, formatting and strict
-Clippy pass. Independent acceptance and PR integration remain required.
+Clippy pass. Final PR-head acceptance and integration remain required.
 Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open.
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -324,11 +324,14 @@ no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
-Its two bounded reference observations are accepted. T-0012/S08 now prepares
-private Null/Boolean/Signed64/Text records and selected getter-result comparison
-under ADR-0011. Schema coupling, physical encoding and public API remain outside
-this packet. No new native value or Differential claim before source acceptance;
-parent and phase delivery gates remain open.
+Its two bounded reference observations are accepted. T-0012/S08 implements
+private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
+`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+18 raw controls, six local storage/transport tests and the unchanged three-schema
+regression. Workspace 35 passed/six intentionally ignored, formatting and strict
+Clippy pass. Independent acceptance and PR integration remain required.
+Schema coupling, physical encoding, public API and production transfer remain
+outside this slice; parent and phase delivery gates stay open.
 
 
 The proposed failure fixture should throw inside input `run` before its own

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -18,7 +18,12 @@ Development state: `bootstrap`
   data-transfer, or performance claim has passed its evidence gate.
 - A private ordered logical schema preserves owned names, type tags, order and
   duplicates. Its live comparison matches three selected schema outcomes;
-  values, nullability, lookup and physical encoding remain unimplemented.
+  schema coupling to values, nullability, lookup and physical encoding remain
+  unimplemented.
+- Private owned Null/Boolean/Signed64/Text records preserve row/cell order and
+  distinguish null from false, zero and empty text. Primary acceptance matches
+  two selected reference getter-result projections; independent acceptance and
+  integration are pending. This is not a production record-transfer path.
 - A private synchronous empty-task coordinator executes original fake callbacks
   with separate cleanup capabilities and reports. Its Unit/Contract tests
   cover zero/one-input plans, one selected input-run failure, and selected
@@ -294,8 +299,11 @@ no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
-Its two bounded reference observations are accepted. T-0012/S08 now prepares
-private Null/Boolean/Signed64/Text records and selected getter-result comparison
-under ADR-0011. Schema coupling, physical encoding and public API remain outside
-this packet. No new native value or Differential claim before source acceptance;
-parent and phase delivery gates remain open.
+Its two bounded reference observations are accepted. T-0012/S08 implements
+private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
+`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+18 raw controls, six local storage/transport tests and the unchanged three-schema
+regression. Workspace 35 passed/six intentionally ignored, formatting and strict
+Clippy pass. Independent acceptance and PR integration remain required.
+Schema coupling, physical encoding, public API and production transfer remain
+outside this slice; parent and phase delivery gates stay open.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -35,8 +35,8 @@ Development state: `bootstrap`
 ## Delivery queue
 
 T-0013/S08 and T-0012/S07 are integrated through PRs #80 and #81. T-0012/S08
-is being prepared for private values-only storage and selected comparison.
-Combined active WIP is zero of two; no item is `Blocked`. T-0012, T-0013 and
+is the single active private values-only storage and selected comparison slice.
+Combined active WIP is one of two; no item is `Blocked`. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
@@ -45,7 +45,7 @@ T-0021 parent contracts remain open.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S08 | Ready | Private values-only records and selected comparison |
+| T-0012/S08 | In Progress | Private values-only records and selected comparison |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S01–S05 integrated; remaining runtime contracts |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -34,9 +34,10 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0013/S08 is integrated through PR #80. T-0012/S07 is the single active
-isolated reference observation. Combined active WIP is one of two;
-no item is `Blocked`. T-0012, T-0013 and T-0021 parent contracts remain open.
+T-0013/S08 and T-0012/S07 are integrated through PRs #80 and #81. T-0012/S08
+is being prepared for private values-only storage and selected comparison.
+Combined active WIP is zero of two; no item is `Blocked`. T-0012, T-0013 and
+T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
 |---|---|---|
@@ -44,7 +45,7 @@ no item is `Blocked`. T-0012, T-0013 and T-0021 parent contracts remain open.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S07 | Review | PR #81; two bounded Page value observations |
+| T-0012/S08 | Ready | Private values-only records and selected comparison |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S01–S05 integrated; remaining runtime contracts |
 
@@ -291,3 +292,10 @@ intentional ignores, formatting, strict Clippy and Bash syntax pass. Evidence
 is selected Reference Observation / Integration plus validator Unit/Contract;
 no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
+
+S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
+Its two bounded reference observations are accepted. T-0012/S08 now prepares
+private Null/Boolean/Signed64/Text records and selected getter-result comparison
+under ADR-0011. Schema coupling, physical encoding and public API remain outside
+this packet. No new native value or Differential claim before source acceptance;
+parent and phase delivery gates remain open.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -22,8 +22,8 @@ Development state: `bootstrap`
   unimplemented.
 - Private owned Null/Boolean/Signed64/Text records preserve row/cell order and
   distinguish null from false, zero and empty text. Primary acceptance matches
-  two selected reference getter-result projections; independent acceptance and
-  integration are pending. This is not a production record-transfer path.
+  two selected reference getter-result projections, reproduced by an independent
+  Tester. Integration is pending; this is not a production record-transfer path.
 - A private synchronous empty-task coordinator executes original fake callbacks
   with separate cleanup capabilities and reports. Its Unit/Contract tests
   cover zero/one-input plans, one selected input-run failure, and selected
@@ -50,7 +50,7 @@ T-0021 parent contracts remain open.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S08 | In Progress | Private values-only records and selected comparison |
+| T-0012/S08 | Review | PR #82: private values-only records and selected comparison |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S01–S05 integrated; remaining runtime contracts |
 
@@ -301,9 +301,9 @@ acceptance and integration remain required; parent and phase gates stay open.
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
 Its two bounded reference observations are accepted. T-0012/S08 implements
 private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
-`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+`914ad2e`, primary and independent acceptance pass two selected getter-result comparisons,
 18 raw controls, six local storage/transport tests and the unchanged three-schema
 regression. Workspace 35 passed/six intentionally ignored, formatting and strict
-Clippy pass. Independent acceptance and PR integration remain required.
+Clippy pass. Final PR-head acceptance and integration remain required.
 Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open.

--- a/docs/decisions/ADR-0011-private-logical-record-values.md
+++ b/docs/decisions/ADR-0011-private-logical-record-values.md
@@ -1,0 +1,43 @@
+# ADR-0011: Private Logical Record Values Before Schema Coupling
+
+- Status: Accepted
+- Date: 2026-09-06
+
+## Context
+
+T-0012/S07 is integrated through PR #81 (`203d7da`) after primary,
+independent and final-head acceptance. Its original test-local Page collector
+observed empty records and three ordered Boolean/Long/String/null rows. This
+does not establish Page encoding, general ownership, schema mismatch timing
+or other value types. ADR-0007's ordered schema remains a separate private
+storage boundary; ADR-0004 remains a physical-batch target, not an encoding
+selected by these observations.
+
+## Decision
+
+Permit T-0012/S08 to add only private, dependency-free, owned logical values:
+Null, Boolean(bool), Signed64(i64), Text(String). Preserve ordered cells in
+records and ordered records without coercion, default substitution, truncation,
+name lookup or deduplication. Text ownership must not depend on caller buffers.
+
+Do not couple this representation to LogicalSchema or Column yet. No constructor
+validation or schema/type mismatch policy is selected. The reference adapter
+validates the exact observed schema before projecting only supplied cells and
+actual getter/null outcomes. A test-only comparison constructs real private
+records from supplied inputs and compares their actual read-only contents with
+those outcomes. Fixture labels cannot manufacture expected values.
+
+No new crate, public export, plugin trait, production data path, Arrow/Page
+encoding or wire format is authorized. The owned test transport is not a public
+record format. Float64, timestamp and JSON values remain unsupported, not
+represented by guessed defaults.
+
+## Consequences
+
+This is a values-only storage/reconstruction boundary, not a general record or
+schema API. Local arbitrary storage tests are Unit/Contract; only the two selected
+S07 getter-result projections may gain Differential evidence. Typed-null getter
+behavior, malformed external record validation, schema coupling, batching,
+transfer, resource permits and public exposure require later packets. Existing
+schema, scalar, lifecycle and S07 source remain unchanged.
+

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,3 +14,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0008](ADR-0008-private-empty-task-coordinator.md) | Private empty-task coordinator before public plugin traits | Accepted |
 | [ADR-0009](ADR-0009-private-last-commit-failure.md) | Private last-commit failure with retained reports | Accepted |
 | [ADR-0010](ADR-0010-private-commit-abort-suffix.md) | Private commit failure aborts the uncommitted suffix | Accepted; supersedes ADR-0009's last-index-only fixture boundary |
+| [ADR-0011](ADR-0011-private-logical-record-values.md) | Private values-only records before schema coupling | Accepted |

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -227,8 +227,11 @@ no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
 
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
-Its two bounded reference observations are accepted. T-0012/S08 now prepares
-private Null/Boolean/Signed64/Text records and selected getter-result comparison
-under ADR-0011. Schema coupling, physical encoding and public API remain outside
-this packet. No new native value or Differential claim before source acceptance;
-parent and phase delivery gates remain open.
+Its two bounded reference observations are accepted. T-0012/S08 implements
+private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
+`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+18 raw controls, six local storage/transport tests and the unchanged three-schema
+regression. Workspace 35 passed/six intentionally ignored, formatting and strict
+Clippy pass. Independent acceptance and PR integration remain required.
+Schema coupling, physical encoding, public API and production transfer remain
+outside this slice; parent and phase delivery gates stay open.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -229,9 +229,9 @@ acceptance and integration remain required; parent and phase gates stay open.
 S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
 Its two bounded reference observations are accepted. T-0012/S08 implements
 private owned Null/Boolean/Signed64/Text records under ADR-0011. At frozen source
-`914ad2e`, primary acceptance passes two selected getter-result comparisons,
+`914ad2e`, primary and independent acceptance pass two selected getter-result comparisons,
 18 raw controls, six local storage/transport tests and the unchanged three-schema
 regression. Workspace 35 passed/six intentionally ignored, formatting and strict
-Clippy pass. Independent acceptance and PR integration remain required.
+Clippy pass. Final PR-head acceptance and integration remain required.
 Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -225,3 +225,10 @@ intentional ignores, formatting, strict Clippy and Bash syntax pass. Evidence
 is selected Reference Observation / Integration plus validator Unit/Contract;
 no Rust values, production transfer or new Differential result. Final-head
 acceptance and integration remain required; parent and phase gates stay open.
+
+S07 final-head Demo passed at `3b95ecd`; PR #81 integrated as `203d7da`.
+Its two bounded reference observations are accepted. T-0012/S08 now prepares
+private Null/Boolean/Signed64/Text records and selected getter-result comparison
+under ADR-0011. Schema coupling, physical encoding and public API remain outside
+this packet. No new native value or Differential claim before source acceptance;
+parent and phase delivery gates remain open.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -25,4 +25,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0021/S05 private commit abort suffix](T-0021-commit-abort-suffix.md) | Done (bounded slice; PR #79, `d36cf28`) |
 | [T-0013/S08 selected commit-position differential](T-0013-commit-position-differential.md) | Done (bounded slice; PR #80, `de38a44`) |
 | [T-0012/S07 bounded Page value observation](T-0012-page-value-probe.md) | Done (bounded reference slice; PR #81, `203d7da`) |
-| [T-0012/S08 private record values](T-0012-private-record-values.md) | Ready; independent packet review passed |
+| [T-0012/S08 private record values](T-0012-private-record-values.md) | In Progress; independent packet review passed |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -24,4 +24,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S07 output commit position observation](T-0013-output-commit-position-probe.md) | Done (bounded reference slice; PR #78, `14cc2a6`) |
 | [T-0021/S05 private commit abort suffix](T-0021-commit-abort-suffix.md) | Done (bounded slice; PR #79, `d36cf28`) |
 | [T-0013/S08 selected commit-position differential](T-0013-commit-position-differential.md) | Done (bounded slice; PR #80, `de38a44`) |
-| [T-0012/S07 bounded Page value observation](T-0012-page-value-probe.md) | Review in PR #81; primary and independent source acceptance passed at `1e7d5c9` |
+| [T-0012/S07 bounded Page value observation](T-0012-page-value-probe.md) | Done (bounded reference slice; PR #81, `203d7da`) |
+| [T-0012/S08 private record values](T-0012-private-record-values.md) | Ready; independent packet review passed |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -25,4 +25,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0021/S05 private commit abort suffix](T-0021-commit-abort-suffix.md) | Done (bounded slice; PR #79, `d36cf28`) |
 | [T-0013/S08 selected commit-position differential](T-0013-commit-position-differential.md) | Done (bounded slice; PR #80, `de38a44`) |
 | [T-0012/S07 bounded Page value observation](T-0012-page-value-probe.md) | Done (bounded reference slice; PR #81, `203d7da`) |
-| [T-0012/S08 private record values](T-0012-private-record-values.md) | In Progress; independent packet review passed |
+| [T-0012/S08 private record values](T-0012-private-record-values.md) | Review in PR #82; primary and independent source acceptance passed |

--- a/docs/provenance/T-0012-page-value-probe.md
+++ b/docs/provenance/T-0012-page-value-probe.md
@@ -1,7 +1,7 @@
 # T-0012/S07 bounded Page value observation
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: Review in [PR #81](https://github.com/bhind/emburk/pull/81); primary and independent source acceptance passed
+- State: Done as a bounded slice; PR #81 integrated as `203d7da`; parent remains open
 - Branch: `research/t-0012-page-value-probe`
 - Priority: P0; parent T-0010
 - Owner: Compatibility Host Implementer; records/decisions/integration: PM
@@ -300,6 +300,21 @@ S06: `${TMPDIR}/t0012-s06.ZJKLSy`. Raw cases/traces SHA-256:
 `c4c9d48f54ad164bfa7f2bd4646835419809647ac54c86c85395b2b30c5bc584`.
 No remaining acceptance finding. Final-head Demo and PR integration remain
 required; source acceptance does not complete parent #15 or any native value gate.
+
+### Final-head acceptance and integration
+
+Final PR-head exact Demo passed with exit 0 at
+`3b95ecdb6918b6ff6449ffb977ee79dba1c0dc21`: two Page fixtures, 39 raw controls,
+artifact controls, one full marker and unchanged three-schema regression.
+Source hashes match frozen acceptance; only canonical records changed afterward.
+Logs: `/private/tmp/t0012-s07-final-head.pFH4ht`; stdout SHA-256
+`8b6a73766fc2f0f35c41041d58d30bc19a1753cd3c5c99ab5a6790867ae287b3`;
+stderr empty. Page evidence: `${TMPDIR}/t0012-page-value-probe/run.kbwGa8/evidence`;
+S06: `${TMPDIR}/t0012-s06.sHVg2E`. Project delivery/governance and clean-head
+checks passed before exact-head guarded squash integration. PR #81 merged as
+`203d7daa9fe27f7421e06ea0a0eca91cc1dc1ff8`. This 3 SP slice is accepted;
+known S03–S07 slice estimates total 15 SP, not parent completion or retroactive
+S01/S02 points. Parent #15 stays open for remaining contracts.
 
 ## Evidence class and non-claims
 

--- a/docs/provenance/T-0012-private-record-values.md
+++ b/docs/provenance/T-0012-private-record-values.md
@@ -1,7 +1,7 @@
 # T-0012/S08 private record values and selected comparison
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: In Progress; independent packet review passed with transport clarifications
+- State: Review in [PR #82](https://github.com/bhind/emburk/pull/82)
 - Branch: `feat/t-0012-private-record-values`
 - Owner: Rust Core Implementer; canonical decisions/integration: PM
 - Priority: P0; parent T-0010
@@ -224,4 +224,36 @@ Temporary agent-slot exhaustion was resolved by starting a fresh read-only
 Tester after implementation finished; no independence gate was waived.
 
 Evidence is Unit/Contract plus the two selected Differential projections only.
-Independent Tester acceptance and final PR-head Demo/integration remain pending.
+
+## Independent reproduction
+
+The fresh read-only Tester reproduced the exact compound Demo with exit 0 at
+unchanged source hashes (`b493925` adds PM documentation only). Retained run:
+`/private/tmp/t0012-s08-final.wqfBnG/exact-demo.exit`; native evidence is its
+`evidence/` subdirectory, with the same normalized manifest hash as primary.
+The tool exposed incomplete outer output for that attempt, so it is not used
+as the complete-log acceptance run. The subsequent redirected exact rerun
+exited 0 and retained complete logs in `/private/tmp/t0012-s08-retained.M3hmoK`:
+`demo.stdout.log`, `demo.stderr.log` (empty), and `demo.exit` (0).
+Stdout SHA-256:
+`1b979f9c917a6acdc389f41cdca04f9b0922666e8fc66f067c636638bc14f8c5`.
+Independent S08/S06 evidence directories under the temporary root above are
+`t0012-s08.jtj0rs` and `t0012-s06.NBFA5H`. The normalized manifest matches primary.
+Primary inspected the retained logs and actual named live-test success.
+
+The earlier independent attempt in `/private/tmp/emburk-t0012-s08-acceptance`
+exited 4 before S06. Its nested artifact attempt `t0012-page-artifact.S4uiIP`
+records `curl: (6) Could not resolve host: github.com` and runner exit 56.
+The EXIT trap did emit the evidence directory. PM corrected the initial Tester
+inference that a missing trap/marker caused failure: retrieval failed before the
+corrupt-copy control could be prepared. This was a network-environment failure,
+not a source defect or an accepted corrupted artifact. No gate was weakened.
+
+Independent workspace tests, formatting, strict Clippy, separate Bash syntax,
+external-cache Python compilation, source hashes and diff checks passed.
+Complete-log independent retention passed. Final PR-head Demo/integration
+remain required; parent and delivery gates stay open.
+
+Environment remains macOS/Darwin arm64, Rust/Cargo 1.98.1, Python 3.14.6,
+Temurin 17 and Bash 3.2, using only the admitted Embulk 0.11.5 reference.
+No MSRV, alternate platform or Java-version compatibility claim follows.

--- a/docs/provenance/T-0012-private-record-values.md
+++ b/docs/provenance/T-0012-private-record-values.md
@@ -1,7 +1,7 @@
 # T-0012/S08 private record values and selected comparison
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: Ready; independent packet review passed with transport clarifications
+- State: In Progress; independent packet review passed with transport clarifications
 - Branch: `feat/t-0012-private-record-values`
 - Owner: Rust Core Implementer; canonical decisions/integration: PM
 - Priority: P0; parent T-0010

--- a/docs/provenance/T-0012-private-record-values.md
+++ b/docs/provenance/T-0012-private-record-values.md
@@ -167,3 +167,61 @@ Return to PM before source allowlist expansion, public/schema/physical coupling,
 different fixtures/artifacts, new normalization exclusions or material IP/security
 uncertainty. Do not edit S07 to make the driver pass, weaken a gate, invent live
 outputs or mutate the user's checkout.
+
+## Frozen source and primary acceptance
+
+Source commit: `914ad2e9f63fffecddcde988cea4caf778270e37`.
+Only the four source/test allowlist paths changed. Existing schema, scalar,
+lifecycle, S07, Cargo and CLI sources are unchanged.
+
+| Source | SHA-256 |
+| --- | --- |
+| `crates/emburk-core/src/logical_record.rs` | `5c8702affa7af6b4c6a669370c2220c1e612d79ecc37be7f246b08928950402d` |
+| `crates/emburk-core/src/lib.rs` | `a81ca1807e5f7570a8268b92dc0e8d95f317f72d3dd9ccde2e8ae3682d0f85bc` |
+| `tools/t0012-page-value-differential` | `e6dbc57428c3c5681d04e604c286c25a030a36851a1ce93b04901fe416407714` |
+| `tests/t0012_page_value_differential_test.sh` | `4d892b0b694618b84a4dc6dce296788451fb5b96e731f3f2b9fb8cebb915ee52` |
+
+Primary reviewed the complete four-file change independently of the source
+implementers. Input cells construct actual private storage; expected-only
+mutation preserves those inputs and fails with the comparison-specific error.
+The raw-only path uses the same complete validation and projection as live mode,
+but emits no live marker. Exact six-file hash identities are checked before
+opening manifest-selected files. No upstream implementation was copied.
+
+The exact two-script Demo exited 0 at the frozen source. Primary logs:
+`/private/tmp/t0012-s08-primary.2S6x04/demo.stdout.log` and `demo.stderr.log`.
+Stdout SHA-256:
+`b56546c8242c79aedfbd3a0b716b0896d258c85b81d533e771fa045a075571e2`;
+stderr is empty. Temporary evidence root is
+`/var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T`:
+
+- S08 `t0012-s08.HnvBfO`, including manifest, source revision/hashes, native
+  control/live logs, full driver stdout/stderr and original raw-evidence path;
+- reference `t0012-page-value-probe/run.9AMos8/evidence`, retaining complete
+  runtime/artifact/source/coordinate/stage identities and raw logs;
+- unchanged S06 `t0012-s06.n6bXJI`.
+
+Both actual reference processes exited 0: empty has 32 raw events and zero rows;
+typed-null has 110 events and three rows. The native live test executed exactly
+once and passed. Eighteen diagnostic-specific S08 raw controls passed, alongside
+the mandatory full S07 gate (39 raw and two artifact controls), six local Rust
+storage/transport tests and unchanged S06's three live schema comparisons.
+The normalized manifest SHA-256 is
+`94b949ebeb6ba7b136323605fcf9307422c05d7d6d328cc1ef82529848d657ae`.
+
+Primary quality logs are in `/private/tmp/t0012-s08-primary-quality.gUJHr1`.
+Workspace tests passed 35 with six intentionally ignored live tests; workspace
+formatting, strict all-target Clippy, separate Bash syntax, external-cache
+Python compilation and diff checks all exited 0. Implementer frozen Demo also
+exited 0 in `t0012-s08-combined-frozen.hAXq4j` under the temporary root above.
+
+Retained non-acceptance attempts include the initial incomplete draft runs,
+`t0012-s08-full-draft.XbnCJd` (pinned retrieval exited 56 before the unchanged
+artifact checksum control could execute), and an initial Clippy rejection of
+constant-size `chunks_exact`, corrected before freezing. Contributor reproduction
+in `t0012-s08-repro.IxwN3W` has no confirmed final exit and is not acceptance.
+Temporary agent-slot exhaustion was resolved by starting a fresh read-only
+Tester after implementation finished; no independence gate was waived.
+
+Evidence is Unit/Contract plus the two selected Differential projections only.
+Independent Tester acceptance and final PR-head Demo/integration remain pending.

--- a/docs/provenance/T-0012-private-record-values.md
+++ b/docs/provenance/T-0012-private-record-values.md
@@ -1,0 +1,169 @@
+# T-0012/S08 private record values and selected comparison
+
+- Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
+- State: Ready; independent packet review passed with transport clarifications
+- Branch: `feat/t-0012-private-record-values`
+- Owner: Rust Core Implementer; canonical decisions/integration: PM
+- Priority: P0; parent T-0010
+- Estimate: 5 SP (implementation 2, uncertainty 0, verification 2, environment 1;
+  raw 5). Within unchanged Current 34 / Initial 5. Known accepted S03–S07
+  slice estimates total 15 SP; S01/S02 receive no retroactive points. Do not
+  combine parent forecast and slice velocity or claim parent completion.
+
+## Authority and dependencies
+
+Standing owner authority permits bounded implementation and independently
+accepted PR integration. ADR-0011 permits the private values-only boundary.
+S07 is integrated through PR #81 as `203d7daa9fe27f7421e06ea0a0eca91cc1dc1ff8`
+after frozen-source acceptance at `1e7d5c9` and final-head Demo at `3b95ecd`.
+Existing schema/scalar/lifecycle slices remain accepted regressions.
+
+Use one serial active Project item and a separate read-only Tester. T-0013
+and T-0021 stay Backlog; all three parents remain open. Preserve the user's
+checkout and unrelated worktrees.
+
+## Mutation owner and exact allowlist
+
+One Rust Core Implementer owns exactly:
+
+- `crates/emburk-core/src/logical_record.rs`: new private types and tests;
+- `crates/emburk-core/src/lib.rs`: private module registration with narrowly
+  scoped unused-code explanation only; preserve existing declarations/tests;
+- `tools/t0012-page-value-differential`: new Python-standard-library driver;
+- `tests/t0012_page_value_differential_test.sh`: new wrapper and controls.
+
+PM owns ADR-0011/index, this packet/provenance index, STATUS, TODO, ROADMAP,
+ARCHITECTURE, COMPATIBILITY, runtime design, S07 closeout and dated log.
+Existing logical_schema/scalar/lifecycle files, S07 Java/runner/wrapper, Cargo,
+dependencies, CLI and public API remain unchanged. Implementers do not edit
+canonical records or integrate PRs. Testers/reviewers remain read-only.
+
+## Private storage decision
+
+Implement only an original private value enum with Null, Boolean(bool),
+Signed64(i64), Text(String), and ordered record/cell storage. Constructors take
+already typed values; read-only iteration returns actual stored contents.
+Own text and record collections. Preserve null separately from false, zero and
+empty text. No source parser, coercion, lookup, schema coupling, shape/type
+validation timing, additional types or physical representation policy.
+
+Local tests cover empty records/sequences, ordered selected cells/rows, exact
+i64 bounds, Unicode/newline/empty text, null versus false/zero/empty text and
+caller-string mutation after construction. Extra local values establish only
+storage invariants, not additional Embulk observations.
+
+## Reference adapter and validation reuse
+
+Invoke exactly `["bash", "tests/t0012_page_value_probe_test.sh"]` with repository
+root as cwd. Require successful exit and exactly one
+`T0012_PAGE_FULL_PROBE=passed|evidence=...` marker. Preserve complete runtime,
+source, local artifact/coordinate, stage, raw-log and hash identities. S07's
+full gate includes two fresh live fixtures, 39 raw controls and two artifact
+controls; capture-only/validate-only cannot substitute for it.
+
+PM explicitly permits reuse of the unchanged S07 raw validator instead of
+duplicating its complete callback model: before any projection, invoke its
+runner with T0012_PAGE_MODE=validate and the selected evidence directory, require
+exit 0 and stdout exactly `T0012_PAGE_VALIDATE_ONLY=passed` followed by one
+newline, with empty stderr; no duplicate/noisy marker or exit-only acceptance.
+This raw validator is not artifact
+admission. Full live mode still requires the full wrapper above. In the new
+driver's raw-copy validate-only mode, call this same raw gate before independent
+projection checks; never emit the full live comparison marker from raw copies.
+
+Independently verify exact cases, canonical capture/sequence, count caps, raw-log/
+trace/digest consistency, exact ordered schema and exhaustive input/read cell
+extraction. Unknown or unpaired records cannot disappear in projection: complete
+S07 validation precedes any exclusion. Retain original input-cell records
+separately from actual isNull/typed-getter records, including row/cell positions.
+Do not derive reference results from fixture names, supplied values or totals.
+
+Only after validation, project supplied inputs and actual null/getter results
+into the owned manifest below. Schema, setters, callbacks and instrumentation
+are not native comparison events in this values-only slice; they must pass S07
+raw validation first. No ignored field becomes an unreviewed normalization rule.
+
+## Owned test manifest
+
+UTF-8 TSV header: `T0012-S08\t1`.
+For exactly empty then typed-null:
+
+- `CASE\tfixture\trow_count\tcells_per_row`
+- For each ordered row: `ROW\trow_index`
+- For each ordered cell:
+  `CELL\tcell_index\tinput_tag\tinput_payload\treference_tag\treference_payload`
+
+The selected schema has three cells per row (never total cells); empty has zero rows and typed-null has
+three. Tags: N for null with payload `-`; B for canonical true/false; L for
+canonical signed-64 decimal; S for lowercase hex UTF-8 bytes, including empty
+payload for empty text. Null is never encoded as false, zero or empty text.
+Require exact header, arity, case membership/order, row/cell indices, counts and
+payloads, no trailing records. Cap row/cell counts at 1024 before allocation and
+also require the selected fixture dimensions. Reject unknown tags, malformed/
+noncanonical numbers/hex/UTF-8 and null/payload contradictions. These are test
+transport constraints, not a production parser or native constructor policy.
+
+Rust constructs real private records from input fields, observes their actual
+stored contents and compares to reference fields. No cloned-reference-as-actual
+shortcut. An expected-only mutation must leave inputs unchanged and cause the
+actual comparison to fail. Keep live tests explicitly ignored in offline runs;
+the wrapper proves exactly one named live test actually passed.
+
+## Artifacts, acceptance and Demo Command
+
+All generated manifests, builds, raw-copy controls and logs remain external
+temporary/ignored artifacts. Retain complete stdout/stderr, source revision/
+hashes, raw evidence paths and normalized manifest hash.
+
+Demo Command:
+`bash tests/t0012_page_value_differential_test.sh && bash tests/t0012_schema_differential_test.sh`
+
+Require two actual live record projections, mandatory full S07 gate and its
+controls, exactly one named Rust live test executed, local transport/storage
+controls and unchanged S06 three-schema regression. Negative tests include:
+
+- missing/duplicate/unknown/reordered cases and malformed header/rows/cells;
+- bounded counts before allocation, wrong dimensions/indices and extra records;
+- type/payload mismatch, malformed bool/i64/text, null/payload contradictions;
+- row/cell order, cross-typed cells, changed values and reference-only mutation;
+- fresh repaired raw copies testing case/capture/sequence/digest/log/schema,
+  input-versus-getter/null contradiction, missing row/exhaustion and callback
+  order, with intended diagnostic checks proving the raw gate was not bypassed.
+
+Use ordinary validation functions; no giant embedded-code exec/argv mutation.
+Primary and read-only Tester reproduce the exact Demo at frozen source, plus
+workspace tests, formatting, strict all-target Clippy, separate shell syntax,
+external-cache Python syntax and diff/source hash checks. Final PR-head Demo
+passes before integration. No zero-match live test or missing-runtime skip.
+
+## Evidence class, provenance and non-claims
+
+Unit/Contract for private storage/transport controls; Differential (Embulk) only
+for the exact two selected S07 getter-result projections after acceptance.
+See [S07 provenance](T-0012-page-value-probe.md): admitted Embulk 0.11.5 SHA-256
+`e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`,
+core `c5ac2d471edac465b45088669d376a7e2a525f8f`, SPI 0.11
+`576e98033a14ba8ac994ed581d3c9d8fcdda2749`; access date 2026-09-06.
+Only original repository tests and accepted black-box observations influence
+implementation. No new external source/API, artifact, dependency or plugin
+admission; no upstream implementation copying/translation or JAR redistribution.
+Apache-2.0 notices stay in retained evidence. SBOM/redistribution, patent,
+standards, trademark and freedom-to-operate gaps remain unreviewed.
+
+No general record/schema API, schema mismatch/nullable-field policy, typed-null
+getter behavior, Float64/time/JSON, Page bytes/ownership, Arrow, batching,
+plugin/host, production transfer, durability/resume/performance/release or parent
+completion claim. Extra synthetic fixtures are never counted as live matches.
+
+Independent read-only packet review found no scope leak. PM accepted its two
+transport clarifications: cells_per_row is explicitly three, not nine total
+cells, and raw-validator success is exact unique output with empty stderr.
+This is readiness evidence only; no implementation or live match is established.
+
+## Stop rule
+
+Fix ordinary build/test/retrieval issues in scope and retain unsuccessful attempts.
+Return to PM before source allowlist expansion, public/schema/physical coupling,
+different fixtures/artifacts, new normalization exclusions or material IP/security
+uncertainty. Do not edit S07 to make the driver pass, weaken a gate, invent live
+outputs or mutate the user's checkout.

--- a/tests/t0012_page_value_differential_test.sh
+++ b/tests/t0012_page_value_differential_test.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+driver="$root/tools/t0012-page-value-differential"
+evidence_dir=${T0012_S08_EVIDENCE_DIR:-$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-s08.XXXXXX")}
+mkdir -p -- "$evidence_dir"
+printf 'T0012_S08_EVIDENCE_DIR=%s\n' "$evidence_dir"
+
+PYTHONPYCACHEPREFIX="$evidence_dir/pycache" python3 -m py_compile "$driver"
+bash -n "$0"
+cargo test --manifest-path "$root/Cargo.toml" -p emburk-core \
+  logical_record::tests -- --nocapture > "$evidence_dir/rust-controls.log" 2>&1
+grep -Fqx 'test logical_record::tests::live_tsv_bridge_rejects_header_case_dimension_and_order_errors ... ok' \
+  "$evidence_dir/rust-controls.log"
+grep -Eq '^test result: ok\. [1-9][0-9]* passed; 0 failed; 1 ignored; .* filtered out;' \
+  "$evidence_dir/rust-controls.log"
+
+"$driver" --output "$evidence_dir/live.tsv" \
+  > "$evidence_dir/driver.stdout.log" 2> "$evidence_dir/driver.stderr.log"
+[[ $(grep -Ec '^T0012_S08_PROJECTED_CASES=2\|evidence=.+\|manifest=.+' \
+  "$evidence_dir/driver.stdout.log") == 1 ]]
+[[ $(grep -c '^T0012_PAGE_FULL_PROBE=passed|evidence=' \
+  "$evidence_dir/driver.stdout.log") == 1 ]]
+raw_evidence=$(python3 - "$evidence_dir/driver.stdout.log" <<'PY'
+import pathlib
+import sys
+
+prefix = "T0012_S08_PROJECTED_CASES=2|evidence="
+lines = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+rows = [line for line in lines if line.startswith(prefix)]
+if len(rows) != 1 or "|manifest=" not in rows[0]:
+    raise SystemExit(1)
+print(rows[0][len(prefix):].split("|manifest=", 1)[0])
+PY
+)
+[[ -d "$raw_evidence" ]]
+grep -Fqx $'T0012-S08\t1' "$evidence_dir/live.tsv"
+[[ $(grep -c $'^CASE\t' "$evidence_dir/live.tsv") == 2 ]]
+[[ $(grep -c $'^ROW\t' "$evidence_dir/live.tsv") == 3 ]]
+[[ $(grep -c $'^CELL\t' "$evidence_dir/live.tsv") == 9 ]]
+
+copy_raw() {
+  local destination=$1
+  mkdir -p -- "$destination"
+  cp "$raw_evidence/page-cases.raw" "$raw_evidence/page-traces.raw" \
+    "$raw_evidence/raw-evidence-hashes.txt" "$raw_evidence/empty.trace.raw" \
+    "$raw_evidence/typed-null.trace.raw" "$raw_evidence/empty.raw.log" \
+    "$raw_evidence/typed-null.raw.log" "$destination/"
+}
+
+mutated_copy() {
+  local action=$1 fixture=${2:-typed-null} copy
+  copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-s08-raw.XXXXXX")
+  copy_raw "$copy"
+  PYTHONDONTWRITEBYTECODE=1 python3 - "$action" "$fixture" "$copy" <<'PY'
+import base64
+import hashlib
+import pathlib
+import sys
+
+action, fixture, directory = sys.argv[1:]
+root = pathlib.Path(directory)
+cases = root.joinpath("page-cases.raw").read_text(encoding="utf-8").splitlines()
+traces = root.joinpath("page-traces.raw").read_text(encoding="utf-8").splitlines()
+
+def enc(value):
+    return base64.b64encode(value.encode("utf-8")).decode("ascii")
+
+def find(name, occurrence=0):
+    matches = [index for index, row in enumerate(traces)
+               if row.split("|")[1] == fixture and row.split("|")[4] == name]
+    return matches[occurrence]
+
+def repair_transport():
+    for selected in ("empty", "typed-null"):
+        sequence = 0
+        for index, row in enumerate(traces):
+            fields = row.split("|")
+            if fields[1] == selected:
+                sequence += 1
+                fields[3] = str(sequence)
+                traces[index] = "|".join(fields)
+        rows = [row for row in traces if row.split("|")[1] == selected]
+        material = ("\n".join(rows) + "\n").encode("utf-8")
+        root.joinpath(f"{selected}.trace.raw").write_bytes(material)
+        log = root / f"{selected}.raw.log"
+        other = [line for line in log.read_text(encoding="utf-8").splitlines()
+                 if not line.startswith("PAGETRACE|")]
+        log.write_text("\n".join(rows + other) + "\n", encoding="utf-8")
+        case_index = next(index for index, row in enumerate(cases)
+                          if row.startswith(f"PAGECASE|{selected}|"))
+        fields = cases[case_index].split("|")
+        fields[3] = str(len(rows))
+        fields[4] = hashlib.sha256(material).hexdigest()
+        cases[case_index] = "|".join(fields)
+
+if action == "missing-case":
+    cases.pop(0)
+elif action == "duplicate-case":
+    cases[1] = cases[0]
+elif action == "reorder-case":
+    cases.reverse()
+elif action == "capture":
+    index = find("schema-column")
+    fields = traces[index].split("|"); fields[2] = "not-a-uuid"
+    traces[index] = "|".join(fields)
+elif action == "sequence":
+    index = find("schema-column")
+    fields = traces[index].split("|"); fields[3] = "1"
+    traces[index] = "|".join(fields)
+elif action == "digest":
+    index = 0 if fixture == "empty" else 1
+    fields = cases[index].split("|"); fields[4] = "0" * 64
+    cases[index] = "|".join(fields)
+elif action == "raw-log":
+    path = root / f"{fixture}.raw.log"
+    path.write_text(path.read_text(encoding="utf-8").replace(
+        f"PAGETRACE|{fixture}|", "BROKEN|", 1), encoding="utf-8")
+elif action == "schema":
+    index = find("schema-column")
+    fields = traces[index].split("|"); fields[-2] = enc("changed")
+    traces[index] = "|".join(fields)
+    repair_transport()
+elif action == "input-value":
+    index = find("input-cell")
+    fields = traces[index].split("|"); fields[-1] = enc("false")
+    traces[index] = "|".join(fields)
+    repair_transport()
+elif action == "null-contradiction":
+    index = find("reader-is-null-return", 6)
+    fields = traces[index].split("|"); fields[-1] = enc("false")
+    traces[index] = "|".join(fields)
+    repair_transport()
+elif action == "missing-row":
+    start = find("reader-next-record-entry", 1)
+    end = find("reader-next-record-entry", 2)
+    del traces[start:end]
+    repair_transport()
+elif action == "exhaustion":
+    index = find("reader-next-record-return", 3)
+    fields = traces[index].split("|"); fields[-1] = enc("true")
+    traces[index] = "|".join(fields)
+    repair_transport()
+elif action == "callback-order":
+    first = find("reader-is-null-entry")
+    second = find("reader-is-null-return")
+    traces[first], traces[second] = traces[second], traces[first]
+    repair_transport()
+elif action.startswith("hash-"):
+    hash_lines = root.joinpath("raw-evidence-hashes.txt").read_text(
+        encoding="utf-8").splitlines()
+    if action == "hash-missing":
+        hash_lines.pop()
+    elif action == "hash-duplicate":
+        hash_lines[-1] = hash_lines[0]
+    elif action == "hash-name":
+        hash_lines[0] = "../page-cases.raw=" + hash_lines[0].split("=", 1)[1]
+    elif action == "hash-extra":
+        hash_lines.append("extra=" + "0" * 64)
+    elif action == "hash-digest":
+        hash_lines[0] = hash_lines[0].split("=", 1)[0] + "=" + "G" * 64
+    root.joinpath("raw-evidence-hashes.txt").write_text(
+        "\n".join(hash_lines) + "\n", encoding="utf-8")
+    print(root)
+    raise SystemExit(0)
+else:
+    raise ValueError(action)
+
+root.joinpath("page-cases.raw").write_text("\n".join(cases) + "\n",
+                                                encoding="utf-8")
+root.joinpath("page-traces.raw").write_text("\n".join(traces) + "\n",
+                                                 encoding="utf-8")
+names = ("page-cases.raw", "page-traces.raw", "empty.raw.log",
+         "typed-null.raw.log", "empty.trace.raw", "typed-null.trace.raw")
+root.joinpath("raw-evidence-hashes.txt").write_text(
+    "".join(f"{name}={hashlib.sha256(root.joinpath(name).read_bytes()).hexdigest()}\n"
+            for name in names), encoding="utf-8")
+print(root)
+PY
+}
+
+validator_fails() {
+  local action=$1 fixture=$2 expected=$3 copy status
+  copy=$(mutated_copy "$action" "$fixture")
+  printf 'T0012_S08_RAW_CONTROL=%s:%s|evidence=%s\n' "$fixture" "$action" "$copy"
+  if "$driver" --validate-evidence "$copy" \
+    > "$copy/validator.stdout.log" 2> "$copy/validator.stderr.log"; then
+    status=0
+  else
+    status=$?
+  fi
+  [[ "$status" == 4 ]]
+  grep -Fqx "T0012_S08_VALIDATION_ERROR|$expected" "$copy/validator.stderr.log"
+  [[ ! -s "$copy/validator.stdout.log" ]]
+}
+
+validator_fails missing-case empty 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|case-count'
+validator_fails duplicate-case empty 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|case-fixture'
+validator_fails reorder-case empty 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|case-fixture'
+validator_fails capture typed-null 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|capture-id'
+validator_fails sequence typed-null 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|sequence-contiguous'
+validator_fails digest empty 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|case-digest-match'
+validator_fails raw-log typed-null 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|raw-log-trace-match'
+validator_fails schema typed-null 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|schema-order-values'
+validator_fails input-value typed-null 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|assignment-order-values'
+validator_fails null-contradiction typed-null 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|page-read-order-values'
+validator_fails missing-row typed-null 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|page-read-order-values'
+validator_fails exhaustion typed-null 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|page-read-order-values'
+validator_fails callback-order typed-null 'S07-raw-gate:4:T0012_PAGE_VALIDATION_ERROR|page-read-order-values'
+validator_fails hash-missing empty raw-hash-file-count
+validator_fails hash-duplicate empty raw-hash-name
+validator_fails hash-name empty raw-hash-name
+validator_fails hash-extra empty raw-hash-file-count
+validator_fails hash-digest empty raw-hash-digest
+
+valid_copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-s08-raw-valid.XXXXXX")
+copy_raw "$valid_copy"
+resolved_valid_copy=$(python3 - "$valid_copy" <<'PY'
+import pathlib
+import sys
+print(pathlib.Path(sys.argv[1]).resolve())
+PY
+)
+"$driver" --validate-evidence "$valid_copy" \
+  > "$evidence_dir/raw-validate.stdout.log" 2> "$evidence_dir/raw-validate.stderr.log"
+grep -Fqx "T0012_S08_RAW_VALIDATE_ONLY=passed|evidence=$resolved_valid_copy" \
+  "$evidence_dir/raw-validate.stdout.log"
+[[ ! -s "$evidence_dir/raw-validate.stderr.log" ]]
+[[ $(grep -c '^T0012_PAGE_FULL_PROBE=' "$evidence_dir/raw-validate.stdout.log") == 0 ]]
+
+T0012_S08_MANIFEST="$evidence_dir/live.tsv" cargo test \
+  --manifest-path "$root/Cargo.toml" -p emburk-core \
+  logical_record::tests::live_page_value_differential -- --ignored --exact \
+  > "$evidence_dir/live-rust-test.log" 2>&1
+grep -Fqx 'test logical_record::tests::live_page_value_differential ... ok' \
+  "$evidence_dir/live-rust-test.log"
+grep -Eq '^test result: ok\. 1 passed; 0 failed; 0 ignored; .* filtered out;' \
+  "$evidence_dir/live-rust-test.log"
+
+git -C "$root" rev-parse HEAD > "$evidence_dir/source-revision.txt"
+printf '%s\n' "$raw_evidence" > "$evidence_dir/raw-evidence-path.txt"
+shasum -a 256 "$root/crates/emburk-core/src/logical_record.rs" \
+  "$root/crates/emburk-core/src/lib.rs" "$driver" "$0" \
+  > "$evidence_dir/source.sha256"
+shasum -a 256 "$evidence_dir/live.tsv" > "$evidence_dir/manifest.sha256"
+cp "$raw_evidence/raw-evidence-hashes.txt" "$evidence_dir/raw-evidence-hashes.txt"
+
+printf 'T0012/S08: compared exactly 2 live record-value projections; S07 full/raw gates, 18 raw controls, and Rust storage/transport controls passed|evidence=%s\n' \
+  "$evidence_dir"

--- a/tools/t0012-page-value-differential
+++ b/tools/t0012-page-value-differential
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Validate S07 evidence and project its two selected logical-value cases.
+
+Live mode admits artifacts only through the complete S07 wrapper. The
+--validate-evidence mode runs both the unchanged S07 raw gate and independent
+evidence/projection checks; it is not artifact admission or a live gate.
+"""
+import argparse
+import base64
+import binascii
+import hashlib
+import os
+import pathlib
+import subprocess
+import sys
+import uuid
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "tools/t0012-page-value-probe/run.sh"
+FIXTURES = ("empty", "typed-null")
+HASHED_FILES = ("page-cases.raw", "page-traces.raw", "empty.raw.log",
+                "typed-null.raw.log", "empty.trace.raw", "typed-null.trace.raw")
+CASE_COUNTS = {"empty": 32, "typed-null": 110}
+CAP = 1024
+
+
+class InvalidEvidence(ValueError):
+    pass
+
+
+def require(condition, label):
+    if not condition:
+        raise InvalidEvidence(label)
+
+
+def decimal(value, label, cap=CAP):
+    require(value.isascii() and value.isdigit() and len(value) <= 6
+            and (value == "0" or not value.startswith("0")), label)
+    parsed = int(value)
+    require(parsed <= cap, label)
+    return parsed
+
+
+def decode(value):
+    if value == "-":
+        return None
+    try:
+        raw = base64.b64decode(value, validate=True)
+        decoded = raw.decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError) as error:
+        raise InvalidEvidence("raw-canonical-base64") from error
+    require(base64.b64encode(raw).decode("ascii") == value,
+            "raw-canonical-base64")
+    return decoded
+
+
+def raw_gate(evidence):
+    run = subprocess.run(
+        ["bash", str(RUNNER)], cwd=ROOT, text=True, capture_output=True,
+        env={**os.environ, "T0012_PAGE_MODE": "validate",
+             "T0012_PAGE_EVIDENCE_DIR": str(evidence)})
+    if run.returncode != 0:
+        raise InvalidEvidence(
+            f"S07-raw-gate:{run.returncode}:{run.stderr.rstrip(chr(10))}")
+    require(run.stdout == "T0012_PAGE_VALIDATE_ONLY=passed\n" and run.stderr == "",
+            "S07-raw-gate-output")
+
+
+def validate_hash_manifest(evidence):
+    lines = evidence.joinpath("raw-evidence-hashes.txt").read_text(
+        encoding="utf-8").splitlines()
+    require(len(lines) == len(HASHED_FILES), "raw-hash-file-count")
+    entries = {}
+    for wanted, line in zip(HASHED_FILES, lines, strict=True):
+        fields = line.split("=")
+        require(len(fields) == 2, "raw-hash-grammar")
+        name, digest = fields
+        require(name == wanted and pathlib.PurePath(name).name == name
+                and "/" not in name and "\\" not in name and name not in entries,
+                "raw-hash-name")
+        require(len(digest) == 64
+                and all(character in "0123456789abcdef" for character in digest),
+                "raw-hash-digest")
+        entries[name] = digest
+    require(tuple(entries) == HASHED_FILES, "raw-hash-completeness")
+    # Validate every name and digest before opening any manifest-selected path.
+    for name in HASHED_FILES:
+        require(hashlib.sha256(evidence.joinpath(name).read_bytes()).hexdigest()
+                == entries[name], "raw-hash-identity")
+
+
+def read_cases(evidence):
+    lines = evidence.joinpath("page-cases.raw").read_text(
+        encoding="utf-8").splitlines()
+    require(len(lines) == 2, "raw-case-count")
+    cases = {}
+    for wanted, line in zip(FIXTURES, lines, strict=True):
+        fields = line.split("|")
+        require(len(fields) == 5 and fields[0] == "PAGECASE",
+                "raw-case-grammar")
+        _, fixture, exit_text, count_text, digest = fields
+        require(fixture == wanted and fixture not in cases, "raw-case-order")
+        require(decimal(exit_text, "raw-case-exit") == 0, "raw-process-success")
+        count = decimal(count_text, "raw-case-event-count")
+        require(count == CASE_COUNTS[fixture], "raw-selected-event-count")
+        require(len(digest) == 64
+                and all(character in "0123456789abcdef" for character in digest),
+                "raw-case-digest")
+        cases[fixture] = (count, digest)
+    return cases
+
+
+def read_traces(evidence, cases):
+    lines = evidence.joinpath("page-traces.raw").read_text(
+        encoding="utf-8").splitlines()
+    require(len(lines) <= CAP, "raw-combined-event-cap")
+    grouped = {fixture: [] for fixture in FIXTURES}
+    decoded = {fixture: [] for fixture in FIXTURES}
+    captures = {fixture: set() for fixture in FIXTURES}
+    sequences = {fixture: 0 for fixture in FIXTURES}
+    for line in lines:
+        fields = line.split("|")
+        require(len(fields) >= 5 and fields[0] == "PAGETRACE",
+                "raw-trace-grammar")
+        _, fixture, capture, sequence_text, name, *encoded = fields
+        require(fixture in grouped, "raw-trace-fixture")
+        try:
+            parsed_capture = uuid.UUID(capture)
+        except ValueError as error:
+            raise InvalidEvidence("raw-capture-id") from error
+        require(str(parsed_capture) == capture and parsed_capture.version == 4,
+                "raw-capture-id")
+        captures[fixture].add(capture)
+        sequence = decimal(sequence_text, "raw-sequence")
+        require(sequence == sequences[fixture] + 1, "raw-sequence-order")
+        sequences[fixture] = sequence
+        grouped[fixture].append(line)
+        decoded[fixture].append((name, [decode(value) for value in encoded]))
+    require(lines == grouped["empty"] + grouped["typed-null"],
+            "raw-combined-order")
+    for fixture in FIXTURES:
+        rows = grouped[fixture]
+        count, digest = cases[fixture]
+        require(len(captures[fixture]) == 1, "raw-single-capture")
+        require(len(rows) == count, "raw-case-count-match")
+        material = ("\n".join(rows) + "\n").encode("utf-8")
+        require(hashlib.sha256(material).hexdigest() == digest,
+                "raw-case-digest-match")
+        require(evidence.joinpath(f"{fixture}.trace.raw").read_bytes() == material,
+                "raw-trace-copy")
+        extracted = [line for line in evidence.joinpath(
+            f"{fixture}.raw.log").read_text(encoding="utf-8").splitlines()
+                     if line.startswith("PAGETRACE|")]
+        require(extracted == rows, "raw-log-extraction")
+    return decoded
+
+
+def one(events, name, label):
+    selected = [values for event_name, values in events if event_name == name]
+    require(len(selected) == 1, label)
+    return selected[0]
+
+
+def selected_projection(decoded):
+    expected_schema = [
+        ["transaction", "0", "flag", "boolean"],
+        ["transaction", "1", "number", "long"],
+        ["transaction", "2", "text", "string"],
+        ["run", "0", "flag", "boolean"],
+        ["run", "1", "number", "long"],
+        ["run", "2", "text", "string"],
+    ]
+    projected = {}
+    for fixture in FIXTURES:
+        events = decoded[fixture]
+        require([values for name, values in events if name == "schema-column"]
+                == expected_schema, "projection-schema")
+        count_values = one(events, "input-row-count", "projection-row-count")
+        require(len(count_values) == 1, "projection-row-count")
+        row_count = decimal(count_values[0], "projection-row-count")
+        inputs, null_returns, getter_returns = {}, {}, {}
+        null_entries, getter_entries, next_returns = [], [], []
+        for name, values in events:
+            if name == "input-cell":
+                require(len(values) == 4, "projection-input-arity")
+                row = decimal(values[0], "projection-input-index")
+                cell = decimal(values[1], "projection-input-index")
+                tag, payload = values[2:]
+                require((row, cell) not in inputs, "projection-input-duplicate")
+                require(tag in {"null", "boolean", "long", "string"},
+                        "projection-input-type")
+                require((tag == "null") == (payload is None),
+                        "projection-input-null")
+                inputs[(row, cell)] = (tag, payload)
+            elif name == "reader-is-null-entry":
+                require(len(values) == 4, "projection-null-arity")
+                null_entries.append(tuple(values))
+            elif name == "reader-is-null-return":
+                require(len(values) == 5 and values[4] in {"true", "false"},
+                        "projection-null-result")
+                position = tuple(values[:4])
+                require(position not in null_returns, "projection-null-result")
+                null_returns[position] = values[4]
+            elif name.startswith("reader-get-") and name.endswith("-entry"):
+                require(len(values) == 4, "projection-getter-arity")
+                getter_entries.append((name[11:-6], tuple(values)))
+            elif name.startswith("reader-get-") and name.endswith("-return"):
+                require(len(values) == 5, "projection-getter-arity")
+                key = (name[11:-7], tuple(values[:4]))
+                require(key not in getter_returns, "projection-getter-duplicate")
+                getter_returns[key] = values[4]
+            elif name == "reader-next-record-return":
+                require(len(values) == 3, "projection-next-arity")
+                next_returns.append(values)
+        if fixture == "empty":
+            require(row_count == 0, "projection-empty-row-count")
+            require(not inputs, "projection-empty-input-absence")
+            require(not null_entries and not null_returns and not getter_entries
+                    and not getter_returns and not next_returns,
+                    "projection-empty-read-absence")
+            require(one(events, "collector-finish-entry", "projection-empty-finish")
+                    == ["0", "0"], "projection-empty-finish")
+            projected[fixture] = []
+            continue
+        require(row_count == 3, "projection-selected-row-count")
+        expected_keys = {(row, cell) for row in range(3) for cell in range(3)}
+        require(set(inputs) == expected_keys, "projection-input-completeness")
+        require(next_returns == [["0", str(row), "true"] for row in range(3)]
+                + [["0", "3", "false"]], "projection-exhaustion")
+        positions = {("0", str(row), str(row), str(cell))
+                     for row, cell in expected_keys}
+        require(set(null_entries) == positions and len(null_entries) == 9
+                and set(null_returns) == positions, "projection-null-pairs")
+        require(set(getter_entries) == set(getter_returns)
+                and len(getter_entries) == len(getter_returns),
+                "projection-getter-pairs")
+        tags = {"null": "N", "boolean": "B", "long": "L", "string": "S"}
+        rows = []
+        for row in range(3):
+            cells = []
+            for cell in range(3):
+                input_kind, input_payload = inputs[(row, cell)]
+                position = ("0", str(row), str(row), str(cell))
+                matches = [(kind, value) for (kind, selected), value
+                           in getter_returns.items() if selected == position]
+                if null_returns[position] == "true":
+                    require(not matches, "projection-null-getter-contradiction")
+                    reference_tag, reference_payload = "N", "-"
+                else:
+                    require(len(matches) == 1, "projection-getter-completeness")
+                    reference_kind, reference_payload = matches[0]
+                    require(reference_kind in {"boolean", "long", "string"},
+                            "projection-getter-type")
+                    reference_tag = tags[reference_kind]
+                cells.append((tags[input_kind],
+                              "-" if input_kind == "null" else input_payload,
+                              reference_tag, reference_payload))
+            rows.append(cells)
+        projected[fixture] = rows
+    return projected
+
+
+def validate_and_project(evidence):
+    evidence = evidence.resolve(strict=True)
+    require(evidence.is_dir(), "evidence-directory")
+    raw_gate(evidence)
+    validate_hash_manifest(evidence)
+    return selected_projection(read_traces(evidence, read_cases(evidence)))
+
+
+def encode(tag, payload):
+    return payload.encode("utf-8").hex() if tag == "S" else payload
+
+
+def write_manifest(data, output):
+    rows = ["T0012-S08\t1"]
+    for fixture in FIXTURES:
+        records = data[fixture]
+        require(len(records) <= CAP, "manifest-row-cap")
+        rows.append(f"CASE\t{fixture}\t{len(records)}\t3")
+        for row_index, cells in enumerate(records):
+            require(len(cells) == 3, "manifest-cell-count")
+            rows.append(f"ROW\t{row_index}")
+            for cell_index, (it, ip, rt, rp) in enumerate(cells):
+                rows.append("\t".join(("CELL", str(cell_index), it,
+                                       encode(it, ip), rt, encode(rt, rp))))
+    output.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def run_live_probe():
+    completed = subprocess.run(
+        ["bash", "tests/t0012_page_value_probe_test.sh"], cwd=ROOT,
+        text=True, capture_output=True)
+    sys.stdout.write(completed.stdout)
+    sys.stderr.write(completed.stderr)
+    require(completed.returncode == 0, f"S07-full-exit:{completed.returncode}")
+    prefix = "T0012_PAGE_FULL_PROBE=passed|evidence="
+    markers = [line for line in completed.stdout.splitlines()
+               if line.startswith(prefix)]
+    require(len(markers) == 1, "S07-full-marker-count")
+    return pathlib.Path(markers[0][len(prefix):])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--output", type=pathlib.Path)
+    group.add_argument("--validate-evidence", type=pathlib.Path)
+    args = parser.parse_args()
+    try:
+        if args.validate_evidence is not None:
+            validate_and_project(args.validate_evidence)
+            print("T0012_S08_RAW_VALIDATE_ONLY=passed|evidence="
+                  f"{args.validate_evidence.resolve()}")
+            return 0
+        evidence = run_live_probe()
+        data = validate_and_project(evidence)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        write_manifest(data, args.output)
+        digest = hashlib.sha256(args.output.read_bytes()).hexdigest()
+        args.output.with_suffix(".sha256").write_text(digest + "\n",
+                                                      encoding="utf-8")
+        print(f"T0012_S08_PROJECTED_CASES=2|evidence={evidence}|manifest={args.output}")
+    except (InvalidEvidence, OSError, UnicodeError) as error:
+        print(f"T0012_S08_VALIDATION_ERROR|{error}", file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Scope
Implements T-0012/S08 under ADR-0011. Adds private owned Null/Boolean/Signed64/Text records and a strict test-only adapter for two selected Embulk getter-result projections. References #15; the parent remains open.

## Evidence
Frozen source: 914ad2e9f63fffecddcde988cea4caf778270e37.
Primary exact Demo passed: bash tests/t0012_page_value_differential_test.sh && bash tests/t0012_schema_differential_test.sh.
Workspace: 35 passed, 6 intentional live ignores; formatting, strict all-target Clippy and syntax checks pass. Includes full S07 gate, 18 new raw controls, six local storage/transport tests and three unchanged schema comparisons.

Independent Tester reproduction and final PR-head Demo are required before merge. Complete packet, retained logs, hashes and non-claims: docs/provenance/T-0012-private-record-values.md.

## Boundaries
No public API, schema coupling, physical encoding, additional value types, plugin/host or production transfer. No parent completion, generalized compatibility or legal-clearance claim. User checkout and previously accepted sources are preserved.