### PR TITLE
fix(project): query snapshot fields directly

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -134,6 +134,9 @@ slice did not register a credential or change Project schema.
 T-0004/S03 is active in Issue #87 to align the workflow with the registered
 Actions Secret name `EMBURK_PROJECT_TOKEN`, followed by credentialed hosted
 snapshot verification. No token value may be read, logged, or persisted.
+Run `34004267606` proved credential discovery and Project audit, but failed at
+the CLI item-list materialization step; #87 remains active for a minimal
+paginated GraphQL snapshot query and another hosted dispatch.
 T-0012/S01 used the official self-contained executable through a local-only
 Maven-style input plugin, rather than assembling the core POM graph. It
 integrated through PR #61 as `e2532e2` after recording nine

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -72,6 +72,10 @@ the committed baseline. Completed count and points are recorded alongside a
 daily Status distribution. Pull requests are excluded from totals so linked
 Issue and PR cards are not counted twice.
 
+Snapshot collection uses a paginated Project GraphQL query limited to item
+type, Status, Story Points, and Iteration. It does not request repository or
+Issue content and does not depend on GitHub CLI's richer item materialization.
+
 ## Automation boundary
 
 Enabled built-in workflows cover item-added defaults, closed items, merged pull

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -89,6 +89,11 @@ T-0004/S03 is active in Issue #87 to align the workflow with the registered
 Actions Secret name `EMBURK_PROJECT_TOKEN`. The secret name exists by live
 metadata read-back; its value was not read or logged. Credentialed Project
 mutation and snapshot publication remain pending hosted verification.
+The first credentialed run `34004267606` passed the credential gate, Project
+audit, and metrics-branch checkout, then failed while the CLI materialized the
+Project item list. Issue #87 was reopened; the repair replaces that snapshot-
+only dependency with a minimal paginated Project GraphQL query. No token-scope
+deficiency is claimed.
 
 ## Evidence and non-claims
 

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -39,6 +39,12 @@
   `EMBURK_PROJECT_TOKEN` without its value. Opened T-0004/S03 as Issue #87 to
   align the trusted workflow reference and run credentialed default-branch
   snapshot verification. Existing CLI credentials are not copied or reused.
+- PR #88 integrated the secret-name alignment as `89cd27e`. Credentialed run
+  `34004267606` passed the gate, live Project audit, and metrics checkout, then
+  failed when `gh project item-list` materialized all items. The masked log
+  exposed no credential. Issue #87 was reopened; the next repair requests only
+  item type, Status, Story Points, and Iteration through paginated GraphQL. No
+  additional token scope is assumed or requested.
 - Activated S05 schema observation after Librarian public-interface triage and
   primary signature inspection of the pinned executable. Three cases precede
   any Rust schema policy. Its 3-SP slice stays within Current SP 8 (Initial 5);

--- a/scripts/project_delivery.py
+++ b/scripts/project_delivery.py
@@ -100,6 +100,49 @@ def make_snapshot(items: Iterable[dict[str, Any]], today: dt.date) -> Snapshot:
     return Snapshot(today.isoformat(), iteration["title"], iteration["startDate"], int(iteration["duration"]), len(selected), sum(map(points, selected)), len(remaining), sum(map(points, remaining)), len(completed), sum(map(points, completed)), dict(sorted(statuses.items())))
 
 
+def normalize_snapshot_item(node: dict[str, Any]) -> dict[str, Any]:
+    content_types = {"ISSUE": "Issue", "PULL_REQUEST": "PullRequest"}
+    item: dict[str, Any] = {
+        "content": {"type": content_types.get(node.get("type"), node.get("type"))}
+    }
+    for value in node.get("fieldValues", {}).get("nodes", []):
+        field_name = (value.get("field") or {}).get("name")
+        if field_name == "Status":
+            item["status"] = value.get("name")
+        elif field_name == "Story Points":
+            item["story Points"] = value.get("number")
+        elif field_name == "Iteration":
+            item["iteration"] = {
+                key: value[key]
+                for key in ("iterationId", "title", "startDate", "duration")
+                if key in value
+            }
+    return item
+
+
+def snapshot_items(project: ProjectRef) -> list[dict[str, Any]]:
+    query = """query($login:String!,$number:Int!,$cursor:String){user(login:$login){projectV2(number:$number){items(first:100,after:$cursor){nodes{type fieldValues(first:50){nodes{... on ProjectV2ItemFieldSingleSelectValue{name field{... on ProjectV2FieldCommon{name}}} ... on ProjectV2ItemFieldNumberValue{number field{... on ProjectV2FieldCommon{name}}} ... on ProjectV2ItemFieldIterationValue{iterationId title startDate duration field{... on ProjectV2FieldCommon{name}}}}}} pageInfo{hasNextPage endCursor}}}}}"""
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    items: list[dict[str, Any]] = []
+    while True:
+        args = ["api", "graphql", "-f", f"query={query}", "-F", f"login={project.owner}", "-F", f"number={project.number}"]
+        if cursor is not None:
+            args.extend(("-F", f"cursor={cursor}"))
+        response = run_gh(*args)
+        connection = response["data"]["user"]["projectV2"]["items"]
+        items.extend(normalize_snapshot_item(node) for node in connection["nodes"])
+        page_info = connection["pageInfo"]
+        if not page_info["hasNextPage"]:
+            return items
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            raise AuditError("Project item pagination has no end cursor")
+        if cursor in seen_cursors:
+            raise AuditError("Project item pagination repeated an end cursor")
+        seen_cursors.add(cursor)
+
+
 CSV_FIELDS = ("date", "iteration", "start_date", "duration", "total_issues", "total_points", "remaining_issues", "remaining_points", "completed_issues", "completed_points", "status_counts")
 
 
