### PR TITLE
test(t-0012): observe selected double values and validate evidence

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,9 +9,9 @@ tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 `T-0013/S08`, `T-0012/S08` and `T-0021/S05` are integrated. T-0012/S09 is
-`Blocked` before source creation pending explicit owner approval for reference-
-probe execution. T-0013, T-0021 and all other unfinished items are `Backlog`.
-Combined active WIP is zero of two.
+`In Progress` following owner approval for reference-probe execution.
+T-0013, T-0021 and all other unfinished items are `Backlog`.
+Combined active WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -36,7 +36,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S09: double-value reference observation) | Blocked | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S09: double-value reference observation) | In Progress | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/TODO.md
+++ b/TODO.md
@@ -355,3 +355,9 @@ S09 is prepared under its [packet](docs/provenance/T-0012-double-value-probe.md)
 5 SP within unchanged Current 34 / Initial 5 for finite/null and nonfinite
 double-value reference observations. PM reviews complete raw capture before
 semantic assertions or any later Rust Float64 representation/equality decision.
+
+S09 Stage A at `7e46379` passed the exact capture Demo and primary reproduction.
+PM reviewed all 114/93 events: both fixtures exit 0; finite bounds, subnormals,
+signed zero, null, infinities and selected NaN bits remain distinguishable.
+Stage B exact vectors and repaired-copy controls are authorized in the packet.
+No full acceptance, native Float64 policy or parent completion follows yet.

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ tasks. Dependencies name predecessor T-IDs and do not imply completion.
 
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 `T-0013/S08`, `T-0012/S08` and `T-0021/S05` are integrated. T-0012/S09 is
-`In Progress` following owner approval for reference-probe execution.
+`Review` in PR #91 following fresh reference-probe acceptance runs.
 T-0013, T-0021 and all other unfinished items are `Backlog`.
 Combined active WIP is one of two.
 
@@ -36,7 +36,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S09: double-value reference observation) | In Progress | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S09: double-value reference observation) | Review | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -369,3 +369,9 @@ PM reviewed all 114/93 events: both fixtures exit 0; finite bounds, subnormals,
 signed zero, null, infinities and selected NaN bits remain distinguishable.
 Stage B exact vectors and repaired-copy controls are authorized in the packet.
 No full acceptance, native Float64 policy or parent completion follows yet.
+
+S09 corrected source acceptance at `3f18966` passes primary and independent
+Tester: two reference fixtures, 45 raw controls, two artifact controls, unchanged
+S08/S06 regressions and strict quality checks. PR #91 is Review; final-head Demo
+and integration remain required. Parent #15 stays open; no native Float64 or
+whole-domain equality decision follows from this bounded reference slice.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,6 +124,14 @@ Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open. S09 prepares a
 separate reference-only double-value observation, with a capture-before-
 expectations gate and no Rust Float64 or equality-policy change.
+S09 primary and independent source acceptance pass at `3f18966`: two selected
+reference double fixtures (114/93 events), 45 diagnostic-specific raw controls,
+two artifact controls, unchanged S08/S06 regressions and strict quality checks.
+Selected finite/subnormal/signed-zero/null/infinity/NaN bits are preserved in
+these observations. Evidence is Reference Observation / Integration plus
+validator Unit/Contract, not a native Float64 or numeric equality decision.
+PR #91 is in Review; final-head acceptance and integration remain required.
+
 
 
 T-0012 reference probes and S04's ignored live comparison are test-only tools

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -178,6 +178,14 @@ Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open. S09 prepares a
 separate reference-only double-value observation, with a capture-before-
 expectations gate and no Rust Float64 or equality-policy change.
+S09 primary and independent source acceptance pass at `3f18966`: two selected
+reference double fixtures (114/93 events), 45 diagnostic-specific raw controls,
+two artifact controls, unchanged S08/S06 regressions and strict quality checks.
+Selected finite/subnormal/signed-zero/null/infinity/NaN bits are preserved in
+these observations. Evidence is Reference Observation / Integration plus
+validator Unit/Contract, not a native Float64 or numeric equality decision.
+PR #91 is in Review; final-head acceptance and integration remain required.
+
 
 
 ## Adding an Entry

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,6 +149,14 @@ Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open. S09 prepares a
 separate reference-only double-value observation, with a capture-before-
 expectations gate and no Rust Float64 or equality-policy change.
+S09 primary and independent source acceptance pass at `3f18966`: two selected
+reference double fixtures (114/93 events), 45 diagnostic-specific raw controls,
+two artifact controls, unchanged S08/S06 regressions and strict quality checks.
+Selected finite/subnormal/signed-zero/null/infinity/NaN bits are preserved in
+these observations. Evidence is Reference Observation / Integration plus
+validator Unit/Contract, not a native Float64 or numeric equality decision.
+PR #91 is in Review; final-head acceptance and integration remain required.
+
 
 
 ## Phase 1: Native File-to-File MVP

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -334,6 +334,14 @@ Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open. S09 prepares a
 separate reference-only double-value observation, with a capture-before-
 expectations gate and no Rust Float64 or equality-policy change.
+S09 primary and independent source acceptance pass at `3f18966`: two selected
+reference double fixtures (114/93 events), 45 diagnostic-specific raw controls,
+two artifact controls, unchanged S08/S06 regressions and strict quality checks.
+Selected finite/subnormal/signed-zero/null/infinity/NaN bits are preserved in
+these observations. Evidence is Reference Observation / Integration plus
+validator Unit/Contract, not a native Float64 or numeric equality decision.
+PR #91 is in Review; final-head acceptance and integration remain required.
+
 
 
 The proposed failure fixture should throw inside input `run` before its own

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -40,8 +40,10 @@ Development state: `bootstrap`
 ## Delivery queue
 
 T-0012/S08 is integrated through PR #82. The owner approved continuation of
-T-0012/S09 after the reference-execution explanation. Stage A capture is
-`In Progress`; combined active WIP is one of two. T-0012, T-0013 and
+T-0012/S09 after the reference-execution explanation. Stage A at `7e46379`
+captured 114/93 events with exact selected double bits preserved; primary
+reproduction and complete raw review authorize Stage B strict validation.
+The slice remains `In Progress`; combined active WIP is one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -39,9 +39,9 @@ Development state: `bootstrap`
 
 ## Delivery queue
 
-T-0012/S08 is integrated through PR #82. T-0012/S09 is `Blocked` before source
-creation: environment review requires explicit owner approval for executing
-the new reference probe. Combined active WIP is zero of two. T-0012, T-0013 and
+T-0012/S08 is integrated through PR #82. The owner approved continuation of
+T-0012/S09 after the reference-execution explanation. Stage A capture is
+`In Progress`; combined active WIP is one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
@@ -50,7 +50,7 @@ T-0021 parent contracts remain open.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S09 | Blocked | Owner execution approval required; no new source created |
+| T-0012/S09 | In Progress | Approved double-value reference capture |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S01–S05 integrated; remaining runtime contracts |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -43,7 +43,7 @@ T-0012/S08 is integrated through PR #82. The owner approved continuation of
 T-0012/S09 after the reference-execution explanation. Stage A at `7e46379`
 captured 114/93 events with exact selected double bits preserved; primary
 reproduction and complete raw review authorize Stage B strict validation.
-The slice remains `In Progress`; combined active WIP is one of two. T-0012, T-0013 and
+The slice is `Review` in PR #91; combined active WIP is one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
@@ -52,7 +52,7 @@ T-0021 parent contracts remain open.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S09 | In Progress | Approved double-value reference capture |
+| T-0012/S09 | Review | Two selected double observations; final PR-head gate pending |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S01–S05 integrated; remaining runtime contracts |
 
@@ -325,3 +325,10 @@ Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open. S09 prepares a
 separate reference-only double-value observation, with a capture-before-
 expectations gate and no Rust Float64 or equality-policy change.
+S09 primary and independent source acceptance pass at `3f18966`: two selected
+reference double fixtures (114/93 events), 45 diagnostic-specific raw controls,
+two artifact controls, unchanged S08/S06 regressions and strict quality checks.
+Selected finite/subnormal/signed-zero/null/infinity/NaN bits are preserved in
+these observations. Evidence is Reference Observation / Integration plus
+validator Unit/Contract, not a native Float64 or numeric equality decision.
+PR #91 is in Review; final-head acceptance and integration remain required.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -268,3 +268,10 @@ Schema coupling, physical encoding, public API and production transfer remain
 outside this slice; parent and phase delivery gates stay open. S09 prepares a
 separate reference-only double-value observation, with a capture-before-
 expectations gate and no Rust Float64 or equality-policy change.
