### PR TITLE
fix(actions): gate Project delivery workflow

### DIFF
--- a/.github/workflows/project-delivery.yml
+++ b/.github/workflows/project-delivery.yml
@@ -16,9 +16,33 @@ concurrency:
 permissions: {}
 
 jobs:
+  credential_gate:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      configured: ${{ steps.check.outputs.configured }}
+    steps:
+      - name: Check Project credential
+        id: check
+        shell: bash
+        env:
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+        run: |
+          if [[ -n "$PROJECTS_TOKEN" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "## Project delivery automation skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "PROJECTS_TOKEN is not configured. No Project data was read or changed." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   review:
+    needs: credential_gate
     if: >-
+      github.event_name == 'pull_request_target' &&
+      needs.credential_gate.outputs.configured == 'true' &&
       github.event.pull_request.base.ref == github.event.repository.default_branch &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     permissions:
@@ -34,7 +58,11 @@ jobs:
           GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
 
   snapshot:
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    needs: credential_gate
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      needs.credential_gate.outputs.configured == 'true' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/TODO.md
+++ b/TODO.md
@@ -127,6 +127,9 @@ These estimates are within the parent's 5 SP, not additional points or accepted
 velocity. Parent completion retains its listed dependencies.
 
 T-0003 is complete through PR #62, and T-0004/S01 is complete through PR #63.
+T-0004/S02 is active in Issue #84 to gate review and snapshot jobs by event and
+to skip safely when `PROJECTS_TOKEN` is absent. It does not register a
+credential or change Project schema.
 T-0012/S01 used the official self-contained executable through a local-only
 Maven-style input plugin, rather than assembling the core POM graph. It
 integrated through PR #61 as `e2532e2` after recording nine

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -93,16 +93,22 @@ and store the daily history on a dedicated `project-metrics` branch. Never
 print, persist, or place the credential in command arguments or artifacts.
 
 The snapshot workflow runs at 00:17 UTC and can also be dispatched manually
-from the default branch. It refuses non-default refs, and exposes the Project
-secret only to the audit and snapshot steps.
-It fails before writing if Project discovery or configuration audit fails.
+from the default branch. It refuses non-default refs. A zero-permission gate
+checks whether the Project credential is configured without printing it. When
+the secret is absent, the workflow succeeds with a non-sensitive job summary
+and skips all Project reads and mutations. When present, the secret is exposed
+only to the gate and the audit, snapshot, or review step that requires it. The
+snapshot path accepts only schedule and manual-dispatch events; pull request
+events cannot invoke it. It fails before writing if Project discovery or
+configuration audit fails.
 Ready-for-review automation uses
 `pull_request_target`, checks out only the default branch without persisting
 credentials, accepts only numeric PR identifiers, and runs only for OWNER,
-MEMBER, or COLLABORATOR authors targeting the default branch. It updates only
-one closing-linked Issue whose current Status is In Progress; every ambiguous
-or conflicting case fails before mutation and requires Project Manager
-reconciliation. The
+MEMBER, or COLLABORATOR authors targeting the default branch from a branch in
+the same repository. Fork pull requests never receive the Project mutation
+credential. It updates only one closing-linked Issue whose current Status is In
+Progress; every ambiguous or conflicting case fails before mutation and
+requires Project Manager reconciliation. The
 `project-metrics` branch must exist before the snapshot workflow is enabled; a
 missing branch fails safely.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -78,6 +78,12 @@ Issue / 5 Story Points after integration. The Action is installed and active;
 scheduled and ready-for-review executions still require the repository owner
 to add the `PROJECTS_TOKEN` secret, so no hosted-run success is claimed.
 
+T-0004/S02 is active to repair the delivery workflow event and credential
+gates after PR events incorrectly reached the snapshot job and an absent
+`PROJECTS_TOKEN` produced failed runs. Issue #84 is the coordination item.
+No hosted success or credential registration is claimed before integration and
+default-branch dispatch evidence.
+
 ## Evidence and non-claims
 
 Current evidence includes repository checks, private scalar Unit/Contract tests,

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -21,6 +21,14 @@
 - Live Project delivery and governance audits passed with 52 items and WIP 2/2.
   The previously recorded absent `PROJECTS_TOKEN` still limits optional hosted
   automation; manual live audits supply coordination evidence, not runtime CI.
+- Opened T-0004/S02 as Issue #84 after Project delivery runs on three T-0012
+  branches failed. The workflow's default-ref predicate also matched
+  `pull_request_target`, so PR events entered the snapshot path; the absent
+  `PROJECTS_TOKEN` then caused GitHub CLI authentication failures. The repair
+  is limited to explicit event and credential gates, regression coverage, and
+  operations documentation. Independent security review additionally required
+  same-repository PR heads before the review mutation path can run. No
+  credential value was read or logged.
 - Activated S05 schema observation after Librarian public-interface triage and
   primary signature inspection of the pinned executable. Three cases precede
   any Rust schema policy. Its 3-SP slice stays within Current SP 8 (Initial 5);

--- a/tests/test_project_delivery.py
+++ b/tests/test_project_delivery.py
@@ -12,6 +12,19 @@ def item(number, status, points, iteration="i1", content_type="Issue"):
 
 
 class ProjectDeliveryTest(unittest.TestCase):
+    def test_workflow_separates_events_and_requires_credential_gate(self):
+        workflow = (Path(__file__).parents[1] / ".github/workflows/project-delivery.yml").read_text(encoding="utf-8")
+        self.assertIn("github.event_name == 'pull_request_target'", workflow)
+        self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", workflow)
+        self.assertIn("github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'", workflow)
+        self.assertEqual(workflow.count("needs: credential_gate"), 2)
+        self.assertEqual(workflow.count("needs.credential_gate.outputs.configured == 'true'"), 2)
+        self.assertNotIn("snapshot:\n    if: github.ref", workflow)
+        review = workflow.split("\n  review:\n", 1)[1].split("\n  snapshot:\n", 1)[0]
+        snapshot = workflow.split("\n  snapshot:\n", 1)[1]
+        self.assertNotIn("github.event_name == 'schedule'", review)
+        self.assertNotIn("github.event_name == 'pull_request_target'", snapshot)
+
     def test_snapshot_counts_remaining_completion_and_status(self):
         value = make_snapshot([item(1, "In Progress", 5), item(2, "Blocked", 3), item(3, "Done", 2), item(4, "Review", 5, content_type="PullRequest")], dt.date(2026, 9, 5))
         self.assertEqual((value.total_issues, value.remaining_issues, value.remaining_points), (3, 2, 8))


### PR DESCRIPTION
## Summary
- restrict Project review automation to trusted same-repository PR events
- restrict snapshots to schedule/manual dispatch on the default branch
- use a zero-permission credential gate so an absent `PROJECTS_TOKEN` yields a successful skip
- document the boundary and add workflow-policy regression coverage

Closes #84

## Validation
- `python3 -m unittest tests.test_project_delivery` (9 passed)
- workflow YAML parsed with Ruby Psych
- `python3 scripts/project_delivery.py audit` (live Project pass)
- independent security review (no findings after same-repository gate)
- `git diff --check`