@@ -160,8 +203,7 @@ def render_svg(rows: list[dict[str, str]], path: Path, metric: str, title: str) 
 
 def snapshot(output_dir: Path, today: dt.date) -> dict[str, Any]:
     project = discover()
-    result = run_gh("project", "item-list", str(project.number), "--owner", project.owner, "--limit", "500", "--format", "json")
-    value = make_snapshot(result.get("items", []), today)
+    value = make_snapshot(snapshot_items(project), today)
     stem = value.iteration.replace("/", "-")
     rows = append_snapshot(output_dir / f"{stem}.csv", value)
     (output_dir / f"{stem}-latest.json").write_text(json.dumps(asdict(value), indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_project_delivery.py
+++ b/tests/test_project_delivery.py
@@ -3,8 +3,9 @@ import datetime as dt
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from scripts.project_delivery import AuditError, append_snapshot, csv_safe, ideal_remaining, make_snapshot, render_svg, review_candidate
+from scripts.project_delivery import AuditError, ProjectRef, append_snapshot, csv_safe, ideal_remaining, make_snapshot, normalize_snapshot_item, render_svg, review_candidate, snapshot_items
 
 
 def item(number, status, points, iteration="i1", content_type="Issue"):
@@ -12,6 +13,49 @@ def item(number, status, points, iteration="i1", content_type="Issue"):
 
 
 class ProjectDeliveryTest(unittest.TestCase):
+    def test_snapshot_item_normalizes_only_delivery_fields(self):
+        node = {"type": "ISSUE", "fieldValues": {"nodes": [
+            {"name": "In Progress", "field": {"name": "Status"}},
+            {"number": 3, "field": {"name": "Story Points"}},
+            {"iterationId": "i1", "title": "2026-W36", "startDate": "2026-08-31", "duration": 7, "field": {"name": "Iteration"}},
+            {"name": "P1", "field": {"name": "Priority"}},
+        ]}}
+        expected = item(1, "In Progress", 3)
+        del expected["content"]["number"]
+        self.assertEqual(normalize_snapshot_item(node), expected)
+
+    @patch("scripts.project_delivery.run_gh")
+    def test_snapshot_items_follows_graphql_pagination(self, run_gh_mock):
+        def page(node_type, has_next, cursor):
+            return {"data": {"user": {"projectV2": {"items": {
+                "nodes": [{"type": node_type, "fieldValues": {"nodes": []}}],
+                "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+            }}}}}
+
+        run_gh_mock.side_effect = [page("ISSUE", True, "next"), page("PULL_REQUEST", False, None)]
+        project = ProjectRef("bhind", 2, "Emburk Delivery", "https://example/project")
+        self.assertEqual([entry["content"]["type"] for entry in snapshot_items(project)], ["Issue", "PullRequest"])
+        self.assertEqual(run_gh_mock.call_count, 2)
+        self.assertIn("cursor=next", run_gh_mock.call_args.args)
+
+    @patch("scripts.project_delivery.run_gh")
+    def test_snapshot_items_fails_closed_without_pagination_cursor(self, run_gh_mock):
+        run_gh_mock.return_value = {"data": {"user": {"projectV2": {"items": {
+            "nodes": [], "pageInfo": {"hasNextPage": True, "endCursor": None},
+        }}}}}
+        with self.assertRaisesRegex(AuditError, "no end cursor"):
+            snapshot_items(ProjectRef("bhind", 2, "Emburk Delivery", "https://example/project"))
+
+    @patch("scripts.project_delivery.run_gh")
+    def test_snapshot_items_fails_closed_on_repeated_cursor(self, run_gh_mock):
+        repeated = {"data": {"user": {"projectV2": {"items": {
+            "nodes": [], "pageInfo": {"hasNextPage": True, "endCursor": "same"},
+        }}}}}
+        run_gh_mock.side_effect = [repeated, repeated]
+        with self.assertRaisesRegex(AuditError, "repeated an end cursor"):
+            snapshot_items(ProjectRef("bhind", 2, "Emburk Delivery", "https://example/project"))
+        self.assertEqual(run_gh_mock.call_count, 2)
+
     def test_workflow_separates_events_and_requires_credential_gate(self):
         workflow = (Path(__file__).parents[1] / ".github/workflows/project-delivery.yml").read_text(encoding="utf-8")
         self.assertIn("github.event_name == 'pull_request_target'", workflow)


### PR DESCRIPTION
## Summary
- replace snapshot-only `gh project item-list` materialization with a minimal paginated GraphQL query
- request only Project item type, Status, Story Points, and Iteration
- fail closed on missing or repeated pagination cursors
- retain the existing review automation path unchanged

Relates #87

## Validation
- `python3 -m unittest tests.test_project_delivery` (13 passed)
- live read-only snapshot against Emburk Delivery passed
- independent security review passed
- `git diff --check`