+S09 primary and independent source acceptance pass at `3f18966`: two selected
+reference double fixtures (114/93 events), 45 diagnostic-specific raw controls,
+two artifact controls, unchanged S08/S06 regressions and strict quality checks.
+Selected finite/subnormal/signed-zero/null/infinity/NaN bits are preserved in
+these observations. Evidence is Reference Observation / Integration plus
+validator Unit/Contract, not a native Float64 or numeric equality decision.
+PR #91 is in Review; final-head acceptance and integration remain required.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -26,4 +26,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S08 selected commit-position differential](T-0013-commit-position-differential.md) | Done (bounded slice; PR #80, `de38a44`) |
 | [T-0012/S07 bounded Page value observation](T-0012-page-value-probe.md) | Done (bounded reference slice; PR #81, `203d7da`) |
 | [T-0012/S08 private record values](T-0012-private-record-values.md) | Done (bounded slice; PR #82, `b428305`) |
-| [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | Blocked before source creation; owner execution approval required |
+| [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | In Progress; execution checkpoint cleared by owner continuation |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -26,4 +26,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0013/S08 selected commit-position differential](T-0013-commit-position-differential.md) | Done (bounded slice; PR #80, `de38a44`) |
 | [T-0012/S07 bounded Page value observation](T-0012-page-value-probe.md) | Done (bounded reference slice; PR #81, `203d7da`) |
 | [T-0012/S08 private record values](T-0012-private-record-values.md) | Done (bounded slice; PR #82, `b428305`) |
-| [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | In Progress; execution checkpoint cleared by owner continuation |
+| [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | Review; PR #91, fresh acceptance at `3f18966` |

--- a/docs/provenance/T-0012-double-value-probe.md
+++ b/docs/provenance/T-0012-double-value-probe.md
@@ -1,7 +1,7 @@
 # T-0012/S09 bounded double-value observation
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: In Progress; Stage A reviewed, Stage B authorized
+- State: Review; PR #91, final PR-head acceptance pending
 - Branch: `research/t-0012-double-value-recovery`
 - Owner: Compatibility Host Implementer; decisions, records and integration: PM
 - Priority: P0; parent task T-0012; parent epic T-0010
@@ -203,8 +203,19 @@ the corrupt-artifact injection). It is not acceptance evidence. Quality checks
 pass: Bash syntax, diff, workspace formatting, 35 Rust tests / six intentional
 live-test ignores, strict all-target Clippy and 19 Project Python tests. The
 environment remains Temurin 17.0.20, Cargo 1.98.1 and Python 3.14.6 on macOS.
-Independent Tester and security review, final PR-head Demo and integration
-remain required before acceptance.
+Independent Tester reproduced the exact Demo at the same source revision:
+`/private/tmp/t0012-s09-independent.LuK8Lk`, exit 0, empty stderr; stdout SHA-256
+`b7d724ea1b5d84f10722f4ac8c57b9af2544735a95eae2bd97e400b9d88fd4f5`.
+Fresh independent evidence is in the same probe root at `run.tcOfGi/evidence`.
+Independent quality/source review passed with no concrete blocker. The separate
+security/supply-chain static review found no blocker within the explicitly
+approved trusted developer-harness scope. Ambient curl/Java/PATH settings are
+not isolated; the harness must not be presented as a security boundary. Durable
+private evidence retention remains unimplemented: all fresh evidence is currently
+inspectable, and cleanup requires fresh review/reproduction before relying on
+it again. These limitations do not establish production isolation, attestation,
+SBOM, redistribution or patent/FTO clearance. Final PR-head Demo and integration
+of PR #91 are required before acceptance. Parent Issue #15 stays open.
 
 The first Stage B source revision `7ec550b` passed the selected live fixtures,
 40 raw rejection controls and existing S08/S06 comparisons in the retained

--- a/docs/provenance/T-0012-double-value-probe.md
+++ b/docs/provenance/T-0012-double-value-probe.md
@@ -2,7 +2,7 @@
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
 - State: In Progress; Stage A reviewed, Stage B authorized
-- Branch: `research/t-0012-double-value-capture`
+- Branch: `research/t-0012-double-value-recovery`
 - Owner: Compatibility Host Implementer; decisions, records and integration: PM
 - Priority: P0; parent task T-0012; parent epic T-0010
 - Estimate: 5 SP (implementation 2, uncertainty 1, verification 1, environment 1;
@@ -178,6 +178,14 @@ These pre-acceptance corrections remain in the same three-file source allowlist;
 no new runtime or native behavior is authorized. The owner requested a temporary
 pause and then resumed with a low-effort implementer. The source handoff preserves
 the interrupted implementation and does not change acceptance requirements.
+
+On the next environment resumption, the previous temporary worktree and retained
+temporary evidence directories were no longer available. Committed sources and
+review records survived at `a247de0` and were restored into a new isolated
+worktree on the recovery branch above. Historical observations remain recorded,
+but their old temporary paths are not currently available evidence. Acceptance
+requires fresh complete executions and newly retained logs at the corrected
+source revision. No lost uncommitted correction is assumed to have survived.
 
 After PM freezes the exact observed outcome matrix, validate complete ordered
 events and all per-cell values, not counts alone. Canonical case membership,

--- a/docs/provenance/T-0012-double-value-probe.md
+++ b/docs/provenance/T-0012-double-value-probe.md
@@ -169,6 +169,43 @@ Implementer capture trace SHA-256, finite-null / nonfinite:
 
 ### Remaining acceptance gates
 
+Corrected source `3f18966bb07d22dab54d8b0ad06b2c2186daa110` passes the exact
+Demo under both the implementer and primary agent. Primary fresh outer logs:
+`/private/tmp/t0012-s09-primary-demo.rVGwnG` (`exit.txt` is 0; stderr is empty).
+Its stdout SHA-256 is
+`66ce8de9489989a3c99ded54eb9929089c8444fcf7278af54d784b44b67790cf`.
+Fresh raw evidence is under
+`/private/var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/t0012-double-value-probe/run.lbI1sY/evidence`.
+Both fixture exits are 0, with 114/93 ordered events. All 45 diagnostic-specific
+raw controls and two artifact controls pass; primary additionally checked all
+45 retained negative stdout/stderr/exit triplets. S08's two value comparisons
+and S06's three schema comparisons pass unchanged.
+
+The corrected gate confines canonical evidence paths outside the repository,
+rejects ancestor/member links, binds a fixed-name copied generated JAR to its
+digest, validates mandatory provenance and exact historical source identity,
+and additionally matches live source hashes on fresh runs. Validate-only remains
+distinct from fresh artifact admission. Normal retrieval allows 120 seconds;
+the unavailable-runtime control has its own short timeout. No external source
+implementation or dependency was added.
+
+Corrected plugin / runner / wrapper source SHA-256:
+
+- `183070a032c4d9654f4eee69f028cb94ba90d248bceb0b33e86f7105069209dd`
+- `9583086246cf68263a395a73bbbe20ee043b38ebeda7cea2d8ef94e77c9fb16b`
+- `71fa8314ea01c0f97cbfb326627fd8e51012f0539e9dfa15052f3c5cc2da2f4c`
+
+Implementer fresh exact Demo logs are
+`/private/tmp/t0012-s09-recovery-demo.qOHhXy` (exit 0). Its earlier sandbox
+retrieval failure is retained separately at
+`/private/tmp/t0012-s09-recovery-demo.5O6kZB` (outer exit 1, retrieval 56 before
+the corrupt-artifact injection). It is not acceptance evidence. Quality checks
+pass: Bash syntax, diff, workspace formatting, 35 Rust tests / six intentional
+live-test ignores, strict all-target Clippy and 19 Project Python tests. The
+environment remains Temurin 17.0.20, Cargo 1.98.1 and Python 3.14.6 on macOS.
+Independent Tester and security review, final PR-head Demo and integration
+remain required before acceptance.
+
 The first Stage B source revision `7ec550b` passed the selected live fixtures,
 40 raw rejection controls and existing S08/S06 comparisons in the retained
 implementer run. It is not accepted: primary and separate read-only Tester

--- a/docs/provenance/T-0012-double-value-probe.md
+++ b/docs/provenance/T-0012-double-value-probe.md
@@ -169,6 +169,16 @@ Implementer capture trace SHA-256, finite-null / nonfinite:
 
 ### Remaining acceptance gates
 
+The first Stage B source revision `7ec550b` passed the selected live fixtures,
+40 raw rejection controls and existing S08/S06 comparisons in the retained
+implementer run. It is not accepted: primary and separate read-only Tester
+review require per-negative stdout/stderr/exit retention, resolved evidence and
+generated-JAR path confinement, and mandatory provenance metadata validation.
+These pre-acceptance corrections remain in the same three-file source allowlist;
+no new runtime or native behavior is authorized. The owner requested a temporary
+pause and then resumed with a low-effort implementer. The source handoff preserves
+the interrupted implementation and does not change acceptance requirements.
+
 After PM freezes the exact observed outcome matrix, validate complete ordered
 events and all per-cell values, not counts alone. Canonical case membership,
 capture/sequence, caps before allocation, raw-log extraction, trace copies,

--- a/docs/provenance/T-0012-double-value-probe.md
+++ b/docs/provenance/T-0012-double-value-probe.md
@@ -1,8 +1,8 @@
 # T-0012/S09 bounded double-value observation
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: Blocked before source creation; awaiting explicit owner approval for reference-probe execution
-- Branch: `research/t-0012-double-value-probe`
+- State: In Progress; execution approval received, Stage A capture
+- Branch: `research/t-0012-double-value-capture`
 - Owner: Compatibility Host Implementer; decisions, records and integration: PM
 - Priority: P0; parent task T-0012; parent epic T-0010
 - Estimate: 5 SP (implementation 2, uncertainty 1, verification 1, environment 1;
@@ -188,3 +188,9 @@ that executable with the original local test plugin. External executable code
 runs locally; the checksum establishes identity, not a security guarantee.
 No new dependency/artifact admission, paid service or redistribution is proposed.
 Owner: repository owner; PM resumes the existing packet only after approval.
+
+The owner subsequently instructed continuation after the explicit explanation
+of creating the probe, checksum-pinned JAR retrieval and local external-code
+execution. This clears the execution checkpoint for the existing scoped packet.
+The earlier denial remains historical evidence. Work resumes from merged PR #83
+on the continuation branch above; the published planning branch is preserved.

--- a/docs/provenance/T-0012-double-value-probe.md
+++ b/docs/provenance/T-0012-double-value-probe.md
@@ -1,7 +1,7 @@
 # T-0012/S09 bounded double-value observation
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: In Progress; execution approval received, Stage A capture
+- State: In Progress; Stage A reviewed, Stage B authorized
 - Branch: `research/t-0012-double-value-capture`
 - Owner: Compatibility Host Implementer; decisions, records and integration: PM
 - Priority: P0; parent task T-0012; parent epic T-0010
@@ -123,6 +123,51 @@ before PM reviews capture and records the decision in this packet.
 | Which Rust representation/equality is justified? | Accepted reference gate followed by a later explicit decision | No Float64 enum variant or Eq-policy change in S09 |
 
 ## Stage B and acceptance
+
+### PM observation decision (2026-09-06)
+
+Corrected Stage A source is frozen at
+`7e463798ebcf007ea12e18d77382362979c3878e`. Earlier draft captures are retained,
+but were not accepted as complete transport evidence. PM reviewed all 207
+ordered decoded events and both complete runtime logs from
+`/var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/t0012-double-value-probe/run.95aMuf/evidence`.
+The exact Stage A Demo also passed independently in the primary agent's run:
+`/private/tmp/t0012-s09-primary-capture.Edu3ve` (complete outer logs, exit 0),
+with raw evidence in the same temporary probe root at `run.g9vBiJ/evidence`.
+All ordered events and payloads match between these captures except fresh UUIDs.
+
+| Fixture | Exit | Events | Pages / rows | Exact supplied and getter bits, in order |
+| --- | --- | --- | --- | --- |
+| finite-null | 0 | 114 | 1 / 7 | `7fefffffffffffff`, `ffefffffffffffff`, `0000000000000001`, `8000000000000001`, `0000000000000000`, `8000000000000000`, explicit null |
+| nonfinite | 0 | 93 | 1 / 5 | `7ff0000000000000`, `fff0000000000000`, `7ff8000000000000`, `7ff8000000000042`, `fff8000000000042` |
+
+Both schemas are exactly `number:double`, index 0. Every non-null getter follows
+an `isNull=false`; the explicit null follows `isNull=true` with no getter.
+Each fixture exhausts its reader with a final `nextRecord=false`. The observed
+finish/close nesting is builder finish -> collector add/read -> collector finish
+-> builder finish return, then builder close -> collector close -> reader close
+and corresponding returns. Runtime output finish, run/control/transaction
+returns, one successful terminal marker, then cleanup entry/return with 1 task
+and 1 report complete the trace. No resume, guess or semantic exception occurs.
+
+PM authorizes Stage B exact vectors and repaired-copy rejection controls for
+these selected facts only. Selected signed zeros and NaN signs/payloads survive
+this reference round trip; this is not a whole-domain numeric equality rule,
+portable Page batching guarantee or native Float64 decision. Keep all Rust and
+accepted S07/S08 sources unchanged. Independent final acceptance remains open.
+
+Frozen source SHA-256 (plugin / runner / wrapper):
+
+- `183070a032c4d9654f4eee69f028cb94ba90d248bceb0b33e86f7105069209dd`
+- `8c6d37428582fc7fbc0de8d13d06de41d8b0d755910fbeb74b76391ec30b6ab0`
+- `641563db5c69e62ec8a0e1dd4b556fcead03a276248347d0a5d941f63a97b9dd`
+
+Implementer capture trace SHA-256, finite-null / nonfinite:
+
+- `61b2a16754fa5f551ef406e96cd8b6e8e33b4d55ebbf9c442cc473bd47238d26`
+- `9c2c56aa00cd98fe1ffbfd770e60a8e28b86b4278e30e2788df58efc8568fd67`
+
+### Remaining acceptance gates
 
 After PM freezes the exact observed outcome matrix, validate complete ordered
 events and all per-cell values, not counts alone. Canonical case membership,

--- a/tests/t0012_double_value_probe_test.sh
+++ b/tests/t0012_double_value_probe_test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+runner="$root/tools/t0012-double-value-probe/run.sh"
+[[ -x "$runner" ]] || exit 2
+attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-capture.XXXXXX")
+mode=${T0012_DOUBLE_MODE:-capture}
+if T0012_DOUBLE_MODE="$mode" "$runner" > "$attempt/stdout.log" 2> "$attempt/stderr.log"; then status=0; else status=$?; fi
+printf 'T0012_DOUBLE_CAPTURE_ATTEMPT=%s|exit=%s\n' "$attempt" "$status"
+[[ "$mode" == capture && "$status" == 0 ]]
+[[ $(grep -c '^T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=' "$attempt/stdout.log") == 1 ]]
+evidence=$(sed -n 's/^T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=//p' "$attempt/stdout.log")
+[[ -d "$evidence" ]]
+for file in executable-url.txt executable.sha256 LICENSE-executable NOTICE-executable java-version.txt source-revision.txt plugin-source.sha256 runner-source.sha256 wrapper-source.sha256 stage.txt double-cases.raw double-traces.raw raw-evidence-hashes.txt finite-null.raw.log nonfinite.raw.log finite-null.trace.raw nonfinite.trace.raw; do [[ -s "$evidence/$file" ]]; done
+grep -Fqx e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47 "$evidence/executable.sha256"
+grep -Eq '^DOUBLECASE\|finite-null\|[0-9]+\|[0-9]+\|[0-9a-f]{64}$' "$evidence/double-cases.raw"
+grep -Eq '^DOUBLECASE\|nonfinite\|[0-9]+\|[0-9]+\|[0-9a-f]{64}$' "$evidence/double-cases.raw"
+if output=$(T0012_DOUBLE_MODE=validate T0012_DOUBLE_EVIDENCE_DIR="$evidence" "$runner" 2>&1); then [[ "$output" == T0012_DOUBLE_VALIDATE_ONLY=passed ]]; else exit 1; fi
+if output=$(T0012_DOUBLE_MODE=full "$runner" 2>&1); then exit 1; else status=$?; fi
+[[ "$status" == 2 && "$output" == T0012_DOUBLE_STAGE_B_REQUIRED ]]
+printf 'T0012_DOUBLE_CAPTURE_PROBE=passed|evidence=%s\n' "$evidence"

--- a/tests/t0012_double_value_probe_test.sh
+++ b/tests/t0012_double_value_probe_test.sh
@@ -1,21 +1,73 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 runner="$root/tools/t0012-double-value-probe/run.sh"
-[[ -x "$runner" ]] || exit 2
+mode=${T0012_DOUBLE_MODE:-full}
+
+if [[ ! -x "$runner" ]]; then
+  printf '%s\n' 'T0012 double probe runner is not executable' >&2
+  exit 2
+fi
+
+if [[ "$mode" == validate ]]; then
+  T0012_DOUBLE_MODE=validate "$runner"
+  exit $?
+fi
+
+if [[ "$mode" != capture ]]; then
+  T0012_DOUBLE_MODE="$mode" "$runner"
+  exit $?
+fi
+
 attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-capture.XXXXXX")
-mode=${T0012_DOUBLE_MODE:-capture}
-if T0012_DOUBLE_MODE="$mode" "$runner" > "$attempt/stdout.log" 2> "$attempt/stderr.log"; then status=0; else status=$?; fi
+status=0
+T0012_DOUBLE_MODE=capture "$runner" > "$attempt/stdout.log" 2> "$attempt/stderr.log" || status=$?
 printf 'T0012_DOUBLE_CAPTURE_ATTEMPT=%s|exit=%s\n' "$attempt" "$status"
-[[ "$mode" == capture && "$status" == 0 ]]
-[[ $(grep -c '^T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=' "$attempt/stdout.log") == 1 ]]
+if [[ "$status" != 0 ]]; then
+  exit "$status"
+fi
+
+if [[ $(grep -c '^T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=' "$attempt/stdout.log") != 1 ]]; then
+  printf '%s\n' 'capture marker missing or duplicated' >&2
+  exit 1
+fi
 evidence=$(sed -n 's/^T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=//p' "$attempt/stdout.log")
-[[ -d "$evidence" ]]
-for file in executable-url.txt executable.sha256 LICENSE-executable NOTICE-executable java-version.txt source-revision.txt plugin-source.sha256 runner-source.sha256 wrapper-source.sha256 stage.txt double-cases.raw double-traces.raw raw-evidence-hashes.txt finite-null.raw.log nonfinite.raw.log finite-null.trace.raw nonfinite.trace.raw; do [[ -s "$evidence/$file" ]]; done
-grep -Fqx e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47 "$evidence/executable.sha256"
+if [[ ! -d "$evidence" ]]; then
+  printf '%s\n' 'capture evidence directory missing' >&2
+  exit 1
+fi
+
+required=(
+  executable-url.txt executable.sha256 executable-manifest.txt
+  executable-license-notice-locators.txt LICENSE-executable NOTICE-executable
+  java-version.txt os-family.txt source-revision.txt
+  plugin-source-path.txt plugin-source.sha256
+  runner-source-path.txt runner-source.sha256
+  wrapper-source-path.txt wrapper-source.sha256
+  plugin-jar.sha256 plugin-coordinate.txt stage.txt
+  double-cases.raw double-traces.raw raw-evidence-hashes.txt
+  finite-null.raw.log nonfinite.raw.log
+  finite-null.trace.raw nonfinite.trace.raw
+)
+for file in "${required[@]}"; do
+  if [[ ! -s "$evidence/$file" ]]; then
+    printf 'missing capture artifact: %s\n' "$file" >&2
+    exit 1
+  fi
+done
+
+expected=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
+grep -Fqx "$expected" "$evidence/executable.sha256"
+grep -Fqx 'META-INF/LICENSE|META-INF/NOTICE' "$evidence/executable-license-notice-locators.txt"
+grep -Fqx 'capture' "$evidence/stage.txt"
 grep -Eq '^DOUBLECASE\|finite-null\|[0-9]+\|[0-9]+\|[0-9a-f]{64}$' "$evidence/double-cases.raw"
 grep -Eq '^DOUBLECASE\|nonfinite\|[0-9]+\|[0-9]+\|[0-9a-f]{64}$' "$evidence/double-cases.raw"
-if output=$(T0012_DOUBLE_MODE=validate T0012_DOUBLE_EVIDENCE_DIR="$evidence" "$runner" 2>&1); then [[ "$output" == T0012_DOUBLE_VALIDATE_ONLY=passed ]]; else exit 1; fi
-if output=$(T0012_DOUBLE_MODE=full "$runner" 2>&1); then exit 1; else status=$?; fi
-[[ "$status" == 2 && "$output" == T0012_DOUBLE_STAGE_B_REQUIRED ]]
+
+validation=$(T0012_DOUBLE_MODE=validate T0012_DOUBLE_EVIDENCE_DIR="$evidence" "$runner")
+if [[ "$validation" != T0012_DOUBLE_VALIDATE_ONLY=passed ]]; then
+  printf '%s\n' 'validate-only marker mismatch' >&2
+  exit 1
+fi
+
 printf 'T0012_DOUBLE_CAPTURE_PROBE=passed|evidence=%s\n' "$evidence"

--- a/tests/t0012_double_value_probe_test.sh
+++ b/tests/t0012_double_value_probe_test.sh
@@ -1,73 +1,176 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 runner="$root/tools/t0012-double-value-probe/run.sh"
+[[ -x "$runner" ]] || exit 2
 mode=${T0012_DOUBLE_MODE:-full}
+if [[ "$mode" == capture || "$mode" == validate ]]; then T0012_DOUBLE_MODE="$mode" "$runner"; exit $?; fi
+[[ "$mode" == full ]] || exit 2
 
-if [[ ! -x "$runner" ]]; then
-  printf '%s\n' 'T0012 double probe runner is not executable' >&2
-  exit 2
-fi
+artifact_control() {
+  local control=$1 expected=$2 attempt status=0 evidence
+  attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-artifact.XXXXXX")
+  T0012_DOUBLE_MODE=full T0012_DOUBLE_NEGATIVE="$control" "$runner" >"$attempt/stdout.log" 2>"$attempt/stderr.log" || status=$?
+  printf 'T0012_DOUBLE_ARTIFACT_CONTROL=%s|exit=%s|attempt=%s\n' "$control" "$status" "$attempt"
+  [[ "$status" == "$expected" ]]
+  if [[ "$control" == corrupt-hash ]]; then
+    grep -Fqx 'pinned executable checksum mismatch' "$attempt/stderr.log"
+    evidence=$(sed -n 's/^T0012_DOUBLE_EVIDENCE_DIR=//p' "$attempt/stdout.log" | tail -1)
+    grep -Fqx corrupt-copy-injected "$evidence/negative-control.txt"
+  else grep -Fq 'unable to retrieve pinned executable:' "$attempt/stderr.log"; fi
+}
+artifact_control corrupt-hash 3
+artifact_control unavailable-runtime 56
 
-if [[ "$mode" == validate ]]; then
-  T0012_DOUBLE_MODE=validate "$runner"
-  exit $?
-fi
-
-if [[ "$mode" != capture ]]; then
-  T0012_DOUBLE_MODE="$mode" "$runner"
-  exit $?
-fi
-
-attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-capture.XXXXXX")
+attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-full.XXXXXX")
 status=0
-T0012_DOUBLE_MODE=capture "$runner" > "$attempt/stdout.log" 2> "$attempt/stderr.log" || status=$?
-printf 'T0012_DOUBLE_CAPTURE_ATTEMPT=%s|exit=%s\n' "$attempt" "$status"
-if [[ "$status" != 0 ]]; then
-  exit "$status"
-fi
+T0012_DOUBLE_MODE=full "$runner" >"$attempt/stdout.log" 2>"$attempt/stderr.log" || status=$?
+printf 'T0012_DOUBLE_FULL_ATTEMPT=%s|exit=%s\n' "$attempt" "$status"
+[[ "$status" == 0 && $(grep -c '^T0012_DOUBLE_FULL_RUN=passed|evidence=' "$attempt/stdout.log") == 1 ]]
+evidence=$(sed -n 's/^T0012_DOUBLE_FULL_RUN=passed|evidence=//p' "$attempt/stdout.log")
+grep -Fqx full "$evidence/stage.txt"
+grep -Eq '^DOUBLECASE\|finite-null\|0\|114\|[0-9a-f]{64}$' "$evidence/double-cases.raw"
+grep -Eq '^DOUBLECASE\|nonfinite\|0\|93\|[0-9a-f]{64}$' "$evidence/double-cases.raw"
 
-if [[ $(grep -c '^T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=' "$attempt/stdout.log") != 1 ]]; then
-  printf '%s\n' 'capture marker missing or duplicated' >&2
-  exit 1
-fi
-evidence=$(sed -n 's/^T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=//p' "$attempt/stdout.log")
-if [[ ! -d "$evidence" ]]; then
-  printf '%s\n' 'capture evidence directory missing' >&2
-  exit 1
-fi
+mutated_copy() {
+  local action=$1 fixture=$2 copy
+  copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-validator.XXXXXX")
+  cp -R "$evidence/." "$copy/"
+  python3 - "$action" "$fixture" "$copy" <<'PY'
+import base64, hashlib, pathlib, sys
+action, fixture, directory = sys.argv[1:]
+root=pathlib.Path(directory); fixtures=("finite-null","nonfinite")
+cases=root.joinpath("double-cases.raw").read_text().splitlines()
+traces=root.joinpath("double-traces.raw").read_text().splitlines()
+enc=lambda x: base64.b64encode(x.encode()).decode()
+def idx(event, selected=None):
+    selected=selected or fixture
+    return [i for i,r in enumerate(traces) if r.split("|")[1]==selected and r.split("|")[4]==event]
+def change(event, field, value, occurrence=0):
+    i=idx(event)[occurrence]; p=traces[i].split("|"); p[field]=value; traces[i]="|".join(p)
+def remove(event, occurrence=0): traces.pop(idx(event)[occurrence])
+if action=="missing-case": cases.pop(0)
+elif action=="duplicate-case": cases[1]=cases[0]
+elif action=="unknown-case": p=cases[0].split("|"); p[1]="unknown"; cases[0]="|".join(p)
+elif action=="case-count": p=cases[0].split("|"); p[3]="9999"; cases[0]="|".join(p)
+elif action=="case-digest": p=cases[0].split("|"); p[4]="0"*64; cases[0]="|".join(p)
+elif action=="capture": change("transaction-entry",2,"not-a-uuid")
+elif action=="capture-mismatch": change("schema-construct-entry",2,"12345678-1234-4234-9234-123456789abc")
+elif action=="sequence": change("schema-construct-entry",3,"1")
+elif action=="unknown-event": change("schema-column",4,"unknown-event")
+elif action=="duplicate-event":
+    i=idx("schema-column")[0]; traces.insert(i+1,traces[i])
+elif action=="bad-base64": change("schema-column",7,"!")
+elif action=="bad-utf8": change("schema-column",7,"/w==")
+elif action=="raw-log":
+    p=root/f"{fixture}.raw.log"; p.write_text(p.read_text().replace("DOUBLETRACE|","BROKEN|",1))
+elif action=="combined-order": traces=list(reversed(traces))
+elif action=="schema": change("schema-column",7,enc("changed"))
+elif action=="bad-hex": change("input-cell",8,enc("ABC"))
+elif action=="noncanonical-hex": change("input-cell",8,enc("7FEFFFFFFFFFFFFF"))
+elif action=="null-tag": change("input-cell",7,enc("null"),0)
+elif action=="null-payload": change("input-cell",8,enc("0000000000000000"),6)
+elif action=="finite-bits": change("input-cell",8,enc("7feffffffffffffe"),0)
+elif action=="zero-sign": change("input-cell",8,enc("0000000000000000"),5)
+elif action=="infinity-sign": change("input-cell",8,enc("7ff0000000000000"),1)
+elif action=="nan-bits": change("input-cell",8,enc("7ff8000000000043"),3)
+elif action=="negative-nan": change("input-cell",8,enc("7ff8000000000042"),4)
+elif action=="input-getter": change("reader-get-double-return",9,enc("0000000000000000"),0)
+elif action=="missing-row":
+    a=idx("reader-next-record-entry")[1]; b=idx("reader-next-record-entry")[2]; del traces[a:b]
+elif action=="reordered-row":
+    a=idx("reader-next-record-return")[0]; b=idx("reader-next-record-return")[1]; traces[a],traces[b]=traces[b],traces[a]
+elif action=="getter-null": change("reader-is-null-return",9,enc("false"),6)
+elif action=="exhaustion": change("reader-next-record-return",7,enc("true"),-1)
+elif action=="setter": remove("builder-set-double-return")
+elif action=="finish": remove("collector-finish-return")
+elif action=="close": remove("reader-close-return")
+elif action=="terminal": change("terminal",5,enc("exception"))
+elif action=="cleanup": remove("cleanup-return")
+elif action=="executable-pin": (root/"executable.sha256").write_text("0"*64+"\n")
+elif action=="jar-hash": (root/"plugin-jar.sha256").write_text("0"*64+"\n")
+elif action=="source-hash": (root/"runner-source.sha256").write_text("0"*64+"\n")
+elif action=="event-cap":
+    p=cases[0].split("|"); p[3]="1025"; cases[0]="|".join(p)
+elif action=="artifact-cap": (root/f"{fixture}.raw.log").write_bytes(b"x"*(8*1024*1024+1))
+elif action=="symlink":
+    target=root/"stage-target.txt"; target.write_text("full\n"); (root/"stage.txt").unlink(); (root/"stage.txt").symlink_to(target)
+else: raise ValueError(action)
+repair=action not in {"missing-case","duplicate-case","unknown-case","case-count","case-digest","raw-log","combined-order","executable-pin","jar-hash","source-hash","event-cap","artifact-cap","symlink"}
+if repair:
+    for selected in fixtures:
+        seq=0; rows=[]
+        for i,row in enumerate(traces):
+            p=row.split("|")
+            if p[1]==selected:
+                seq+=1; p[3]=str(seq); traces[i]="|".join(p); rows.append(traces[i])
+        if action == "sequence" and selected == fixture:
+            i = next(i for i, row in enumerate(traces) if row.split("|")[1] == selected and row.split("|")[4] == "schema-construct-entry")
+            p = traces[i].split("|"); p[3] = "1"; traces[i] = "|".join(p)
+            rows = [row for row in traces if row.split("|")[1] == selected]
+        material=("\n".join(rows)+"\n").encode(); (root/f"{selected}.trace.raw").write_bytes(material)
+        log=root/f"{selected}.raw.log"; other=[x for x in log.read_text().splitlines() if not x.startswith("DOUBLETRACE|")]
+        log.write_text("\n".join(rows+other)+"\n")
+        ci=next(i for i,x in enumerate(cases) if x.startswith("DOUBLECASE|"+selected+"|")); p=cases[ci].split("|")
+        p[3]=str(len(rows)); p[4]=hashlib.sha256(material).hexdigest(); cases[ci]="|".join(p)
+(root/"double-cases.raw").write_text("\n".join(cases)+"\n"); (root/"double-traces.raw").write_text("\n".join(traces)+"\n")
+if repair:
+    names=("double-cases.raw","double-traces.raw","finite-null.raw.log","nonfinite.raw.log","finite-null.trace.raw","nonfinite.trace.raw")
+    (root/"raw-evidence-hashes.txt").write_text("".join(f"{n}={hashlib.sha256((root/n).read_bytes()).hexdigest()}\n" for n in names))
+PY
+  printf '%s\n' "$copy"
+}
 
-required=(
-  executable-url.txt executable.sha256 executable-manifest.txt
-  executable-license-notice-locators.txt LICENSE-executable NOTICE-executable
-  java-version.txt os-family.txt source-revision.txt
-  plugin-source-path.txt plugin-source.sha256
-  runner-source-path.txt runner-source.sha256
-  wrapper-source-path.txt wrapper-source.sha256
-  plugin-jar.sha256 plugin-coordinate.txt stage.txt
-  double-cases.raw double-traces.raw raw-evidence-hashes.txt
-  finite-null.raw.log nonfinite.raw.log
-  finite-null.trace.raw nonfinite.trace.raw
-)
-for file in "${required[@]}"; do
-  if [[ ! -s "$evidence/$file" ]]; then
-    printf 'missing capture artifact: %s\n' "$file" >&2
-    exit 1
-  fi
-done
+validator_fails() {
+  local action=$1 fixture=$2 expected=$3 copy output status=0
+  copy=$(mutated_copy "$action" "$fixture")
+  output=$(T0012_DOUBLE_MODE=validate T0012_DOUBLE_STRICT_VALIDATE=1 T0012_DOUBLE_EVIDENCE_DIR="$copy" "$runner" 2>&1) || status=$?
+  [[ "$status" == 4 && "$output" == "T0012_DOUBLE_VALIDATION_ERROR|$expected" ]] || { printf 'unexpected %s:%s => %s (%s)\n' "$fixture" "$action" "$output" "$status" >&2; exit 1; }
+  printf 'T0012_DOUBLE_MUTATION=%s:%s|diagnostic=%s\n' "$fixture" "$action" "$expected"
+}
 
-expected=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
-grep -Fqx "$expected" "$evidence/executable.sha256"
-grep -Fqx 'META-INF/LICENSE|META-INF/NOTICE' "$evidence/executable-license-notice-locators.txt"
-grep -Fqx 'capture' "$evidence/stage.txt"
-grep -Eq '^DOUBLECASE\|finite-null\|[0-9]+\|[0-9]+\|[0-9a-f]{64}$' "$evidence/double-cases.raw"
-grep -Eq '^DOUBLECASE\|nonfinite\|[0-9]+\|[0-9]+\|[0-9a-f]{64}$' "$evidence/double-cases.raw"
+validator_fails missing-case finite-null case-count
+validator_fails duplicate-case finite-null case-grammar
+validator_fails unknown-case finite-null case-grammar
+validator_fails case-count finite-null case-count
+validator_fails case-digest finite-null case-digest
+validator_fails capture finite-null capture-id
+validator_fails capture-mismatch finite-null single-capture
+validator_fails sequence finite-null sequence
+validator_fails unknown-event finite-null event-known
+validator_fails duplicate-event finite-null expected-event-count
+validator_fails bad-base64 finite-null canonical-base64
+validator_fails bad-utf8 finite-null utf8
+validator_fails raw-log finite-null raw-log
+validator_fails combined-order finite-null combined-order
+validator_fails schema finite-null expected-schema
+validator_fails bad-hex finite-null input-value
+validator_fails noncanonical-hex finite-null input-value
+validator_fails null-tag finite-null input-value
+validator_fails null-payload finite-null input-value
+validator_fails finite-bits finite-null expected-finite-bits
+validator_fails zero-sign finite-null expected-zero-sign
+validator_fails infinity-sign nonfinite expected-infinity-sign
+validator_fails nan-bits nonfinite expected-nan-bits
+validator_fails negative-nan nonfinite expected-nan-bits
+validator_fails input-getter finite-null expected-input-getter
+validator_fails missing-row finite-null expected-event-count
+validator_fails reordered-row finite-null operation-identity
+validator_fails getter-null finite-null expected-getter-null-pairing
+validator_fails exhaustion finite-null expected-reader-exhaustion
+validator_fails setter finite-null operation-pair
+validator_fails finish finite-null operation-pair
+validator_fails close finite-null operation-pair
+validator_fails terminal finite-null terminal-exception
+validator_fails cleanup finite-null unpaired-operation
+validator_fails executable-pin finite-null executable-pin
+validator_fails jar-hash finite-null jar-hash
+validator_fails source-hash finite-null source-hash
+validator_fails event-cap finite-null case-count
+validator_fails artifact-cap finite-null artifact-size
+validator_fails symlink finite-null evidence-path
 
-validation=$(T0012_DOUBLE_MODE=validate T0012_DOUBLE_EVIDENCE_DIR="$evidence" "$runner")
-if [[ "$validation" != T0012_DOUBLE_VALIDATE_ONLY=passed ]]; then
-  printf '%s\n' 'validate-only marker mismatch' >&2
-  exit 1
-fi
-
-printf 'T0012_DOUBLE_CAPTURE_PROBE=passed|evidence=%s\n' "$evidence"
+[[ $(T0012_DOUBLE_MODE=validate T0012_DOUBLE_EVIDENCE_DIR="$evidence" "$runner") == T0012_DOUBLE_VALIDATE_ONLY=passed ]]
+[[ $(T0012_DOUBLE_MODE=validate T0012_DOUBLE_STRICT_VALIDATE=1 T0012_DOUBLE_EVIDENCE_DIR="$evidence" "$runner") == T0012_DOUBLE_VALIDATE_ONLY=passed ]]
+printf 'T0012_DOUBLE_VALIDATED_CASES=2|events=207|evidence=%s\n' "$evidence"
+printf 'T0012_DOUBLE_FULL_PROBE=passed|evidence=%s\n' "$evidence"

--- a/tests/t0012_double_value_probe_test.sh
+++ b/tests/t0012_double_value_probe_test.sh
@@ -4,13 +4,18 @@ root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 runner="$root/tools/t0012-double-value-probe/run.sh"
 [[ -x "$runner" ]] || exit 2
 mode=${T0012_DOUBLE_MODE:-full}
-if [[ "$mode" == capture || "$mode" == validate ]]; then T0012_DOUBLE_MODE="$mode" "$runner"; exit $?; fi
+if [[ "$mode" == capture || "$mode" == validate ]]; then
+  T0012_DOUBLE_MODE="$mode" "$runner"
+  exit $?
+fi
 [[ "$mode" == full ]] || exit 2
 
 artifact_control() {
   local control=$1 expected=$2 attempt status=0 evidence
   attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-artifact.XXXXXX")
+  attempt=$(cd -- "$attempt" && pwd -P)
   T0012_DOUBLE_MODE=full T0012_DOUBLE_NEGATIVE="$control" "$runner" >"$attempt/stdout.log" 2>"$attempt/stderr.log" || status=$?
+  printf '%s\n' "$status" > "$attempt/exit.txt"
   printf 'T0012_DOUBLE_ARTIFACT_CONTROL=%s|exit=%s|attempt=%s\n' "$control" "$status" "$attempt"
   [[ "$status" == "$expected" ]]
   if [[ "$control" == corrupt-hash ]]; then
@@ -23,8 +28,10 @@ artifact_control corrupt-hash 3
 artifact_control unavailable-runtime 56
 
 attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-full.XXXXXX")
+attempt=$(cd -- "$attempt" && pwd -P)
 status=0
 T0012_DOUBLE_MODE=full "$runner" >"$attempt/stdout.log" 2>"$attempt/stderr.log" || status=$?
+printf '%s\n' "$status" > "$attempt/exit.txt"
 printf 'T0012_DOUBLE_FULL_ATTEMPT=%s|exit=%s\n' "$attempt" "$status"
 [[ "$status" == 0 && $(grep -c '^T0012_DOUBLE_FULL_RUN=passed|evidence=' "$attempt/stdout.log") == 1 ]]
 evidence=$(sed -n 's/^T0012_DOUBLE_FULL_RUN=passed|evidence=//p' "$attempt/stdout.log")
@@ -33,87 +40,197 @@ grep -Eq '^DOUBLECASE\|finite-null\|0\|114\|[0-9a-f]{64}$' "$evidence/double-cas
 grep -Eq '^DOUBLECASE\|nonfinite\|0\|93\|[0-9a-f]{64}$' "$evidence/double-cases.raw"
 
 mutated_copy() {
-  local action=$1 fixture=$2 copy
+  local action=$1 fixture=$2 copy container
   copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-validator.XXXXXX")
-  cp -R "$evidence/." "$copy/"
-  python3 - "$action" "$fixture" "$copy" <<'PY'
-import base64, hashlib, pathlib, sys
-action, fixture, directory = sys.argv[1:]
-root=pathlib.Path(directory); fixtures=("finite-null","nonfinite")
-cases=root.joinpath("double-cases.raw").read_text().splitlines()
-traces=root.joinpath("double-traces.raw").read_text().splitlines()
-enc=lambda x: base64.b64encode(x.encode()).decode()
+  copy=$(cd -- "$copy" && pwd -P)
+  if [[ "$action" == ancestor-link ]]; then
+    container=$copy
+    mkdir -p "$container/real/evidence"
+    ln -s "$container/real" "$container/alias"
+    copy="$container/alias/evidence"
+  fi
+  python3 - "$action" "$fixture" "$evidence" "$copy" <<'PY'
+import base64
+import hashlib
+import pathlib
+import shutil
+import sys
+
+action, fixture, source_directory, copy_directory = sys.argv[1:]
+source = pathlib.Path(source_directory)
+root = pathlib.Path(copy_directory)
+fixtures = ("finite-null", "nonfinite")
+
+for item in source.iterdir():
+    if item.is_symlink() or not item.is_file():
+        raise ValueError("unsafe evidence member: " + item.name)
+    shutil.copy2(item, root / item.name)
+
+cases = root.joinpath("double-cases.raw").read_text().splitlines()
+traces = root.joinpath("double-traces.raw").read_text().splitlines()
+
+def enc(value):
+    return base64.b64encode(value.encode()).decode()
+
 def idx(event, selected=None):
-    selected=selected or fixture
-    return [i for i,r in enumerate(traces) if r.split("|")[1]==selected and r.split("|")[4]==event]
+    selected = selected or fixture
+    return [
+        index for index, row in enumerate(traces)
+        if row.split("|")[1] == selected and row.split("|")[4] == event
+    ]
+
 def change(event, field, value, occurrence=0):
-    i=idx(event)[occurrence]; p=traces[i].split("|"); p[field]=value; traces[i]="|".join(p)
-def remove(event, occurrence=0): traces.pop(idx(event)[occurrence])
-if action=="missing-case": cases.pop(0)
-elif action=="duplicate-case": cases[1]=cases[0]
-elif action=="unknown-case": p=cases[0].split("|"); p[1]="unknown"; cases[0]="|".join(p)
-elif action=="case-count": p=cases[0].split("|"); p[3]="9999"; cases[0]="|".join(p)
-elif action=="case-digest": p=cases[0].split("|"); p[4]="0"*64; cases[0]="|".join(p)
-elif action=="capture": change("transaction-entry",2,"not-a-uuid")
-elif action=="capture-mismatch": change("schema-construct-entry",2,"12345678-1234-4234-9234-123456789abc")
-elif action=="sequence": change("schema-construct-entry",3,"1")
-elif action=="unknown-event": change("schema-column",4,"unknown-event")
+    index = idx(event)[occurrence]
+    parts = traces[index].split("|")
+    parts[field] = value
+    traces[index] = "|".join(parts)
+
+def remove(event, occurrence=0):
+    traces.pop(idx(event)[occurrence])
+
+if action == "missing-case":
+    cases.pop(0)
+elif action == "duplicate-case":
+    cases[1] = cases[0]
+elif action == "unknown-case":
+    parts = cases[0].split("|")
+    parts[1] = "unknown"
+    cases[0] = "|".join(parts)
+elif action == "case-count":
+    parts = cases[0].split("|")
+    parts[3] = "9999"
+    cases[0] = "|".join(parts)
+elif action == "case-digest":
+    parts = cases[0].split("|")
+    parts[4] = "0" * 64
+    cases[0] = "|".join(parts)
+elif action == "capture":
+    change("transaction-entry", 2, "not-a-uuid")
+elif action == "capture-mismatch":
+    change("schema-construct-entry", 2, "12345678-1234-4234-9234-123456789abc")
+elif action == "sequence":
+    change("schema-construct-entry", 3, "1")
+elif action == "unknown-event":
+    change("schema-column", 4, "unknown-event")
 elif action=="duplicate-event":
     i=idx("schema-column")[0]; traces.insert(i+1,traces[i])
-elif action=="bad-base64": change("schema-column",7,"!")
-elif action=="bad-utf8": change("schema-column",7,"/w==")
+elif action == "bad-base64":
+    change("schema-column", 7, "!")
+elif action == "bad-utf8":
+    change("schema-column", 7, "/w==")
 elif action=="raw-log":
     p=root/f"{fixture}.raw.log"; p.write_text(p.read_text().replace("DOUBLETRACE|","BROKEN|",1))
-elif action=="combined-order": traces=list(reversed(traces))
-elif action=="schema": change("schema-column",7,enc("changed"))
-elif action=="bad-hex": change("input-cell",8,enc("ABC"))
-elif action=="noncanonical-hex": change("input-cell",8,enc("7FEFFFFFFFFFFFFF"))
-elif action=="null-tag": change("input-cell",7,enc("null"),0)
-elif action=="null-payload": change("input-cell",8,enc("0000000000000000"),6)
-elif action=="finite-bits": change("input-cell",8,enc("7feffffffffffffe"),0)
-elif action=="zero-sign": change("input-cell",8,enc("0000000000000000"),5)
-elif action=="infinity-sign": change("input-cell",8,enc("7ff0000000000000"),1)
-elif action=="nan-bits": change("input-cell",8,enc("7ff8000000000043"),3)
-elif action=="negative-nan": change("input-cell",8,enc("7ff8000000000042"),4)
-elif action=="input-getter": change("reader-get-double-return",9,enc("0000000000000000"),0)
+elif action == "combined-order":
+    traces = list(reversed(traces))
+elif action == "schema":
+    change("schema-column", 7, enc("changed"))
+elif action == "bad-hex":
+    change("input-cell", 8, enc("ABC"))
+elif action == "noncanonical-hex":
+    change("input-cell", 8, enc("7FEFFFFFFFFFFFFF"))
+elif action == "null-tag":
+    change("input-cell", 7, enc("null"), 0)
+elif action == "null-payload":
+    change("input-cell", 8, enc("0000000000000000"), 6)
+elif action == "finite-bits":
+    change("input-cell", 8, enc("7feffffffffffffe"), 0)
+elif action == "zero-sign":
+    change("input-cell", 8, enc("0000000000000000"), 5)
+elif action == "infinity-sign":
+    change("input-cell", 8, enc("7ff0000000000000"), 1)
+elif action == "nan-bits":
+    change("input-cell", 8, enc("7ff8000000000043"), 3)
+elif action == "negative-nan":
+    change("input-cell", 8, enc("7ff8000000000042"), 4)
+elif action == "input-getter":
+    change("reader-get-double-return", 9, enc("0000000000000000"), 0)
 elif action=="missing-row":
     a=idx("reader-next-record-entry")[1]; b=idx("reader-next-record-entry")[2]; del traces[a:b]
 elif action=="reordered-row":
     a=idx("reader-next-record-return")[0]; b=idx("reader-next-record-return")[1]; traces[a],traces[b]=traces[b],traces[a]
-elif action=="getter-null": change("reader-is-null-return",9,enc("false"),6)
-elif action=="exhaustion": change("reader-next-record-return",7,enc("true"),-1)
-elif action=="setter": remove("builder-set-double-return")
-elif action=="finish": remove("collector-finish-return")
-elif action=="close": remove("reader-close-return")
-elif action=="terminal": change("terminal",5,enc("exception"))
-elif action=="cleanup": remove("cleanup-return")
-elif action=="executable-pin": (root/"executable.sha256").write_text("0"*64+"\n")
-elif action=="jar-hash": (root/"plugin-jar.sha256").write_text("0"*64+"\n")
-elif action=="source-hash": (root/"runner-source.sha256").write_text("0"*64+"\n")
+elif action == "getter-null":
+    change("reader-is-null-return", 9, enc("false"), 6)
+elif action == "exhaustion":
+    change("reader-next-record-return", 7, enc("true"), -1)
+elif action == "setter":
+    remove("builder-set-double-return")
+elif action == "finish":
+    remove("collector-finish-return")
+elif action == "close":
+    remove("reader-close-return")
+elif action == "terminal":
+    change("terminal", 5, enc("exception"))
+elif action == "cleanup":
+    remove("cleanup-return")
+elif action == "executable-pin":
+    (root / "executable.sha256").write_text("0" * 64 + "\n")
+elif action == "jar-hash":
+    (root / "plugin-jar.sha256").write_text("0" * 64 + "\n")
+elif action == "source-hash":
+    (root / "runner-source.sha256").write_text("0" * 64 + "\n")
 elif action=="event-cap":
     p=cases[0].split("|"); p[3]="1025"; cases[0]="|".join(p)
-elif action=="artifact-cap": (root/f"{fixture}.raw.log").write_bytes(b"x"*(8*1024*1024+1))
-elif action=="symlink":
-    target=root/"stage-target.txt"; target.write_text("full\n"); (root/"stage.txt").unlink(); (root/"stage.txt").symlink_to(target)
-else: raise ValueError(action)
-repair=action not in {"missing-case","duplicate-case","unknown-case","case-count","case-digest","raw-log","combined-order","executable-pin","jar-hash","source-hash","event-cap","artifact-cap","symlink"}
+elif action == "artifact-cap":
+    (root / f"{fixture}.raw.log").write_bytes(b"x" * (8 * 1024 * 1024 + 1))
+elif action == "symlink":
+    target = root / "stage-target.txt"
+    target.write_text("full\n")
+    (root / "stage.txt").unlink()
+    (root / "stage.txt").symlink_to(target)
+elif action == "ancestor-link":
+    pass
+elif action == "jar-path-escape":
+    (root / "plugin-jar-path.txt").write_text("../plugin-under-test.jar\n")
+elif action == "missing-provenance":
+    (root / "executable-manifest.txt").unlink()
+elif action == "bad-revision":
+    (root / "source-revision.txt").write_text("0" * 40 + "\n")
+elif action == "wrong-source-path":
+    (root / "runner-source-path.txt").write_text("tools/wrong/run.sh\n")
+else:
+    raise ValueError(action)
+repair = action not in {
+    "missing-case", "duplicate-case", "unknown-case", "case-count",
+    "case-digest", "raw-log", "combined-order", "executable-pin",
+    "jar-hash", "source-hash", "event-cap", "artifact-cap", "symlink",
+    "ancestor-link", "jar-path-escape", "missing-provenance", "bad-revision",
+    "wrong-source-path",
+}
 if repair:
     for selected in fixtures:
-        seq=0; rows=[]
-        for i,row in enumerate(traces):
-            p=row.split("|")
-            if p[1]==selected:
-                seq+=1; p[3]=str(seq); traces[i]="|".join(p); rows.append(traces[i])
+        sequence = 0
+        rows = []
+        for index, row in enumerate(traces):
+            parts = row.split("|")
+            if parts[1] == selected:
+                sequence += 1
+                parts[3] = str(sequence)
+                traces[index] = "|".join(parts)
+                rows.append(traces[index])
         if action == "sequence" and selected == fixture:
             i = next(i for i, row in enumerate(traces) if row.split("|")[1] == selected and row.split("|")[4] == "schema-construct-entry")
-            p = traces[i].split("|"); p[3] = "1"; traces[i] = "|".join(p)
+            parts = traces[i].split("|")
+            parts[3] = "1"
+            traces[i] = "|".join(parts)
             rows = [row for row in traces if row.split("|")[1] == selected]
-        material=("\n".join(rows)+"\n").encode(); (root/f"{selected}.trace.raw").write_bytes(material)
-        log=root/f"{selected}.raw.log"; other=[x for x in log.read_text().splitlines() if not x.startswith("DOUBLETRACE|")]
-        log.write_text("\n".join(rows+other)+"\n")
-        ci=next(i for i,x in enumerate(cases) if x.startswith("DOUBLECASE|"+selected+"|")); p=cases[ci].split("|")
-        p[3]=str(len(rows)); p[4]=hashlib.sha256(material).hexdigest(); cases[ci]="|".join(p)
-(root/"double-cases.raw").write_text("\n".join(cases)+"\n"); (root/"double-traces.raw").write_text("\n".join(traces)+"\n")
+        material = ("\n".join(rows) + "\n").encode()
+        (root / f"{selected}.trace.raw").write_bytes(material)
+        log = root / f"{selected}.raw.log"
+        other = [
+            line for line in log.read_text().splitlines()
+            if not line.startswith("DOUBLETRACE|")
+        ]
+        log.write_text("\n".join(rows + other) + "\n")
+        case_index = next(
+            index for index, value in enumerate(cases)
+            if value.startswith("DOUBLECASE|" + selected + "|")
+        )
+        parts = cases[case_index].split("|")
+        parts[3] = str(len(rows))
+        parts[4] = hashlib.sha256(material).hexdigest()
+        cases[case_index] = "|".join(parts)
+(root / "double-cases.raw").write_text("\n".join(cases) + "\n")
+(root / "double-traces.raw").write_text("\n".join(traces) + "\n")
 if repair:
     names=("double-cases.raw","double-traces.raw","finite-null.raw.log","nonfinite.raw.log","finite-null.trace.raw","nonfinite.trace.raw")
     (root/"raw-evidence-hashes.txt").write_text("".join(f"{n}={hashlib.sha256((root/n).read_bytes()).hexdigest()}\n" for n in names))
@@ -122,11 +239,24 @@ PY
 }
 
 validator_fails() {
-  local action=$1 fixture=$2 expected=$3 copy output status=0
+  local action=$1 fixture=$2 expected=$3 copy attempt status=0
   copy=$(mutated_copy "$action" "$fixture")
-  output=$(T0012_DOUBLE_MODE=validate T0012_DOUBLE_STRICT_VALIDATE=1 T0012_DOUBLE_EVIDENCE_DIR="$copy" "$runner" 2>&1) || status=$?
-  [[ "$status" == 4 && "$output" == "T0012_DOUBLE_VALIDATION_ERROR|$expected" ]] || { printf 'unexpected %s:%s => %s (%s)\n' "$fixture" "$action" "$output" "$status" >&2; exit 1; }
-  printf 'T0012_DOUBLE_MUTATION=%s:%s|diagnostic=%s\n' "$fixture" "$action" "$expected"
+  attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-double-negative.XXXXXX")
+  attempt=$(cd -- "$attempt" && pwd -P)
+  T0012_DOUBLE_MODE=validate T0012_DOUBLE_STRICT_VALIDATE=1 \
+    T0012_DOUBLE_EVIDENCE_DIR="$copy" "$runner" \
+    > "$attempt/stdout.log" 2> "$attempt/stderr.log" || status=$?
+  printf '%s\n' "$status" > "$attempt/exit.txt"
+  if [[ "$status" != 4 ]] ||
+    [[ -s "$attempt/stdout.log" ]] ||
+    [[ $(cat "$attempt/stderr.log") != "T0012_DOUBLE_VALIDATION_ERROR|$expected" ]]
+  then
+    printf 'unexpected %s:%s; see %s (exit %s)\n' \
+      "$fixture" "$action" "$attempt" "$status" >&2
+    exit 1
+  fi
+  printf 'T0012_DOUBLE_MUTATION=%s:%s|diagnostic=%s|copy=%s|attempt=%s\n' \
+    "$fixture" "$action" "$expected" "$copy" "$attempt"
 }
 
 validator_fails missing-case finite-null case-count
@@ -169,6 +299,11 @@ validator_fails source-hash finite-null source-hash
 validator_fails event-cap finite-null case-count
 validator_fails artifact-cap finite-null artifact-size
 validator_fails symlink finite-null evidence-path
+validator_fails ancestor-link finite-null evidence-path
+validator_fails jar-path-escape finite-null jar-path
+validator_fails missing-provenance finite-null missing-artifact
+validator_fails bad-revision finite-null source-revision
+validator_fails wrong-source-path finite-null source-path
 
 [[ $(T0012_DOUBLE_MODE=validate T0012_DOUBLE_EVIDENCE_DIR="$evidence" "$runner") == T0012_DOUBLE_VALIDATE_ONLY=passed ]]
 [[ $(T0012_DOUBLE_MODE=validate T0012_DOUBLE_STRICT_VALIDATE=1 T0012_DOUBLE_EVIDENCE_DIR="$evidence" "$runner") == T0012_DOUBLE_VALIDATE_ONLY=passed ]]

--- a/tools/t0012-double-value-probe/run.sh
+++ b/tools/t0012-double-value-probe/run.sh
@@ -11,10 +11,6 @@ if [[ "$mode" != capture && "$mode" != full && "$mode" != validate ]]; then
   printf '%s\n' 'T0012_DOUBLE_MODE must be capture, full, or validate' >&2
   exit 2
 fi
-if [[ "$mode" == full ]]; then
-  printf '%s\n' 'T0012_DOUBLE_STAGE_B_REQUIRED' >&2
-  exit 2
-fi
 
 temporary_root=${T0012_DOUBLE_TEMP_ROOT:-"${TMPDIR:-/private/tmp}/t0012-double-value-probe"}
 resolved_root=$(python3 -c 'import pathlib, sys
@@ -40,8 +36,9 @@ if [[ -L "$temporary_root" || ! -f "$source_file" || ! -f "$wrapper_file" ]]; th
 fi
 
 validate_evidence() {
-  PYTHONDONTWRITEBYTECODE=1 python3 - "$1" "$source_file" "$script_dir/run.sh" "$wrapper_file" <<'PY'
+  PYTHONDONTWRITEBYTECODE=1 python3 - "$1" "$source_file" "$script_dir/run.sh" "$wrapper_file" "$2" <<'PY'
 import base64
+import binascii
 import hashlib
 import pathlib
 import re
@@ -49,8 +46,10 @@ import sys
 import uuid
 
 evidence = pathlib.Path(sys.argv[1])
-sources = [pathlib.Path(value) for value in sys.argv[2:]]
+sources = [pathlib.Path(value) for value in sys.argv[2:5]]
 fixtures = ("finite-null", "nonfinite")
+validation_level = sys.argv[5]
+strict = validation_level == "strict"
 hex16 = re.compile(r"[0-9a-f]{16}")
 hex64 = re.compile(r"[0-9a-f]{64}")
 
@@ -72,11 +71,22 @@ def number(label, text, cap):
 def decode(field):
     if field == "-":
         return None
-    raw = base64.b64decode(field, validate=True)
+    try:
+        raw = base64.b64decode(field, validate=True)
+    except binascii.Error as error:
+        raise Bad("canonical-base64") from error
     need("canonical-base64", base64.b64encode(raw).decode() == field)
-    return raw.decode("utf-8")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise Bad("utf8") from error
 
 def bounded_bytes(path, cap):
+    if path not in sources:
+        need("evidence-path", evidence.is_dir() and not evidence.is_symlink())
+        need("evidence-path", path.parent == evidence and not path.is_symlink())
+    else:
+        need("source-path", path.is_absolute() and not path.is_symlink())
     need("artifact-size", path.is_file() and path.stat().st_size <= cap)
     return path.read_bytes()
 
@@ -148,7 +158,10 @@ def typed(event, values):
 def parse(line, fixture, capture, sequence, stack):
     fields = line.split("|")
     need("trace-grammar", len(fields) >= 5 and fields[:2] == ["DOUBLETRACE", fixture])
-    parsed_uuid = uuid.UUID(fields[2])
+    try:
+        parsed_uuid = uuid.UUID(fields[2])
+    except ValueError as error:
+        raise Bad("capture-id") from error
     need("capture-id", str(parsed_uuid) == fields[2] and parsed_uuid.version == 4)
     need("single-capture", capture is None or capture == fields[2])
     need("sequence", number("sequence", fields[3], 2048) == sequence)
@@ -217,22 +230,140 @@ def parser_self_check():
             rejected = True
         need("self-check-rejection", rejected)
 
+def expected_vector(fixture):
+    bits = {
+        "finite-null": [
+            "7fefffffffffffff", "ffefffffffffffff", "0000000000000001",
+            "8000000000000001", "0000000000000000", "8000000000000000",
+            None,
+        ],
+        "nonfinite": [
+            "7ff0000000000000", "fff0000000000000", "7ff8000000000000",
+            "7ff8000000000042", "fff8000000000042",
+        ],
+    }[fixture]
+    events = [
+        ("transaction-entry", ["1"]),
+        ("schema-construct-entry", []),
+        ("schema-construct-return", []),
+        ("schema-column", ["transaction", "0", "number", "double"]),
+        ("control-run-entry", ["1"]),
+        ("run-entry", ["0", "1"]),
+        ("schema-column", ["run", "0", "number", "double"]),
+        ("collector-construct-entry", []),
+        ("reader-construct-entry", []),
+        ("reader-construct-return", []),
+        ("collector-construct-return", []),
+        ("builder-construct-entry", []),
+        ("builder-construct-return", []),
+        ("input-row-count", [str(len(bits))]),
+    ]
+    for row, value in enumerate(bits):
+        position = [str(row), "0"]
+        if value is None:
+            events.append(("input-cell", position + ["null", None]))
+            events.append(("builder-set-null-entry", position))
+            events.append(("builder-set-null-return", position))
+        else:
+            events.append(("input-cell", position + ["double-bits", value]))
+            events.append(("builder-set-double-entry", position + [value]))
+            events.append(("builder-set-double-return", position + [value]))
+        events.append(("builder-add-record-entry", [str(row)]))
+        events.append(("builder-add-record-return", [str(row)]))
+    events.extend([
+        ("builder-finish-entry", []),
+        ("collector-add-entry", ["0"]),
+        ("reader-set-page-entry", ["0"]),
+        ("reader-set-page-return", ["0"]),
+    ])
+    for row, value in enumerate(bits):
+        position = ["0", str(row), str(row), "0"]
+        events.append(("reader-next-record-entry", ["0", str(row)]))
+        events.append(("reader-next-record-return", ["0", str(row), "true"]))
+        events.append(("reader-is-null-entry", position))
+        events.append(("reader-is-null-return", position + ["true" if value is None else "false"]))
+        if value is None:
+            events.append(("cell-null", position))
+        else:
+            events.append(("reader-get-double-entry", position))
+            events.append(("reader-get-double-return", position + [value]))
+    rows = str(len(bits))
+    events.extend([
+        ("reader-next-record-entry", ["0", rows]),
+        ("reader-next-record-return", ["0", rows, "false"]),
+        ("collector-add-return", ["0", rows, rows]),
+        ("collector-finish-entry", ["1", rows]),
+        ("collector-finish-return", ["1", rows]),
+        ("builder-finish-return", []),
+        ("builder-close-entry", []),
+        ("collector-close-entry", ["1", rows]),
+        ("reader-close-entry", ["1", rows]),
+        ("reader-close-return", ["1", rows]),
+        ("collector-close-return", ["1", rows]),
+        ("builder-close-return", []),
+        ("runtime-output-finish-entry", []),
+        ("runtime-output-finish-return", []),
+        ("run-return", ["0"]),
+        ("control-run-return", ["1"]),
+        ("transaction-return", ["1"]),
+        ("terminal", ["success", None, None]),
+        ("cleanup-entry", ["1", "1"]),
+        ("cleanup-return", ["1", "1"]),
+    ])
+    return events
+
+def vector_label(fixture, expected, actual):
+    event, values = expected
+    if event == "schema-column":
+        return "expected-schema"
+    if event.startswith("builder-set") or event.startswith("builder-add"):
+        return "expected-setters"
+    if event == "input-cell":
+        row = int(values[0])
+        if fixture == "finite-null" and row in (4, 5):
+            return "expected-zero-sign"
+        if fixture == "nonfinite" and row in (0, 1):
+            return "expected-infinity-sign"
+        if fixture == "nonfinite" and row >= 2:
+            return "expected-nan-bits"
+        return "expected-finite-bits"
+    if event.startswith("reader-get-double"):
+        return "expected-input-getter"
+    if event.startswith("reader-is-null") or event == "cell-null":
+        return "expected-getter-null-pairing"
+    if event.startswith("reader-next-record"):
+        return "expected-reader-exhaustion"
+    lifecycle = ("finish", "close", "return", "terminal", "cleanup")
+    if any(part in event for part in lifecycle):
+        return "expected-lifecycle"
+    return "expected-event-vector"
+
 try:
     parser_self_check()
     required = (
+        "executable.sha256",
         "double-cases.raw", "double-traces.raw", "raw-evidence-hashes.txt",
         "finite-null.raw.log", "nonfinite.raw.log", "finite-null.trace.raw",
         "nonfinite.trace.raw", "plugin-source.sha256", "runner-source.sha256",
-        "wrapper-source.sha256", "plugin-jar.sha256", "plugin-coordinate.txt", "stage.txt",
+        "wrapper-source.sha256", "plugin-jar.sha256", "plugin-jar-path.txt",
+        "plugin-coordinate.txt", "stage.txt",
     )
     for name in required:
         need("missing-artifact", evidence.joinpath(name).is_file())
+    executable_hash = bounded_text(evidence.joinpath("executable.sha256"), 1024).strip()
+    need("executable-pin", executable_hash == "e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47")
     for name, source in zip(("plugin-source.sha256", "runner-source.sha256", "wrapper-source.sha256"), sources):
         recorded = bounded_text(evidence.joinpath(name), 1024).strip()
         need("source-hash", recorded == digest(source, 1024 * 1024))
     jar_hash = bounded_text(evidence.joinpath("plugin-jar.sha256"), 1024).strip()
     need("jar-hash", hex64.fullmatch(jar_hash) is not None)
-    need("stage", bounded_text(evidence.joinpath("stage.txt"), 1024) == "capture\n")
+    artifact = pathlib.Path(bounded_text(evidence.joinpath("plugin-jar-path.txt"), 4096).strip())
+    need("jar-path", artifact.is_absolute() and artifact.is_file() and not artifact.is_symlink())
+    need("jar-path", evidence.parent in artifact.parents)
+    need("jar-size", artifact.stat().st_size <= 4 * 1024 * 1024)
+    need("jar-hash", hashlib.sha256(artifact.read_bytes()).hexdigest() == jar_hash)
+    recorded_stage = bounded_text(evidence.joinpath("stage.txt"), 1024)
+    need("stage", recorded_stage == "full\n" if strict else recorded_stage in ("capture\n", "full\n"))
     coordinate = "source=maven|group=org.embulk.t0012|name=t0012_double|version=0.0.1|artifact=embulk-input-t0012_double|local-only\n"
     need("coordinate", bounded_text(evidence.joinpath("plugin-coordinate.txt"), 4096) == coordinate)
     cases = bounded_text(evidence.joinpath("double-cases.raw"), 65536).splitlines()
@@ -271,6 +402,12 @@ try:
             need("terminal-exception", terminal[1] not in (None, "") and exit_code != 0)
             need("transaction-result", parsed[terminal_index - 1][0] == "transaction-exception")
             need("terminal-exception-match", terminal[1:] == parsed[terminal_index - 1][1][-2:])
+        if strict:
+            expected = expected_vector(fixture)
+            need("expected-event-count", len(parsed) == len(expected))
+            for expected_item, actual_item in zip(expected, parsed):
+                if expected_item != actual_item:
+                    raise Bad(vector_label(fixture, expected_item, actual_item))
         combined.extend(lines)
     all_lines = bounded_text(evidence.joinpath("double-traces.raw"), 2 * 1024 * 1024).splitlines()
     need("combined-event-cap", len(all_lines) <= 2048)
@@ -295,7 +432,11 @@ PY
 }
 
 if [[ "$mode" == validate ]]; then
-  validate_evidence "${T0012_DOUBLE_EVIDENCE_DIR:-}"
+  validation_level=transport
+  if [[ ${T0012_DOUBLE_STRICT_VALIDATE:-0} == 1 ]]; then
+    validation_level=strict
+  fi
+  validate_evidence "${T0012_DOUBLE_EVIDENCE_DIR:-}" "$validation_level"
   printf '%s\n' 'T0012_DOUBLE_VALIDATE_ONLY=passed'
   exit 0
 fi
@@ -312,9 +453,16 @@ trap 'printf "T0012_DOUBLE_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
 executable="$run_dir/embulk.jar"
 url=${T0012_EXECUTABLE_URL:-https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar}
 expected=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
-if ! curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error --output "$executable" "$url"; then
+if [[ ${T0012_DOUBLE_NEGATIVE:-} == unavailable-runtime ]]; then
+  url=https://127.0.0.1:1/t0012-unavailable.jar
+fi
+if ! curl --connect-timeout 2 --max-time 5 --fail --location --proto '=https' --tlsv1.2 --silent --show-error --output "$executable" "$url"; then
   printf 'unable to retrieve pinned executable: %s\n' "$url" >&2
   exit 56
+fi
+if [[ ${T0012_DOUBLE_NEGATIVE:-} == corrupt-hash ]]; then
+  printf '%s\n' 'corrupt-copy-injected' >> "$executable"
+  printf '%s\n' 'corrupt-copy-injected' > "$evidence/negative-control.txt"
 fi
 actual=$(shasum -a 256 "$executable" | awk '{print $1}')
 if [[ "$actual" != "$expected" ]]; then
@@ -337,13 +485,14 @@ for item in "plugin:$source_file" "runner:$script_dir/run.sh" "wrapper:$wrapper_
   printf '%s\n' "$path" > "$evidence/$label-source-path.txt"
   shasum -a 256 "$path" | awk '{print $1}' > "$evidence/$label-source.sha256"
 done
-printf '%s\n' capture > "$evidence/stage.txt"
+printf '%s\n' "$mode" > "$evidence/stage.txt"
 
 javac -cp "$executable" -d "$plugin/classes" "$source_file"
 printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0012DoubleValueInputPlugin' 'Embulk-Plugin-Category: input' 'Embulk-Plugin-Type: t0012_double' 'Embulk-Plugin-Spi-Version: 0' > "$plugin/MANIFEST.MF"
 jar_file="$repository/embulk-input-t0012_double-0.0.1.jar"
 jar cfm "$jar_file" "$plugin/MANIFEST.MF" -C "$plugin/classes" .
 shasum -a 256 "$jar_file" | awk '{print $1}' > "$evidence/plugin-jar.sha256"
+printf '%s\n' "$jar_file" > "$evidence/plugin-jar-path.txt"
 printf '%s\n' '<project><modelVersion>4.0.0</modelVersion><groupId>org.embulk.t0012</groupId><artifactId>embulk-input-t0012_double</artifactId><version>0.0.1</version></project>' > "$repository/embulk-input-t0012_double-0.0.1.pom"
 printf '%s\n' 'source=maven|group=org.embulk.t0012|name=t0012_double|version=0.0.1|artifact=embulk-input-t0012_double|local-only' > "$evidence/plugin-coordinate.txt"
 
@@ -365,6 +514,14 @@ for file in double-cases.raw double-traces.raw finite-null.raw.log nonfinite.raw
   shasum -a 256 "$evidence/$file" | awk -v name="$file" '{print name "=" $1}'
 done > "$evidence/raw-evidence-hashes.txt"
 
-validate_evidence "$evidence"
+validation_level=transport
+if [[ "$mode" == full ]]; then
+  validation_level=strict
+fi
+validate_evidence "$evidence" "$validation_level"
 cat "$evidence/double-cases.raw"
-printf 'T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=%s\n' "$evidence"
+if [[ "$mode" == capture ]]; then
+  printf 'T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=%s\n' "$evidence"
+else
+  printf 'T0012_DOUBLE_FULL_RUN=passed|evidence=%s\n' "$evidence"
+fi

--- a/tools/t0012-double-value-probe/run.sh
+++ b/tools/t0012-double-value-probe/run.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+root=$(cd -- "$script_dir/../.." && pwd)
+source_file="$script_dir/src/T0012DoubleValueInputPlugin.java"
+mode=${T0012_DOUBLE_MODE:-full}
+if [[ "$mode" != capture && "$mode" != full && "$mode" != validate ]]; then printf '%s\n' 'T0012_DOUBLE_MODE must be capture, full, or validate' >&2; exit 2; fi
+if [[ "$mode" == full ]]; then printf '%s\n' 'T0012_DOUBLE_STAGE_B_REQUIRED' >&2; exit 2; fi
+temporary_root=${T0012_DOUBLE_TEMP_ROOT:-"${TMPDIR:-/private/tmp}/t0012-double-value-probe"}
+resolved_root=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$temporary_root")
+resolved_repository=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$root")
+case "$resolved_root" in /tmp/*|/private/tmp/*|/var/folders/*|/private/var/folders/*) ;; *) printf '%s\n' 'T0012_DOUBLE_TEMP_ROOT must be external' >&2; exit 2;; esac
+case "$resolved_root/" in "$resolved_repository/"*) printf '%s\n' 'T0012_DOUBLE_TEMP_ROOT resolves inside repository' >&2; exit 2;; esac
+[[ ! -L "$temporary_root" && -f "$source_file" ]] || { printf '%s\n' 'invalid double probe path' >&2; exit 2; }
+
+validate_evidence() {
+  PYTHONDONTWRITEBYTECODE=1 python3 - "$1" <<'PY'
+import base64, hashlib, pathlib, sys, uuid
+root=pathlib.Path(sys.argv[1]); fixtures=("finite-null","nonfinite"); required=("double-cases.raw","double-traces.raw")
+class Bad(Exception): pass
+def need(label, condition):
+    if not condition: raise Bad(label)
+def dec(label, text):
+    need(label, text.isascii() and text.isdigit() and len(text)<=6 and (text=="0" or not text.startswith("0"))); return int(text)
+try:
+    for name in required: need("missing-artifact", root.joinpath(name).is_file())
+    cases=root.joinpath("double-cases.raw").read_text(encoding="utf-8").splitlines(); need("case-count",len(cases)==2)
+    case_fields = [row.split("|") for row in cases]
+    need("case-order", [row[1] if len(row) > 1 else None for row in case_fields] == list(fixtures))
+    for fields in case_fields:
+        need("case-grammar", len(fields) == 5 and fields[0] == "DOUBLECASE")
+        need("case-event-cap", dec("case-count", fields[3]) <= 1024)
+    traces=root.joinpath("double-traces.raw").read_text(encoding="utf-8").splitlines(); grouped={x:[] for x in fixtures}; captures={x:set() for x in fixtures}; last={x:0 for x in fixtures}
+    need("combined-event-cap", len(traces) <= 2048)
+    parsed={}
+    for row in traces:
+        parts=row.split("|"); need("trace-grammar",len(parts)>=5 and parts[0]=="DOUBLETRACE" and parts[1] in grouped)
+        fixture,capture,sequence=parts[1:4]; parsed_uuid=uuid.UUID(capture); need("capture-id",str(parsed_uuid)==capture and parsed_uuid.version==4)
+        value=dec("sequence",sequence); need("sequence",value==last[fixture]+1); last[fixture]=value; captures[fixture].add(capture)
+        event_name = parts[4]
+        arities = {
+            "transaction-entry": 1, "schema-column": 4, "control-run-entry": 1,
+            "run-entry": 2, "reader-construct-entry": 0, "reader-construct-return": 0,
+            "builder-construct-entry": 0, "builder-construct-return": 0,
+            "input-row-count": 1, "input-cell": 4, "builder-set-double-entry": 3,
+            "builder-set-double-return": 3, "builder-set-null-entry": 2,
+            "builder-set-null-return": 2, "builder-add-record-entry": 1,
+            "builder-add-record-return": 1, "builder-finish-entry": 0,
+            "collector-add-entry": 1, "reader-set-page-entry": 1,
+            "reader-set-page-return": 1, "reader-next-record-entry": 2,
+            "reader-next-record-return": 3, "reader-is-null-entry": 4,
+            "reader-is-null-return": 5, "reader-get-double-entry": 4,
+            "reader-get-double-return": 5, "cell-null": 4, "collector-add-return": 3,
+            "collector-finish-entry": 2, "collector-finish-return": 2,
+            "builder-finish-return": 0, "builder-close-entry": 0,
+            "reader-close-entry": 2, "reader-close-return": 2,
+            "collector-close-entry": 2, "collector-close-return": 2,
+            "builder-close-return": 0, "runtime-output-finish-entry": 0,
+            "runtime-output-finish-return": 0, "run-return": 1,
+            "control-run-return": 1, "transaction-return": 1, "terminal": 3,
+            "cleanup-entry": 2, "cleanup-return": 2, "run-exception": 2,
+            "transaction-exception": 2, "collector-add-exception": 3,
+            "reader-close-exception": 2, "collector-close-exception": 2,
+        }
+        need("event-known", event_name in arities)
+        need("event-arity", len(parts) - 5 == arities[event_name])
+        for field in parts[5:]:
+            if field == "-": continue
+            decoded=base64.b64decode(field,validate=True); need("canonical-base64",base64.b64encode(decoded).decode()==field)
+            decoded.decode("utf-8")
+        grouped[fixture].append(row)
+    need("combined-order",traces==grouped[fixtures[0]]+grouped[fixtures[1]])
+    for fixture in fixtures:
+        values=[x.split("|") for x in cases if x.startswith("DOUBLECASE|"+fixture+"|")]; need("case-fixture",len(values)==1)
+        fields=values[0]; need("case-grammar",len(fields)==5); exit_code=dec("case-exit",fields[2]); count=dec("case-count",fields[3]); need("case-event-cap",count<=1024); need("single-capture",len(captures[fixture])==1); need("case-count-match",count==len(grouped[fixture]))
+        material=("\n".join(grouped[fixture])+"\n").encode(); need("case-digest",hashlib.sha256(material).hexdigest()==fields[4]); need("trace-copy",root.joinpath(fixture+".trace.raw").read_bytes()==material)
+        extracted=[x for x in root.joinpath(fixture+".raw.log").read_text(encoding="utf-8").splitlines() if x.startswith("DOUBLETRACE|")]; need("raw-log",extracted==grouped[fixture])
+        observed = {line.split("|")[4] for line in grouped[fixture]}
+        need("capture-complete", "transaction-entry" in observed and "terminal" in observed)
+except (Bad,OSError,UnicodeError,ValueError) as error:
+    print("T0012_DOUBLE_VALIDATION_ERROR|"+(error.args[0] if error.args else "unclassified"),file=sys.stderr); raise SystemExit(4)
+PY
+}
+if [[ "$mode" == validate ]]; then validate_evidence "${T0012_DOUBLE_EVIDENCE_DIR:-}"; printf '%s\n' 'T0012_DOUBLE_VALIDATE_ONLY=passed'; exit 0; fi
+
+mkdir -p -- "$temporary_root"; run_dir=$(mktemp -d "$temporary_root/run.XXXXXX"); evidence="$run_dir/evidence"; plugin="$run_dir/plugin"; export EMBULK_HOME="$run_dir/embulk-home"; repository="$EMBULK_HOME/lib/m2/repository/org/embulk/t0012/embulk-input-t0012_double/0.0.1"; mkdir -p "$evidence" "$plugin/classes" "$repository"; trap 'printf "T0012_DOUBLE_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
+executable="$run_dir/embulk.jar"; executable_url=${T0012_EXECUTABLE_URL:-https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar}; expected=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
+if ! curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error --output "$executable" "$executable_url"; then printf 'unable to retrieve pinned executable: %s\n' "$executable_url" >&2; exit 56; fi
+actual=$(shasum -a 256 "$executable" | awk '{print $1}'); [[ "$actual" == "$expected" ]] || { printf '%s\n' 'pinned executable checksum mismatch' >&2; exit 3; }
+printf '%s\n' "$executable_url" > "$evidence/executable-url.txt"
+printf '%s\n' "$actual" > "$evidence/executable.sha256"
+unzip -p "$executable" META-INF/MANIFEST.MF > "$evidence/executable-manifest.txt" || [[ -s "$evidence/executable-manifest.txt" ]]
+unzip -p "$executable" META-INF/LICENSE > "$evidence/LICENSE-executable" || [[ -s "$evidence/LICENSE-executable" ]]
+unzip -p "$executable" META-INF/NOTICE > "$evidence/NOTICE-executable" || [[ -s "$evidence/NOTICE-executable" ]]
+printf '%s\n' 'META-INF/LICENSE|META-INF/NOTICE' > "$evidence/executable-license-notice-locators.txt"
+java -XshowSettings:properties -version > "$evidence/java-version.txt" 2>&1
+uname -s > "$evidence/os-family.txt"
+git -C "$root" rev-parse HEAD > "$evidence/source-revision.txt"
+printf '%s\n' "$source_file" > "$evidence/plugin-source-path.txt"
+shasum -a 256 "$source_file" | awk '{print $1}' > "$evidence/plugin-source.sha256"
+printf '%s\n' "$script_dir/run.sh" > "$evidence/runner-source-path.txt"
+shasum -a 256 "$script_dir/run.sh" | awk '{print $1}' > "$evidence/runner-source.sha256"
+printf '%s\n' "$root/tests/t0012_double_value_probe_test.sh" > "$evidence/wrapper-source-path.txt"
+shasum -a 256 "$root/tests/t0012_double_value_probe_test.sh" | awk '{print $1}' > "$evidence/wrapper-source.sha256"
+printf '%s\n' capture > "$evidence/stage.txt"
+javac -cp "$executable" -d "$plugin/classes" "$source_file"
+printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0012DoubleValueInputPlugin' 'Embulk-Plugin-Category: input' 'Embulk-Plugin-Type: t0012_double' 'Embulk-Plugin-Spi-Version: 0' > "$plugin/MANIFEST.MF"
+jar_file="$repository/embulk-input-t0012_double-0.0.1.jar"
+jar cfm "$jar_file" "$plugin/MANIFEST.MF" -C "$plugin/classes" .
+shasum -a 256 "$jar_file" | awk '{print $1}' > "$evidence/plugin-jar.sha256"
+printf '%s\n' '<project><modelVersion>4.0.0</modelVersion><groupId>org.embulk.t0012</groupId><artifactId>embulk-input-t0012_double</artifactId><version>0.0.1</version></project>' > "$repository/embulk-input-t0012_double-0.0.1.pom"
+printf '%s\n' 'source=maven|group=org.embulk.t0012|name=t0012_double|version=0.0.1|artifact=embulk-input-t0012_double|local-only' > "$evidence/plugin-coordinate.txt"
+: > "$evidence/double-cases.raw"; : > "$evidence/double-traces.raw"
+for fixture in finite-null nonfinite; do
+  config="$run_dir/$fixture.yml"; raw="$evidence/$fixture.raw.log"; printf '%s\n' 'in:' '  type:' '    source: maven' '    group: org.embulk.t0012' '    name: t0012_double' '    version: 0.0.1' 'out:' '  type: "null"' > "$config"
+  if T0012_DOUBLE_FIXTURE="$fixture" java -jar "$executable" "-Xembulk_home=$EMBULK_HOME" run "$config" > "$raw" 2>&1; then status=0; else status=$?; fi
+  grep "^DOUBLETRACE|$fixture|" "$raw" > "$evidence/$fixture.trace.raw" || true; count=$(wc -l < "$evidence/$fixture.trace.raw" | tr -d ' '); digest=$(shasum -a 256 "$evidence/$fixture.trace.raw" | awk '{print $1}'); printf 'DOUBLECASE|%s|%s|%s|%s\n' "$fixture" "$status" "$count" "$digest" >> "$evidence/double-cases.raw"; cat "$evidence/$fixture.trace.raw" >> "$evidence/double-traces.raw"
+done
+validate_evidence "$evidence"
+for file in double-cases.raw double-traces.raw finite-null.raw.log nonfinite.raw.log finite-null.trace.raw nonfinite.trace.raw; do shasum -a 256 "$evidence/$file" | awk -v name="$file" '{print name "=" $1}'; done > "$evidence/raw-evidence-hashes.txt"
+cat "$evidence/double-cases.raw"; printf 'T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=%s\n' "$evidence"

--- a/tools/t0012-double-value-probe/run.sh
+++ b/tools/t0012-double-value-probe/run.sh
@@ -4,91 +4,325 @@ set -euo pipefail
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 root=$(cd -- "$script_dir/../.." && pwd)
 source_file="$script_dir/src/T0012DoubleValueInputPlugin.java"
+wrapper_file="$root/tests/t0012_double_value_probe_test.sh"
 mode=${T0012_DOUBLE_MODE:-full}
-if [[ "$mode" != capture && "$mode" != full && "$mode" != validate ]]; then printf '%s\n' 'T0012_DOUBLE_MODE must be capture, full, or validate' >&2; exit 2; fi
-if [[ "$mode" == full ]]; then printf '%s\n' 'T0012_DOUBLE_STAGE_B_REQUIRED' >&2; exit 2; fi
+
+if [[ "$mode" != capture && "$mode" != full && "$mode" != validate ]]; then
+  printf '%s\n' 'T0012_DOUBLE_MODE must be capture, full, or validate' >&2
+  exit 2
+fi
+if [[ "$mode" == full ]]; then
+  printf '%s\n' 'T0012_DOUBLE_STAGE_B_REQUIRED' >&2
+  exit 2
+fi
+
 temporary_root=${T0012_DOUBLE_TEMP_ROOT:-"${TMPDIR:-/private/tmp}/t0012-double-value-probe"}
-resolved_root=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$temporary_root")
-resolved_repository=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$root")
-case "$resolved_root" in /tmp/*|/private/tmp/*|/var/folders/*|/private/var/folders/*) ;; *) printf '%s\n' 'T0012_DOUBLE_TEMP_ROOT must be external' >&2; exit 2;; esac
-case "$resolved_root/" in "$resolved_repository/"*) printf '%s\n' 'T0012_DOUBLE_TEMP_ROOT resolves inside repository' >&2; exit 2;; esac
-[[ ! -L "$temporary_root" && -f "$source_file" ]] || { printf '%s\n' 'invalid double probe path' >&2; exit 2; }
+resolved_root=$(python3 -c 'import pathlib, sys
+print(pathlib.Path(sys.argv[1]).resolve())' "$temporary_root")
+resolved_repository=$(python3 -c 'import pathlib, sys
+print(pathlib.Path(sys.argv[1]).resolve())' "$root")
+case "$resolved_root" in
+  /tmp/* | /private/tmp/* | /var/folders/* | /private/var/folders/*) ;;
+  *)
+    printf '%s\n' 'T0012_DOUBLE_TEMP_ROOT must be external' >&2
+    exit 2
+    ;;
+esac
+case "$resolved_root/" in
+  "$resolved_repository/"*)
+    printf '%s\n' 'T0012_DOUBLE_TEMP_ROOT resolves inside repository' >&2
+    exit 2
+    ;;
+esac
+if [[ -L "$temporary_root" || ! -f "$source_file" || ! -f "$wrapper_file" ]]; then
+  printf '%s\n' 'invalid double probe path' >&2
+  exit 2
+fi
 
 validate_evidence() {
-  PYTHONDONTWRITEBYTECODE=1 python3 - "$1" <<'PY'
-import base64, hashlib, pathlib, sys, uuid
-root=pathlib.Path(sys.argv[1]); fixtures=("finite-null","nonfinite"); required=("double-cases.raw","double-traces.raw")
-class Bad(Exception): pass
+  PYTHONDONTWRITEBYTECODE=1 python3 - "$1" "$source_file" "$script_dir/run.sh" "$wrapper_file" <<'PY'
+import base64
+import hashlib
+import pathlib
+import re
+import sys
+import uuid
+
+evidence = pathlib.Path(sys.argv[1])
+sources = [pathlib.Path(value) for value in sys.argv[2:]]
+fixtures = ("finite-null", "nonfinite")
+hex16 = re.compile(r"[0-9a-f]{16}")
+hex64 = re.compile(r"[0-9a-f]{64}")
+
+class Bad(Exception):
+    pass
+
 def need(label, condition):
-    if not condition: raise Bad(label)
-def dec(label, text):
-    need(label, text.isascii() and text.isdigit() and len(text)<=6 and (text=="0" or not text.startswith("0"))); return int(text)
+    if not condition:
+        raise Bad(label)
+
+def number(label, text, cap):
+    canonical = text.isascii() and text.isdigit()
+    canonical = canonical and (text == "0" or not text.startswith("0"))
+    need(label, canonical and len(text) <= 6)
+    value = int(text)
+    need(label, value <= cap)
+    return value
+
+def decode(field):
+    if field == "-":
+        return None
+    raw = base64.b64decode(field, validate=True)
+    need("canonical-base64", base64.b64encode(raw).decode() == field)
+    return raw.decode("utf-8")
+
+def bounded_bytes(path, cap):
+    need("artifact-size", path.is_file() and path.stat().st_size <= cap)
+    return path.read_bytes()
+
+def bounded_text(path, cap):
+    return bounded_bytes(path, cap).decode("utf-8")
+
+def digest(path, cap):
+    return hashlib.sha256(bounded_bytes(path, cap)).hexdigest()
+
+# entry arity, return arity. Exceptions always repeat entry fields plus class/message.
+operations = {
+    "transaction": (1, 1), "schema-construct": (0, 0), "control-run": (1, 1),
+    "resume": (1, 1), "cleanup": (2, 2), "run": (2, 1),
+    "collector-construct": (0, 0), "reader-construct": (0, 0),
+    "builder-construct": (0, 0), "builder-set-double": (3, 3),
+    "builder-set-null": (2, 2), "builder-add-record": (1, 1),
+    "builder-finish": (0, 0), "builder-close": (0, 0),
+    "runtime-output-finish": (0, 0), "collector-add": (1, 3),
+    "reader-set-page": (1, 1), "reader-next-record": (2, 3),
+    "reader-is-null": (4, 5), "reader-get-double": (4, 5),
+    "collector-finish": (2, 2), "collector-close": (2, 2),
+    "reader-close": (2, 2), "guess": (0, 0),
+}
+plain = {"schema-column": 4, "input-row-count": 1, "input-cell": 4,
+         "cell-null": 4, "terminal": 3}
+
+def typed(event, values):
+    numeric = {
+        "transaction": (0,), "control-run": (0,), "resume": (0,),
+        "cleanup": (0, 1), "run": (0,), "builder-set-double": (0, 1),
+        "builder-set-null": (0, 1), "builder-add-record": (0,),
+        "collector-add": (0,), "reader-set-page": (0,),
+        "reader-next-record": (0, 1), "reader-is-null": (0, 1, 2, 3),
+        "reader-get-double": (0, 1, 2, 3), "collector-finish": (0, 1),
+        "collector-close": (0, 1), "reader-close": (0, 1),
+    }
+    base = event.removesuffix("-entry").removesuffix("-return").removesuffix("-exception")
+    for position in numeric.get(base, ()):
+        if position < len(values) - (2 if event.endswith("-exception") else 0):
+            number("numeric-payload", values[position], 2048)
+    if event == "schema-column":
+        number("column-index", values[1], 64)
+    if event == "input-row-count":
+        number("input-row-count", values[0], 2048)
+    if event == "run-entry":
+        number("column-count", values[1], 64)
+    if event == "collector-add-return":
+        number("page-row-count", values[1], 2048)
+        number("total-row-count", values[2], 2048)
+    if event == "input-cell":
+        number("row", values[0], 2048)
+        number("column", values[1], 64)
+    if event == "cell-null":
+        for value in values:
+            number("cell-position", value, 2048)
+    if event == "reader-next-record-return":
+        need("boolean-payload", values[2] in ("true", "false"))
+    if event == "reader-is-null-return":
+        need("boolean-payload", values[4] in ("true", "false"))
+    if event in ("builder-set-double-entry", "builder-set-double-return"):
+        need("double-bits", hex16.fullmatch(values[2] or "") is not None)
+    if event == "reader-get-double-return":
+        need("double-bits", hex16.fullmatch(values[4] or "") is not None)
+    if event == "input-cell":
+        need("cell-tag", values[2] in ("double-bits", "null"))
+        valid = values[3] is None if values[2] == "null" else hex16.fullmatch(values[3] or "") is not None
+        need("input-value", valid)
+
+def parse(line, fixture, capture, sequence, stack):
+    fields = line.split("|")
+    need("trace-grammar", len(fields) >= 5 and fields[:2] == ["DOUBLETRACE", fixture])
+    parsed_uuid = uuid.UUID(fields[2])
+    need("capture-id", str(parsed_uuid) == fields[2] and parsed_uuid.version == 4)
+    need("single-capture", capture is None or capture == fields[2])
+    need("sequence", number("sequence", fields[3], 2048) == sequence)
+    event = fields[4]
+    values = [decode(field) for field in fields[5:]]
+    if event.endswith("-entry"):
+        name = event[:-6]
+        need("event-known", name in operations)
+        need("event-arity", len(values) == operations[name][0])
+        stack.append((name, values))
+    elif event.endswith("-return") or event.endswith("-exception"):
+        suffix = "-return" if event.endswith("-return") else "-exception"
+        name = event[:-len(suffix)]
+        need("event-known", name in operations)
+        need("operation-pair", bool(stack) and stack[-1][0] == name)
+        entry = stack.pop()[1]
+        arity = operations[name][1] if suffix == "-return" else operations[name][0] + 2
+        need("event-arity", len(values) == arity)
+        if suffix == "-exception":
+            need("exception-class", values[-2] not in (None, ""))
+        shared = len(entry) if suffix == "-exception" else min(len(entry), operations[name][1])
+        need("operation-identity", values[:shared] == entry[:shared])
+    else:
+        need("event-known", event in plain)
+        need("event-arity", len(values) == plain[event])
+        if event == "terminal":
+            need("terminal-with-open-operation", not stack)
+    typed(event, values)
+    return fields[2], event, values
+
+def encoded(value):
+    if value is None:
+        return "-"
+    return base64.b64encode(value.encode("utf-8")).decode("ascii")
+
+def parser_self_check():
+    capture = "12345678-1234-4234-9234-123456789abc"
+    defaults = {
+        "transaction": ["1"], "control-run": ["1"], "resume": ["1"],
+        "cleanup": ["1", "1"], "run": ["0", "1"],
+        "builder-set-double": ["0", "0", "0000000000000000"],
+        "builder-set-null": ["0", "0"], "builder-add-record": ["0"],
+        "collector-add": ["0"], "reader-set-page": ["0"],
+        "reader-next-record": ["0", "0"],
+        "reader-is-null": ["0", "0", "0", "0"],
+        "reader-get-double": ["0", "0", "0", "0"],
+        "collector-finish": ["0", "0"], "collector-close": ["0", "0"],
+        "reader-close": ["0", "0"],
+    }
+    for name, (entry_arity, _) in operations.items():
+        values = defaults.get(name, [])
+        need("self-check-entry-arity", len(values) == entry_arity)
+        stack = []
+        entry = "|".join(["DOUBLETRACE", "finite-null", capture, "1", name + "-entry"] + [encoded(value) for value in values])
+        exception_values = values + ["java.lang.RuntimeException", None]
+        exception = "|".join(["DOUBLETRACE", "finite-null", capture, "2", name + "-exception"] + [encoded(value) for value in exception_values])
+        current, _, _ = parse(entry, "finite-null", None, 1, stack)
+        parse(exception, "finite-null", current, 2, stack)
+        need("self-check-pair", not stack)
+        malformed = "|".join(exception.split("|")[:-1])
+        rejected = False
+        try:
+            probe_stack = [(name, values)]
+            parse(malformed, "finite-null", capture, 2, probe_stack)
+        except Bad:
+            rejected = True
+        need("self-check-rejection", rejected)
+
 try:
-    for name in required: need("missing-artifact", root.joinpath(name).is_file())
-    cases=root.joinpath("double-cases.raw").read_text(encoding="utf-8").splitlines(); need("case-count",len(cases)==2)
-    case_fields = [row.split("|") for row in cases]
-    need("case-order", [row[1] if len(row) > 1 else None for row in case_fields] == list(fixtures))
-    for fields in case_fields:
-        need("case-grammar", len(fields) == 5 and fields[0] == "DOUBLECASE")
-        need("case-event-cap", dec("case-count", fields[3]) <= 1024)
-    traces=root.joinpath("double-traces.raw").read_text(encoding="utf-8").splitlines(); grouped={x:[] for x in fixtures}; captures={x:set() for x in fixtures}; last={x:0 for x in fixtures}
-    need("combined-event-cap", len(traces) <= 2048)
-    parsed={}
-    for row in traces:
-        parts=row.split("|"); need("trace-grammar",len(parts)>=5 and parts[0]=="DOUBLETRACE" and parts[1] in grouped)
-        fixture,capture,sequence=parts[1:4]; parsed_uuid=uuid.UUID(capture); need("capture-id",str(parsed_uuid)==capture and parsed_uuid.version==4)
-        value=dec("sequence",sequence); need("sequence",value==last[fixture]+1); last[fixture]=value; captures[fixture].add(capture)
-        event_name = parts[4]
-        arities = {
-            "transaction-entry": 1, "schema-column": 4, "control-run-entry": 1,
-            "run-entry": 2, "reader-construct-entry": 0, "reader-construct-return": 0,
-            "builder-construct-entry": 0, "builder-construct-return": 0,
-            "input-row-count": 1, "input-cell": 4, "builder-set-double-entry": 3,
-            "builder-set-double-return": 3, "builder-set-null-entry": 2,
-            "builder-set-null-return": 2, "builder-add-record-entry": 1,
-            "builder-add-record-return": 1, "builder-finish-entry": 0,
-            "collector-add-entry": 1, "reader-set-page-entry": 1,
-            "reader-set-page-return": 1, "reader-next-record-entry": 2,
-            "reader-next-record-return": 3, "reader-is-null-entry": 4,
-            "reader-is-null-return": 5, "reader-get-double-entry": 4,
-            "reader-get-double-return": 5, "cell-null": 4, "collector-add-return": 3,
-            "collector-finish-entry": 2, "collector-finish-return": 2,
-            "builder-finish-return": 0, "builder-close-entry": 0,
-            "reader-close-entry": 2, "reader-close-return": 2,
-            "collector-close-entry": 2, "collector-close-return": 2,
-            "builder-close-return": 0, "runtime-output-finish-entry": 0,
-            "runtime-output-finish-return": 0, "run-return": 1,
-            "control-run-return": 1, "transaction-return": 1, "terminal": 3,
-            "cleanup-entry": 2, "cleanup-return": 2, "run-exception": 2,
-            "transaction-exception": 2, "collector-add-exception": 3,
-            "reader-close-exception": 2, "collector-close-exception": 2,
-        }
-        need("event-known", event_name in arities)
-        need("event-arity", len(parts) - 5 == arities[event_name])
-        for field in parts[5:]:
-            if field == "-": continue
-            decoded=base64.b64decode(field,validate=True); need("canonical-base64",base64.b64encode(decoded).decode()==field)
-            decoded.decode("utf-8")
-        grouped[fixture].append(row)
-    need("combined-order",traces==grouped[fixtures[0]]+grouped[fixtures[1]])
-    for fixture in fixtures:
-        values=[x.split("|") for x in cases if x.startswith("DOUBLECASE|"+fixture+"|")]; need("case-fixture",len(values)==1)
-        fields=values[0]; need("case-grammar",len(fields)==5); exit_code=dec("case-exit",fields[2]); count=dec("case-count",fields[3]); need("case-event-cap",count<=1024); need("single-capture",len(captures[fixture])==1); need("case-count-match",count==len(grouped[fixture]))
-        material=("\n".join(grouped[fixture])+"\n").encode(); need("case-digest",hashlib.sha256(material).hexdigest()==fields[4]); need("trace-copy",root.joinpath(fixture+".trace.raw").read_bytes()==material)
-        extracted=[x for x in root.joinpath(fixture+".raw.log").read_text(encoding="utf-8").splitlines() if x.startswith("DOUBLETRACE|")]; need("raw-log",extracted==grouped[fixture])
-        observed = {line.split("|")[4] for line in grouped[fixture]}
-        need("capture-complete", "transaction-entry" in observed and "terminal" in observed)
-except (Bad,OSError,UnicodeError,ValueError) as error:
-    print("T0012_DOUBLE_VALIDATION_ERROR|"+(error.args[0] if error.args else "unclassified"),file=sys.stderr); raise SystemExit(4)
+    parser_self_check()
+    required = (
+        "double-cases.raw", "double-traces.raw", "raw-evidence-hashes.txt",
+        "finite-null.raw.log", "nonfinite.raw.log", "finite-null.trace.raw",
+        "nonfinite.trace.raw", "plugin-source.sha256", "runner-source.sha256",
+        "wrapper-source.sha256", "plugin-jar.sha256", "plugin-coordinate.txt", "stage.txt",
+    )
+    for name in required:
+        need("missing-artifact", evidence.joinpath(name).is_file())
+    for name, source in zip(("plugin-source.sha256", "runner-source.sha256", "wrapper-source.sha256"), sources):
+        recorded = bounded_text(evidence.joinpath(name), 1024).strip()
+        need("source-hash", recorded == digest(source, 1024 * 1024))
+    jar_hash = bounded_text(evidence.joinpath("plugin-jar.sha256"), 1024).strip()
+    need("jar-hash", hex64.fullmatch(jar_hash) is not None)
+    need("stage", bounded_text(evidence.joinpath("stage.txt"), 1024) == "capture\n")
+    coordinate = "source=maven|group=org.embulk.t0012|name=t0012_double|version=0.0.1|artifact=embulk-input-t0012_double|local-only\n"
+    need("coordinate", bounded_text(evidence.joinpath("plugin-coordinate.txt"), 4096) == coordinate)
+    cases = bounded_text(evidence.joinpath("double-cases.raw"), 65536).splitlines()
+    need("case-count", len(cases) == 2)
+    combined = []
+    for index, fixture in enumerate(fixtures):
+        case = cases[index].split("|")
+        need("case-grammar", len(case) == 5 and case[:2] == ["DOUBLECASE", fixture])
+        exit_code = number("case-exit", case[2], 255)
+        count = number("case-count", case[3], 1024)
+        need("case-digest-format", hex64.fullmatch(case[4]) is not None)
+        trace_path = evidence.joinpath(fixture + ".trace.raw")
+        trace_bytes = bounded_bytes(trace_path, 1024 * 1024)
+        need("trace-final-newline", trace_bytes.endswith(b"\n"))
+        lines = trace_bytes.decode("utf-8").splitlines()
+        need("case-count-match", count == len(lines) and count > 0)
+        need("case-digest", hashlib.sha256(trace_bytes).hexdigest() == case[4])
+        raw = bounded_text(evidence.joinpath(fixture + ".raw.log"), 8 * 1024 * 1024).splitlines()
+        need("raw-log", [line for line in raw if line.startswith("DOUBLETRACE|")] == lines)
+        capture = None
+        stack = []
+        parsed = []
+        for sequence, line in enumerate(lines, 1):
+            capture, event, values = parse(line, fixture, capture, sequence, stack)
+            parsed.append((event, values))
+        need("unpaired-operation", not stack)
+        need("capture-start", parsed[0][0] == "transaction-entry")
+        need("single-terminal", sum(event == "terminal" for event, _ in parsed) == 1)
+        terminal_index = next(i for i, item in enumerate(parsed) if item[0] == "terminal")
+        terminal = parsed[terminal_index][1]
+        need("terminal-outcome", terminal[0] in ("success", "exception"))
+        if terminal[0] == "success":
+            need("terminal-success", terminal[1:] == [None, None] and exit_code == 0)
+            need("transaction-result", parsed[terminal_index - 1][0] == "transaction-return")
+        else:
+            need("terminal-exception", terminal[1] not in (None, "") and exit_code != 0)
+            need("transaction-result", parsed[terminal_index - 1][0] == "transaction-exception")
+            need("terminal-exception-match", terminal[1:] == parsed[terminal_index - 1][1][-2:])
+        combined.extend(lines)
+    all_lines = bounded_text(evidence.joinpath("double-traces.raw"), 2 * 1024 * 1024).splitlines()
+    need("combined-event-cap", len(all_lines) <= 2048)
+    need("combined-order", all_lines == combined)
+    hashes = {}
+    manifest = bounded_text(evidence.joinpath("raw-evidence-hashes.txt"), 65536)
+    for line in manifest.splitlines():
+        pair = line.split("=")
+        need("hash-manifest-grammar", len(pair) == 2 and hex64.fullmatch(pair[1]) is not None)
+        need("hash-manifest-duplicate", pair[0] not in hashes)
+        hashes[pair[0]] = pair[1]
+    hashed = {"double-cases.raw", "double-traces.raw", "finite-null.raw.log", "nonfinite.raw.log", "finite-null.trace.raw", "nonfinite.trace.raw"}
+    need("hash-manifest-membership", set(hashes) == hashed)
+    for name, value in hashes.items():
+        cap = 8 * 1024 * 1024 if name.endswith(".raw.log") else 2 * 1024 * 1024
+        need("hash-manifest-value", digest(evidence.joinpath(name), cap) == value)
+except (Bad, OSError, UnicodeError, ValueError) as error:
+    label = error.args[0] if error.args else "unclassified"
+    print("T0012_DOUBLE_VALIDATION_ERROR|" + label, file=sys.stderr)
+    raise SystemExit(4)
 PY
 }
-if [[ "$mode" == validate ]]; then validate_evidence "${T0012_DOUBLE_EVIDENCE_DIR:-}"; printf '%s\n' 'T0012_DOUBLE_VALIDATE_ONLY=passed'; exit 0; fi
 
-mkdir -p -- "$temporary_root"; run_dir=$(mktemp -d "$temporary_root/run.XXXXXX"); evidence="$run_dir/evidence"; plugin="$run_dir/plugin"; export EMBULK_HOME="$run_dir/embulk-home"; repository="$EMBULK_HOME/lib/m2/repository/org/embulk/t0012/embulk-input-t0012_double/0.0.1"; mkdir -p "$evidence" "$plugin/classes" "$repository"; trap 'printf "T0012_DOUBLE_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
-executable="$run_dir/embulk.jar"; executable_url=${T0012_EXECUTABLE_URL:-https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar}; expected=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
-if ! curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error --output "$executable" "$executable_url"; then printf 'unable to retrieve pinned executable: %s\n' "$executable_url" >&2; exit 56; fi
-actual=$(shasum -a 256 "$executable" | awk '{print $1}'); [[ "$actual" == "$expected" ]] || { printf '%s\n' 'pinned executable checksum mismatch' >&2; exit 3; }
-printf '%s\n' "$executable_url" > "$evidence/executable-url.txt"
+if [[ "$mode" == validate ]]; then
+  validate_evidence "${T0012_DOUBLE_EVIDENCE_DIR:-}"
+  printf '%s\n' 'T0012_DOUBLE_VALIDATE_ONLY=passed'
+  exit 0
+fi
+
+mkdir -p -- "$temporary_root"
+run_dir=$(mktemp -d "$temporary_root/run.XXXXXX")
+evidence="$run_dir/evidence"
+plugin="$run_dir/plugin"
+export EMBULK_HOME="$run_dir/embulk-home"
+repository="$EMBULK_HOME/lib/m2/repository/org/embulk/t0012/embulk-input-t0012_double/0.0.1"
+mkdir -p "$evidence" "$plugin/classes" "$repository"
+trap 'printf "T0012_DOUBLE_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
+
+executable="$run_dir/embulk.jar"
+url=${T0012_EXECUTABLE_URL:-https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar}
+expected=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
+if ! curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error --output "$executable" "$url"; then
+  printf 'unable to retrieve pinned executable: %s\n' "$url" >&2
+  exit 56
+fi
+actual=$(shasum -a 256 "$executable" | awk '{print $1}')
+if [[ "$actual" != "$expected" ]]; then
+  printf '%s\n' 'pinned executable checksum mismatch' >&2
+  exit 3
+fi
+
+printf '%s\n' "$url" > "$evidence/executable-url.txt"
 printf '%s\n' "$actual" > "$evidence/executable.sha256"
 unzip -p "$executable" META-INF/MANIFEST.MF > "$evidence/executable-manifest.txt" || [[ -s "$evidence/executable-manifest.txt" ]]
 unzip -p "$executable" META-INF/LICENSE > "$evidence/LICENSE-executable" || [[ -s "$evidence/LICENSE-executable" ]]
@@ -97,13 +331,14 @@ printf '%s\n' 'META-INF/LICENSE|META-INF/NOTICE' > "$evidence/executable-license
 java -XshowSettings:properties -version > "$evidence/java-version.txt" 2>&1
 uname -s > "$evidence/os-family.txt"
 git -C "$root" rev-parse HEAD > "$evidence/source-revision.txt"
-printf '%s\n' "$source_file" > "$evidence/plugin-source-path.txt"
-shasum -a 256 "$source_file" | awk '{print $1}' > "$evidence/plugin-source.sha256"
-printf '%s\n' "$script_dir/run.sh" > "$evidence/runner-source-path.txt"
-shasum -a 256 "$script_dir/run.sh" | awk '{print $1}' > "$evidence/runner-source.sha256"
-printf '%s\n' "$root/tests/t0012_double_value_probe_test.sh" > "$evidence/wrapper-source-path.txt"
-shasum -a 256 "$root/tests/t0012_double_value_probe_test.sh" | awk '{print $1}' > "$evidence/wrapper-source.sha256"
+for item in "plugin:$source_file" "runner:$script_dir/run.sh" "wrapper:$wrapper_file"; do
+  label=${item%%:*}
+  path=${item#*:}
+  printf '%s\n' "$path" > "$evidence/$label-source-path.txt"
+  shasum -a 256 "$path" | awk '{print $1}' > "$evidence/$label-source.sha256"
+done
 printf '%s\n' capture > "$evidence/stage.txt"
+
 javac -cp "$executable" -d "$plugin/classes" "$source_file"
 printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0012DoubleValueInputPlugin' 'Embulk-Plugin-Category: input' 'Embulk-Plugin-Type: t0012_double' 'Embulk-Plugin-Spi-Version: 0' > "$plugin/MANIFEST.MF"
 jar_file="$repository/embulk-input-t0012_double-0.0.1.jar"
@@ -111,12 +346,25 @@ jar cfm "$jar_file" "$plugin/MANIFEST.MF" -C "$plugin/classes" .
 shasum -a 256 "$jar_file" | awk '{print $1}' > "$evidence/plugin-jar.sha256"
 printf '%s\n' '<project><modelVersion>4.0.0</modelVersion><groupId>org.embulk.t0012</groupId><artifactId>embulk-input-t0012_double</artifactId><version>0.0.1</version></project>' > "$repository/embulk-input-t0012_double-0.0.1.pom"
 printf '%s\n' 'source=maven|group=org.embulk.t0012|name=t0012_double|version=0.0.1|artifact=embulk-input-t0012_double|local-only' > "$evidence/plugin-coordinate.txt"
-: > "$evidence/double-cases.raw"; : > "$evidence/double-traces.raw"
+
+: > "$evidence/double-cases.raw"
+: > "$evidence/double-traces.raw"
 for fixture in finite-null nonfinite; do
-  config="$run_dir/$fixture.yml"; raw="$evidence/$fixture.raw.log"; printf '%s\n' 'in:' '  type:' '    source: maven' '    group: org.embulk.t0012' '    name: t0012_double' '    version: 0.0.1' 'out:' '  type: "null"' > "$config"
-  if T0012_DOUBLE_FIXTURE="$fixture" java -jar "$executable" "-Xembulk_home=$EMBULK_HOME" run "$config" > "$raw" 2>&1; then status=0; else status=$?; fi
-  grep "^DOUBLETRACE|$fixture|" "$raw" > "$evidence/$fixture.trace.raw" || true; count=$(wc -l < "$evidence/$fixture.trace.raw" | tr -d ' '); digest=$(shasum -a 256 "$evidence/$fixture.trace.raw" | awk '{print $1}'); printf 'DOUBLECASE|%s|%s|%s|%s\n' "$fixture" "$status" "$count" "$digest" >> "$evidence/double-cases.raw"; cat "$evidence/$fixture.trace.raw" >> "$evidence/double-traces.raw"
+  config="$run_dir/$fixture.yml"
+  raw="$evidence/$fixture.raw.log"
+  printf '%s\n' 'in:' '  type:' '    source: maven' '    group: org.embulk.t0012' '    name: t0012_double' '    version: 0.0.1' 'out:' '  type: "null"' > "$config"
+  status=0
+  T0012_DOUBLE_FIXTURE="$fixture" java -jar "$executable" "-Xembulk_home=$EMBULK_HOME" run "$config" > "$raw" 2>&1 || status=$?
+  awk -v prefix="DOUBLETRACE|$fixture|" 'index($0, prefix) == 1' "$raw" > "$evidence/$fixture.trace.raw"
+  count=$(wc -l < "$evidence/$fixture.trace.raw" | tr -d ' ')
+  hash=$(shasum -a 256 "$evidence/$fixture.trace.raw" | awk '{print $1}')
+  printf 'DOUBLECASE|%s|%s|%s|%s\n' "$fixture" "$status" "$count" "$hash" >> "$evidence/double-cases.raw"
+  cat "$evidence/$fixture.trace.raw" >> "$evidence/double-traces.raw"
 done
+for file in double-cases.raw double-traces.raw finite-null.raw.log nonfinite.raw.log finite-null.trace.raw nonfinite.trace.raw; do
+  shasum -a 256 "$evidence/$file" | awk -v name="$file" '{print name "=" $1}'
+done > "$evidence/raw-evidence-hashes.txt"
+
 validate_evidence "$evidence"
-for file in double-cases.raw double-traces.raw finite-null.raw.log nonfinite.raw.log finite-null.trace.raw nonfinite.trace.raw; do shasum -a 256 "$evidence/$file" | awk -v name="$file" '{print name "=" $1}'; done > "$evidence/raw-evidence-hashes.txt"
-cat "$evidence/double-cases.raw"; printf 'T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=%s\n' "$evidence"
+cat "$evidence/double-cases.raw"
+printf 'T0012_DOUBLE_CAPTURE_ONLY=collected|evidence=%s\n' "$evidence"

--- a/tools/t0012-double-value-probe/run.sh
+++ b/tools/t0012-double-value-probe/run.sh
@@ -36,12 +36,13 @@ if [[ -L "$temporary_root" || ! -f "$source_file" || ! -f "$wrapper_file" ]]; th
 fi
 
 validate_evidence() {
-  PYTHONDONTWRITEBYTECODE=1 python3 - "$1" "$source_file" "$script_dir/run.sh" "$wrapper_file" "$2" <<'PY'
+  PYTHONDONTWRITEBYTECODE=1 python3 - "$1" "$source_file" "$script_dir/run.sh" "$wrapper_file" "$2" "$root" <<'PY'
 import base64
 import binascii
 import hashlib
 import pathlib
 import re
+import subprocess
 import sys
 import uuid
 
@@ -49,7 +50,10 @@ evidence = pathlib.Path(sys.argv[1])
 sources = [pathlib.Path(value) for value in sys.argv[2:5]]
 fixtures = ("finite-null", "nonfinite")
 validation_level = sys.argv[5]
+repository = pathlib.Path(sys.argv[6]).resolve()
 strict = validation_level == "strict"
+live = validation_level == "live"
+strict = strict or live
 hex16 = re.compile(r"[0-9a-f]{16}")
 hex64 = re.compile(r"[0-9a-f]{64}")
 
@@ -95,6 +99,32 @@ def bounded_text(path, cap):
 
 def digest(path, cap):
     return hashlib.sha256(bounded_bytes(path, cap)).hexdigest()
+
+def is_within(path, parent):
+    return path == parent or parent in path.parents
+
+def validate_external_directory(path):
+    need("evidence-path", path.is_absolute() and path.is_dir() and not path.is_symlink())
+    resolved = path.resolve(strict=True)
+    need("evidence-path", resolved == path)
+    need("evidence-path", not is_within(resolved, repository))
+    allowed = tuple(pathlib.Path(value) for value in (
+        "/tmp", "/private/tmp", "/var/folders", "/private/var/folders"
+    ))
+    need("evidence-path", any(is_within(resolved, root) for root in allowed))
+    current = resolved
+    while current != current.parent:
+        need("evidence-path", not current.is_symlink())
+        current = current.parent
+
+def git_bytes(*arguments):
+    return subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+    ).stdout
+
+def git_output(*arguments):
+    return git_bytes(*arguments).decode("utf-8")
 
 # entry arity, return arity. Exceptions always repeat entry fields plus class/message.
 operations = {
@@ -340,8 +370,13 @@ def vector_label(fixture, expected, actual):
 
 try:
     parser_self_check()
+    validate_external_directory(evidence)
     required = (
-        "executable.sha256",
+        "executable-url.txt", "executable.sha256", "executable-manifest.txt",
+        "LICENSE-executable", "NOTICE-executable",
+        "executable-license-notice-locators.txt", "java-version.txt",
+        "os-family.txt", "source-revision.txt", "plugin-source-path.txt",
+        "runner-source-path.txt", "wrapper-source-path.txt",
         "double-cases.raw", "double-traces.raw", "raw-evidence-hashes.txt",
         "finite-null.raw.log", "nonfinite.raw.log", "finite-null.trace.raw",
         "nonfinite.trace.raw", "plugin-source.sha256", "runner-source.sha256",
@@ -352,14 +387,43 @@ try:
         need("missing-artifact", evidence.joinpath(name).is_file())
     executable_hash = bounded_text(evidence.joinpath("executable.sha256"), 1024).strip()
     need("executable-pin", executable_hash == "e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47")
-    for name, source in zip(("plugin-source.sha256", "runner-source.sha256", "wrapper-source.sha256"), sources):
-        recorded = bounded_text(evidence.joinpath(name), 1024).strip()
-        need("source-hash", recorded == digest(source, 1024 * 1024))
+    expected_url = "https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar\n"
+    need("provenance-url", bounded_text(evidence.joinpath("executable-url.txt"), 4096) == expected_url)
+    need("provenance-manifest", bool(bounded_text(evidence.joinpath("executable-manifest.txt"), 1024 * 1024).strip()))
+    need("provenance-license", digest(evidence.joinpath("LICENSE-executable"), 1024 * 1024) == "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30")
+    need("provenance-notice", digest(evidence.joinpath("NOTICE-executable"), 1024 * 1024) == "27f0e45afdf10e406ee8bf478bfce38279e9087338a7981942a4a2762bcd5be8")
+    need("provenance-locators", bounded_text(evidence.joinpath("executable-license-notice-locators.txt"), 4096) == "META-INF/LICENSE|META-INF/NOTICE\n")
+    need("provenance-java", bool(bounded_text(evidence.joinpath("java-version.txt"), 65536).strip()))
+    need("provenance-os", bool(bounded_text(evidence.joinpath("os-family.txt"), 1024).strip()))
+    revision = bounded_text(evidence.joinpath("source-revision.txt"), 1024).strip()
+    need("source-revision", re.fullmatch(r"[0-9a-f]{40}", revision) is not None)
+    try:
+        canonical_revision = git_output("rev-parse", revision + "^{commit}").strip()
+    except subprocess.SubprocessError as error:
+        raise Bad("source-revision") from error
+    need("source-revision", canonical_revision == revision)
+    source_names = (
+        "tools/t0012-double-value-probe/src/T0012DoubleValueInputPlugin.java",
+        "tools/t0012-double-value-probe/run.sh",
+        "tests/t0012_double_value_probe_test.sh",
+    )
+    for label, name, source in zip(("plugin", "runner", "wrapper"), source_names, sources):
+        recorded_path = bounded_text(evidence.joinpath(label + "-source-path.txt"), 4096)
+        need("source-path", recorded_path == name + "\n")
+        recorded = bounded_text(evidence.joinpath(label + "-source.sha256"), 1024).strip()
+        try:
+            historical = hashlib.sha256(git_bytes("show", revision + ":" + name)).hexdigest()
+        except subprocess.SubprocessError as error:
+            raise Bad("source-hash") from error
+        need("source-hash", recorded == historical)
+        if live:
+            need("source-hash", recorded == digest(source, 1024 * 1024))
     jar_hash = bounded_text(evidence.joinpath("plugin-jar.sha256"), 1024).strip()
     need("jar-hash", hex64.fullmatch(jar_hash) is not None)
-    artifact = pathlib.Path(bounded_text(evidence.joinpath("plugin-jar-path.txt"), 4096).strip())
-    need("jar-path", artifact.is_absolute() and artifact.is_file() and not artifact.is_symlink())
-    need("jar-path", evidence.parent in artifact.parents)
+    artifact_name = bounded_text(evidence.joinpath("plugin-jar-path.txt"), 4096)
+    need("jar-path", artifact_name == "plugin-under-test.jar\n")
+    artifact = evidence.joinpath(artifact_name.strip())
+    need("jar-path", artifact.parent == evidence and artifact.is_file() and not artifact.is_symlink())
     need("jar-size", artifact.stat().st_size <= 4 * 1024 * 1024)
     need("jar-hash", hashlib.sha256(artifact.read_bytes()).hexdigest() == jar_hash)
     recorded_stage = bounded_text(evidence.joinpath("stage.txt"), 1024)
@@ -424,7 +488,7 @@ try:
     for name, value in hashes.items():
         cap = 8 * 1024 * 1024 if name.endswith(".raw.log") else 2 * 1024 * 1024
         need("hash-manifest-value", digest(evidence.joinpath(name), cap) == value)
-except (Bad, OSError, UnicodeError, ValueError) as error:
+except (Bad, OSError, UnicodeError, ValueError, subprocess.SubprocessError) as error:
     label = error.args[0] if error.args else "unclassified"
     print("T0012_DOUBLE_VALIDATION_ERROR|" + label, file=sys.stderr)
     raise SystemExit(4)
@@ -441,6 +505,7 @@ if [[ "$mode" == validate ]]; then
   exit 0
 fi
 
+temporary_root=$resolved_root
 mkdir -p -- "$temporary_root"
 run_dir=$(mktemp -d "$temporary_root/run.XXXXXX")
 evidence="$run_dir/evidence"
@@ -456,7 +521,13 @@ expected=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
 if [[ ${T0012_DOUBLE_NEGATIVE:-} == unavailable-runtime ]]; then
   url=https://127.0.0.1:1/t0012-unavailable.jar
 fi
-if ! curl --connect-timeout 2 --max-time 5 --fail --location --proto '=https' --tlsv1.2 --silent --show-error --output "$executable" "$url"; then
+connect_timeout=15
+maximum_time=120
+if [[ ${T0012_DOUBLE_NEGATIVE:-} == unavailable-runtime ]]; then
+  connect_timeout=2
+  maximum_time=5
+fi
+if ! curl --connect-timeout "$connect_timeout" --max-time "$maximum_time" --fail --location --proto '=https' --tlsv1.2 --silent --show-error --output "$executable" "$url"; then
   printf 'unable to retrieve pinned executable: %s\n' "$url" >&2
   exit 56
 fi
@@ -479,10 +550,15 @@ printf '%s\n' 'META-INF/LICENSE|META-INF/NOTICE' > "$evidence/executable-license
 java -XshowSettings:properties -version > "$evidence/java-version.txt" 2>&1
 uname -s > "$evidence/os-family.txt"
 git -C "$root" rev-parse HEAD > "$evidence/source-revision.txt"
-for item in "plugin:$source_file" "runner:$script_dir/run.sh" "wrapper:$wrapper_file"; do
+for item in \
+  "plugin:tools/t0012-double-value-probe/src/T0012DoubleValueInputPlugin.java" \
+  "runner:tools/t0012-double-value-probe/run.sh" \
+  "wrapper:tests/t0012_double_value_probe_test.sh"
+do
   label=${item%%:*}
-  path=${item#*:}
-  printf '%s\n' "$path" > "$evidence/$label-source-path.txt"
+  relative_path=${item#*:}
+  path="$root/$relative_path"
+  printf '%s\n' "$relative_path" > "$evidence/$label-source-path.txt"
   shasum -a 256 "$path" | awk '{print $1}' > "$evidence/$label-source.sha256"
 done
 printf '%s\n' "$mode" > "$evidence/stage.txt"
@@ -492,7 +568,8 @@ printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0012DoubleValu
 jar_file="$repository/embulk-input-t0012_double-0.0.1.jar"
 jar cfm "$jar_file" "$plugin/MANIFEST.MF" -C "$plugin/classes" .
 shasum -a 256 "$jar_file" | awk '{print $1}' > "$evidence/plugin-jar.sha256"
-printf '%s\n' "$jar_file" > "$evidence/plugin-jar-path.txt"
+cp "$jar_file" "$evidence/plugin-under-test.jar"
+printf '%s\n' 'plugin-under-test.jar' > "$evidence/plugin-jar-path.txt"
 printf '%s\n' '<project><modelVersion>4.0.0</modelVersion><groupId>org.embulk.t0012</groupId><artifactId>embulk-input-t0012_double</artifactId><version>0.0.1</version></project>' > "$repository/embulk-input-t0012_double-0.0.1.pom"
 printf '%s\n' 'source=maven|group=org.embulk.t0012|name=t0012_double|version=0.0.1|artifact=embulk-input-t0012_double|local-only' > "$evidence/plugin-coordinate.txt"
 
@@ -516,7 +593,9 @@ done > "$evidence/raw-evidence-hashes.txt"
 
 validation_level=transport
 if [[ "$mode" == full ]]; then
-  validation_level=strict
+  validation_level=live
+elif [[ "$mode" == capture ]]; then
+  validation_level=live
 fi
 validate_evidence "$evidence" "$validation_level"
 cat "$evidence/double-cases.raw"

--- a/tools/t0012-double-value-probe/src/T0012DoubleValueInputPlugin.java
+++ b/tools/t0012-double-value-probe/src/T0012DoubleValueInputPlugin.java
@@ -26,18 +26,24 @@ public final class T0012DoubleValueInputPlugin implements InputPlugin {
 
     @Override
     public ConfigDiff transaction(ConfigSource config, Control control) {
-        Schema schema = schema();
         trace("transaction-entry", "1");
-        traceSchema("transaction", schema);
         try {
+            Schema schema = recordSchemaConstruction();
+            traceSchema("transaction", schema);
             trace("control-run-entry", "1");
-            control.run(Exec.newTaskSource(), schema, 1);
-            trace("control-run-return", "1");
+            try {
+                control.run(Exec.newTaskSource(), schema, 1);
+                trace("control-run-return", "1");
+            } catch (RuntimeException failure) {
+                traceException("control-run-exception", failure, "1");
+                throw failure;
+            }
+            ConfigDiff result = Exec.newConfigDiff();
             trace("transaction-return", "1");
             terminal("success", null);
-            return Exec.newConfigDiff();
+            return result;
         } catch (RuntimeException failure) {
-            traceException("transaction-exception", failure);
+            traceException("transaction-exception", failure, "1");
             terminal("exception", failure);
             throw failure;
         }
@@ -46,36 +52,63 @@ public final class T0012DoubleValueInputPlugin implements InputPlugin {
     @Override
     public ConfigDiff resume(TaskSource taskSource, Schema schema, int taskCount, Control control) {
         trace("resume-entry", Integer.toString(taskCount));
-        trace("resume-return", Integer.toString(taskCount));
-        return Exec.newConfigDiff();
+        try {
+            ConfigDiff result = Exec.newConfigDiff();
+            trace("resume-return", Integer.toString(taskCount));
+            return result;
+        } catch (RuntimeException failure) {
+            traceException("resume-exception", failure, Integer.toString(taskCount));
+            throw failure;
+        }
     }
 
     @Override
     public void cleanup(TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> reports) {
         trace("cleanup-entry", Integer.toString(taskCount), Integer.toString(reports.size()));
-        trace("cleanup-return", Integer.toString(taskCount), Integer.toString(reports.size()));
+        try {
+            trace("cleanup-return", Integer.toString(taskCount), Integer.toString(reports.size()));
+        } catch (RuntimeException failure) {
+            traceException("cleanup-exception", failure, Integer.toString(taskCount), Integer.toString(reports.size()));
+            throw failure;
+        }
     }
 
     @Override
     public TaskReport run(TaskSource taskSource, Schema schema, int taskIndex, PageOutput output) {
-        trace("run-entry", Integer.toString(taskIndex), Integer.toString(schema.getColumnCount()));
+        String task = Integer.toString(taskIndex);
+        String columnCount = Integer.toString(schema.getColumnCount());
+        trace("run-entry", task, columnCount);
         traceSchema("run", schema);
-        RecordingOutput collector = new RecordingOutput(schema);
+        RecordingOutput collector;
         PageBuilder builder = null;
         try {
+            trace("collector-construct-entry");
+            try {
+                collector = new RecordingOutput(schema);
+                trace("collector-construct-return");
+            } catch (RuntimeException failure) {
+                traceException("collector-construct-exception", failure);
+                throw failure;
+            }
             trace("builder-construct-entry");
-            builder = new PageBuilder(Exec.getBufferAllocator(), schema, collector);
-            trace("builder-construct-return");
+            try {
+                builder = new PageBuilder(Exec.getBufferAllocator(), schema, collector);
+                trace("builder-construct-return");
+            } catch (RuntimeException failure) {
+                traceException("builder-construct-exception", failure);
+                throw failure;
+            }
             final PageBuilder activeBuilder = builder;
             writeFixture(activeBuilder, schema.getColumn(0));
             recordOperation("builder-finish", () -> activeBuilder.finish());
             recordOperation("builder-close", () -> activeBuilder.close());
             builder = null;
             recordOperation("runtime-output-finish", () -> output.finish());
+            TaskReport result = Exec.newTaskReport();
             trace("run-return", Integer.toString(taskIndex));
-            return Exec.newTaskReport();
+            return result;
         } catch (RuntimeException failure) {
-            traceException("run-exception", failure);
+            traceException("run-exception", failure, task, columnCount);
             throw failure;
         } finally {
             if (builder != null) {
@@ -88,12 +121,26 @@ public final class T0012DoubleValueInputPlugin implements InputPlugin {
     @Override
     public ConfigDiff guess(ConfigSource config) {
         trace("guess-entry");
-        trace("guess-return");
-        return Exec.newConfigDiff();
+        try {
+            ConfigDiff result = Exec.newConfigDiff();
+            trace("guess-return");
+            return result;
+        } catch (RuntimeException failure) {
+            traceException("guess-exception", failure);
+            throw failure;
+        }
     }
 
-    private static Schema schema() {
-        return Schema.builder().add("number", Types.DOUBLE).build();
+    private static Schema recordSchemaConstruction() {
+        trace("schema-construct-entry");
+        try {
+            Schema result = Schema.builder().add("number", Types.DOUBLE).build();
+            trace("schema-construct-return");
+            return result;
+        } catch (RuntimeException failure) {
+            traceException("schema-construct-exception", failure);
+            throw failure;
+        }
     }
 
     private static void traceSchema(String phase, Schema schema) {
@@ -154,8 +201,13 @@ public final class T0012DoubleValueInputPlugin implements InputPlugin {
         RecordingOutput(Schema schema) {
             this.schema = schema;
             trace("reader-construct-entry");
-            reader = new PageReader(schema);
-            trace("reader-construct-return");
+            try {
+                reader = new PageReader(schema);
+                trace("reader-construct-return");
+            } catch (RuntimeException failure) {
+                traceException("reader-construct-exception", failure);
+                throw failure;
+            }
         }
 
         @Override
@@ -167,8 +219,14 @@ public final class T0012DoubleValueInputPlugin implements InputPlugin {
                 int pageRow = 0;
                 while (true) {
                     trace("reader-next-record-entry", Integer.toString(pageIndex), Integer.toString(pageRow));
-                    boolean available = reader.nextRecord();
-                    trace("reader-next-record-return", Integer.toString(pageIndex), Integer.toString(pageRow), Boolean.toString(available));
+                    boolean available;
+                    try {
+                        available = reader.nextRecord();
+                        trace("reader-next-record-return", Integer.toString(pageIndex), Integer.toString(pageRow), Boolean.toString(available));
+                    } catch (RuntimeException failure) {
+                        traceException("reader-next-record-exception", failure, Integer.toString(pageIndex), Integer.toString(pageRow));
+                        throw failure;
+                    }
                     if (!available) {
                         break;
                     }
@@ -187,15 +245,26 @@ public final class T0012DoubleValueInputPlugin implements InputPlugin {
             Column column = schema.getColumn(0);
             String[] position = {Integer.toString(page), Integer.toString(pageRow), Integer.toString(totalRow), "0"};
             trace("reader-is-null-entry", position);
-            boolean isNull = reader.isNull(column);
-            trace("reader-is-null-return", position[0], position[1], position[2], position[3], Boolean.toString(isNull));
+            boolean isNull;
+            try {
+                isNull = reader.isNull(column);
+                trace("reader-is-null-return", position[0], position[1], position[2], position[3], Boolean.toString(isNull));
+            } catch (RuntimeException failure) {
+                traceException("reader-is-null-exception", failure, position);
+                throw failure;
+            }
             if (isNull) {
                 trace("cell-null", position);
                 return;
             }
             trace("reader-get-double-entry", position);
-            double value = reader.getDouble(column);
-            trace("reader-get-double-return", position[0], position[1], position[2], position[3], hex(Double.doubleToRawLongBits(value)));
+            try {
+                double value = reader.getDouble(column);
+                trace("reader-get-double-return", position[0], position[1], position[2], position[3], hex(Double.doubleToRawLongBits(value)));
+            } catch (RuntimeException failure) {
+                traceException("reader-get-double-exception", failure, position);
+                throw failure;
+            }
         }
 
         @Override
@@ -218,16 +287,21 @@ public final class T0012DoubleValueInputPlugin implements InputPlugin {
                 }
                 trace("collector-close-return", Integer.toString(pageOrdinal), Integer.toString(totalRows));
             } catch (RuntimeException failure) {
-                traceException("reader-close-exception", failure);
-                traceException("collector-close-exception", failure);
+                traceException("collector-close-exception", failure, Integer.toString(pageOrdinal), Integer.toString(totalRows));
                 throw failure;
             }
         }
     }
 
-    private static String hex(long value) { return String.format("%016x", value); }
+    private static String hex(long value) {
+        return String.format("%016x", value);
+    }
+
     @FunctionalInterface
-    private interface Operation { void run(); }
+    private interface Operation {
+        void run();
+    }
+
     private static void recordOperation(String name, Operation operation) {
         recordOperation(name, new String[0], operation);
     }
@@ -241,11 +315,17 @@ public final class T0012DoubleValueInputPlugin implements InputPlugin {
             throw failure;
         }
     }
+
     private static synchronized void terminal(String outcome, RuntimeException failure) {
-        if (terminalEmitted) { return; }
+        if (terminalEmitted) {
+            return;
+        }
         terminalEmitted = true;
-        if (failure == null) { trace("terminal", outcome, null, null); }
-        else { trace("terminal", outcome, failure.getClass().getName(), failure.getMessage()); }
+        if (failure == null) {
+            trace("terminal", outcome, null, null);
+        } else {
+            trace("terminal", outcome, failure.getClass().getName(), failure.getMessage());
+        }
     }
     private static void traceException(String event, RuntimeException failure, String... prefix) {
         String[] values = new String[prefix.length + 2];
@@ -256,15 +336,33 @@ public final class T0012DoubleValueInputPlugin implements InputPlugin {
     }
     private static synchronized void trace(String event, String... values) {
         StringBuilder row = new StringBuilder("DOUBLETRACE|").append(FIXTURE).append('|').append(CAPTURE).append('|').append(++sequence).append('|').append(event);
-        for (String value : values) { row.append('|').append(encode(value)); }
+        for (String value : values) {
+            row.append('|').append(encode(value));
+        }
         System.out.println(row);
-        if (System.out.checkError()) { throw new EvidenceWriteError("unable to write double observation evidence"); }
+        if (System.out.checkError()) {
+            throw new EvidenceWriteError("unable to write double observation evidence");
+        }
     }
-    private static String encode(String value) { return value == null ? "-" : Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8)); }
+
+    private static String encode(String value) {
+        if (value == null) {
+            return "-";
+        }
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
     private static String requiredEnvironment(String name) {
         String value = System.getenv(name);
-        if (value == null || value.isEmpty()) { throw new IllegalStateException("missing environment: " + name); }
+        if (value == null || value.isEmpty()) {
+            throw new IllegalStateException("missing environment: " + name);
+        }
         return value;
     }
-    private static final class EvidenceWriteError extends Error { EvidenceWriteError(String message) { super(message); } }
+
+    private static final class EvidenceWriteError extends Error {
+        EvidenceWriteError(String message) {
+            super(message);
+        }
+    }
 }

--- a/tools/t0012-double-value-probe/src/T0012DoubleValueInputPlugin.java
+++ b/tools/t0012-double-value-probe/src/T0012DoubleValueInputPlugin.java
@@ -1,0 +1,270 @@
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Column;
+import org.embulk.spi.Exec;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.Page;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.PageReader;
+import org.embulk.spi.Schema;
+import org.embulk.spi.type.Types;
+
+/** Test-only original fixture for the bounded T-0012/S09 observation. */
+public final class T0012DoubleValueInputPlugin implements InputPlugin {
+    private static final String FIXTURE = requiredEnvironment("T0012_DOUBLE_FIXTURE");
+    private static final String CAPTURE = UUID.randomUUID().toString();
+    private static int sequence;
+    private static boolean terminalEmitted;
+
+    @Override
+    public ConfigDiff transaction(ConfigSource config, Control control) {
+        Schema schema = schema();
+        trace("transaction-entry", "1");
+        traceSchema("transaction", schema);
+        try {
+            trace("control-run-entry", "1");
+            control.run(Exec.newTaskSource(), schema, 1);
+            trace("control-run-return", "1");
+            trace("transaction-return", "1");
+            terminal("success", null);
+            return Exec.newConfigDiff();
+        } catch (RuntimeException failure) {
+            traceException("transaction-exception", failure);
+            terminal("exception", failure);
+            throw failure;
+        }
+    }
+
+    @Override
+    public ConfigDiff resume(TaskSource taskSource, Schema schema, int taskCount, Control control) {
+        trace("resume-entry", Integer.toString(taskCount));
+        trace("resume-return", Integer.toString(taskCount));
+        return Exec.newConfigDiff();
+    }
+
+    @Override
+    public void cleanup(TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> reports) {
+        trace("cleanup-entry", Integer.toString(taskCount), Integer.toString(reports.size()));
+        trace("cleanup-return", Integer.toString(taskCount), Integer.toString(reports.size()));
+    }
+
+    @Override
+    public TaskReport run(TaskSource taskSource, Schema schema, int taskIndex, PageOutput output) {
+        trace("run-entry", Integer.toString(taskIndex), Integer.toString(schema.getColumnCount()));
+        traceSchema("run", schema);
+        RecordingOutput collector = new RecordingOutput(schema);
+        PageBuilder builder = null;
+        try {
+            trace("builder-construct-entry");
+            builder = new PageBuilder(Exec.getBufferAllocator(), schema, collector);
+            trace("builder-construct-return");
+            final PageBuilder activeBuilder = builder;
+            writeFixture(activeBuilder, schema.getColumn(0));
+            recordOperation("builder-finish", () -> activeBuilder.finish());
+            recordOperation("builder-close", () -> activeBuilder.close());
+            builder = null;
+            recordOperation("runtime-output-finish", () -> output.finish());
+            trace("run-return", Integer.toString(taskIndex));
+            return Exec.newTaskReport();
+        } catch (RuntimeException failure) {
+            traceException("run-exception", failure);
+            throw failure;
+        } finally {
+            if (builder != null) {
+                final PageBuilder pendingBuilder = builder;
+                recordOperation("builder-close", () -> pendingBuilder.close());
+            }
+        }
+    }
+
+    @Override
+    public ConfigDiff guess(ConfigSource config) {
+        trace("guess-entry");
+        trace("guess-return");
+        return Exec.newConfigDiff();
+    }
+
+    private static Schema schema() {
+        return Schema.builder().add("number", Types.DOUBLE).build();
+    }
+
+    private static void traceSchema(String phase, Schema schema) {
+        Column column = schema.getColumn(0);
+        trace("schema-column", phase, Integer.toString(column.getIndex()), column.getName(), column.getType().getName());
+    }
+
+    private static void writeFixture(PageBuilder builder, Column column) {
+        long[] bits;
+        if ("finite-null".equals(FIXTURE)) {
+            bits = new long[] {
+                Double.doubleToRawLongBits(Double.MAX_VALUE), Double.doubleToRawLongBits(-Double.MAX_VALUE),
+                Double.doubleToRawLongBits(Double.MIN_VALUE), Double.doubleToRawLongBits(-Double.MIN_VALUE),
+                Double.doubleToRawLongBits(0.0d), Double.doubleToRawLongBits(-0.0d)
+            };
+            trace("input-row-count", "7");
+            for (int row = 0; row < bits.length; row++) {
+                assignDouble(builder, column, row, bits[row]);
+                addRecord(builder, row);
+            }
+            trace("input-cell", "6", "0", "null", null);
+            recordOperation("builder-set-null", new String[] {"6", "0"}, () -> builder.setNull(column));
+            addRecord(builder, 6);
+            return;
+        }
+        if ("nonfinite".equals(FIXTURE)) {
+            bits = new long[] {
+                Double.doubleToRawLongBits(Double.POSITIVE_INFINITY), Double.doubleToRawLongBits(Double.NEGATIVE_INFINITY),
+                Double.doubleToRawLongBits(Double.NaN), 0x7ff8000000000042L, 0xfff8000000000042L
+            };
+            trace("input-row-count", "5");
+            for (int row = 0; row < bits.length; row++) {
+                assignDouble(builder, column, row, bits[row]);
+                addRecord(builder, row);
+            }
+            return;
+        }
+        throw new IllegalArgumentException("unknown fixture: " + FIXTURE);
+    }
+
+    private static void assignDouble(PageBuilder builder, Column column, int row, long bits) {
+        double value = Double.longBitsToDouble(bits);
+        String raw = hex(Double.doubleToRawLongBits(value));
+        trace("input-cell", Integer.toString(row), "0", "double-bits", raw);
+        recordOperation("builder-set-double", new String[] {Integer.toString(row), "0", raw}, () -> builder.setDouble(column, value));
+    }
+
+    private static void addRecord(PageBuilder builder, int row) {
+        recordOperation("builder-add-record", new String[] {Integer.toString(row)}, () -> builder.addRecord());
+    }
+
+    private static final class RecordingOutput implements PageOutput {
+        private final Schema schema;
+        private final PageReader reader;
+        private int pageOrdinal;
+        private int totalRows;
+
+        RecordingOutput(Schema schema) {
+            this.schema = schema;
+            trace("reader-construct-entry");
+            reader = new PageReader(schema);
+            trace("reader-construct-return");
+        }
+
+        @Override
+        public void add(Page incomingPage) {
+            int pageIndex = pageOrdinal++;
+            trace("collector-add-entry", Integer.toString(pageIndex));
+            try {
+                recordOperation("reader-set-page", new String[] {Integer.toString(pageIndex)}, () -> reader.setPage(incomingPage));
+                int pageRow = 0;
+                while (true) {
+                    trace("reader-next-record-entry", Integer.toString(pageIndex), Integer.toString(pageRow));
+                    boolean available = reader.nextRecord();
+                    trace("reader-next-record-return", Integer.toString(pageIndex), Integer.toString(pageRow), Boolean.toString(available));
+                    if (!available) {
+                        break;
+                    }
+                    readCell(pageIndex, pageRow, totalRows);
+                    pageRow++;
+                    totalRows++;
+                }
+                trace("collector-add-return", Integer.toString(pageIndex), Integer.toString(pageRow), Integer.toString(totalRows));
+            } catch (RuntimeException failure) {
+                traceException("collector-add-exception", failure, Integer.toString(pageIndex));
+                throw failure;
+            }
+        }
+
+        private void readCell(int page, int pageRow, int totalRow) {
+            Column column = schema.getColumn(0);
+            String[] position = {Integer.toString(page), Integer.toString(pageRow), Integer.toString(totalRow), "0"};
+            trace("reader-is-null-entry", position);
+            boolean isNull = reader.isNull(column);
+            trace("reader-is-null-return", position[0], position[1], position[2], position[3], Boolean.toString(isNull));
+            if (isNull) {
+                trace("cell-null", position);
+                return;
+            }
+            trace("reader-get-double-entry", position);
+            double value = reader.getDouble(column);
+            trace("reader-get-double-return", position[0], position[1], position[2], position[3], hex(Double.doubleToRawLongBits(value)));
+        }
+
+        @Override
+        public void finish() {
+            trace("collector-finish-entry", Integer.toString(pageOrdinal), Integer.toString(totalRows));
+            trace("collector-finish-return", Integer.toString(pageOrdinal), Integer.toString(totalRows));
+        }
+
+        @Override
+        public void close() {
+            trace("collector-close-entry", Integer.toString(pageOrdinal), Integer.toString(totalRows));
+            try {
+                trace("reader-close-entry", Integer.toString(pageOrdinal), Integer.toString(totalRows));
+                try {
+                    reader.close();
+                    trace("reader-close-return", Integer.toString(pageOrdinal), Integer.toString(totalRows));
+                } catch (RuntimeException failure) {
+                    traceException("reader-close-exception", failure, Integer.toString(pageOrdinal), Integer.toString(totalRows));
+                    throw failure;
+                }
+                trace("collector-close-return", Integer.toString(pageOrdinal), Integer.toString(totalRows));
+            } catch (RuntimeException failure) {
+                traceException("reader-close-exception", failure);
+                traceException("collector-close-exception", failure);
+                throw failure;
+            }
+        }
+    }
+
+    private static String hex(long value) { return String.format("%016x", value); }
+    @FunctionalInterface
+    private interface Operation { void run(); }
+    private static void recordOperation(String name, Operation operation) {
+        recordOperation(name, new String[0], operation);
+    }
+    private static void recordOperation(String name, String[] values, Operation operation) {
+        trace(name + "-entry", values);
+        try {
+            operation.run();
+            trace(name + "-return", values);
+        } catch (RuntimeException failure) {
+            traceException(name + "-exception", failure, values);
+            throw failure;
+        }
+    }
+    private static synchronized void terminal(String outcome, RuntimeException failure) {
+        if (terminalEmitted) { return; }
+        terminalEmitted = true;
+        if (failure == null) { trace("terminal", outcome, null, null); }
+        else { trace("terminal", outcome, failure.getClass().getName(), failure.getMessage()); }
+    }
+    private static void traceException(String event, RuntimeException failure, String... prefix) {
+        String[] values = new String[prefix.length + 2];
+        System.arraycopy(prefix, 0, values, 0, prefix.length);
+        values[prefix.length] = failure.getClass().getName();
+        values[prefix.length + 1] = failure.getMessage();
+        trace(event, values);
+    }
+    private static synchronized void trace(String event, String... values) {
+        StringBuilder row = new StringBuilder("DOUBLETRACE|").append(FIXTURE).append('|').append(CAPTURE).append('|').append(++sequence).append('|').append(event);
+        for (String value : values) { row.append('|').append(encode(value)); }
+        System.out.println(row);
+        if (System.out.checkError()) { throw new EvidenceWriteError("unable to write double observation evidence"); }
+    }
+    private static String encode(String value) { return value == null ? "-" : Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8)); }
+    private static String requiredEnvironment(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isEmpty()) { throw new IllegalStateException("missing environment: " + name); }
+        return value;
+    }
+    private static final class EvidenceWriteError extends Error { EvidenceWriteError(String message) { super(message); } }
+}


### PR DESCRIPTION
## Scope
T-0012/S09, refs #15 (parent stays open). Two original reference-only double fixtures; no Rust, public API, native Float64, or production transfer change.

## Evidence
Frozen source 3f18966 passes the exact Demo under implementer, primary, and independent Tester: 114/93 events, 45 raw rejection controls, two artifact controls, unchanged S08/S06 regression. Complete current evidence and the temporary-environment recovery are recorded in docs/provenance/T-0012-double-value-probe.md. Workspace format/test/strict Clippy and Project Python tests pass under primary verification.

## Remaining gates
Independent quality/source review completion, security review, final PR-head Demo, and canonical record reconciliation remain required before merge. Earlier temporary evidence is unavailable and is not substituted for fresh acceptance.

## Non-claims
Reference Observation / Integration and validator Unit/Contract only. No general float equality, batching, ownership, recovery, release or parent completion claim.