### PR TITLE
feat(t-0012): preserve private double bits and compare selected outcomes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,8 +10,8 @@ tasks. Dependencies name predecessor T-IDs and do not imply completion.
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 `T-0013/S08`, `T-0012/S08` and `T-0021/S05` are integrated. T-0012/S09 is
 integrated through PR #91 following fresh reference-probe acceptance runs.
-T-0012/S10 is `Ready`; T-0013, T-0021 and all other unfinished items are `Backlog`.
-Combined active implementation WIP is zero of two before S10 activation.
+T-0012/S10 is `In Progress`; T-0013, T-0021 and all other unfinished items are `Backlog`.
+Combined active implementation WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -36,7 +36,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S09 integrated; S10 ready) | Ready | P0 | 34 | T-0011 | Rust Core Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S09 integrated; S10 private double values) | In Progress | P0 | 34 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@ tasks. Dependencies name predecessor T-IDs and do not imply completion.
 Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 `T-0013/S08`, `T-0012/S08` and `T-0021/S05` are integrated. T-0012/S09 is
 integrated through PR #91 following fresh reference-probe acceptance runs.
-T-0012/S10 is `In Progress`; T-0013, T-0021 and all other unfinished items are `Backlog`.
+T-0012/S10 is `Review`; T-0013, T-0021 and all other unfinished items are `Backlog`.
 Combined active implementation WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -36,7 +36,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S09 integrated; S10 private double values) | In Progress | P0 | 34 | T-0011 | Rust Core Implementer | Differential (Embulk) |
+| T-0012 | Specify configuration, schema, and value semantics (S09 integrated; S10 private double values) | Review | P0 | 34 | T-0011 | Rust Core Implementer | Differential (Embulk) |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -379,5 +379,7 @@ whole-domain equality decision follows from this bounded reference slice.
 S09 final-head Demo passed at `59f1b2e`; PR #91 integrated as `34757c8`.
 Known accepted S03–S09 slice estimates total 25 SP; parent Current 34 / Initial
 5 stay unchanged. S10's 5 SP private-double-storage/comparison packet and
-ADR-0012 passed readiness review; no implementation or new Differential claim
-is active yet.
+ADR-0012 passed readiness review. Implementation at `3df2a88` now passes the
+implementer and independent Tester exact Demo: 12 selected bit/null cells,
+five bridge controls and unchanged S09/S08/S06 regressions. Primary final
+acceptance and PR integration remain required; no points are awarded yet.

--- a/crates/emburk-core/src/logical_record.rs
+++ b/crates/emburk-core/src/logical_record.rs
@@ -1,11 +1,29 @@
 //! Private owned logical record values with no schema or physical encoding policy.
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Float64Bits(u64);
+
+impl Float64Bits {
+    fn from_float(value: f64) -> Self {
+        Self(value.to_bits())
+    }
+
+    fn to_float(self) -> f64 {
+        f64::from_bits(self.0)
+    }
+
+    fn bits(self) -> u64 {
+        self.0
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum LogicalValue {
     Null,
     Boolean(bool),
     Signed64(i64),
     Text(String),
+    Float64(Float64Bits),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -460,3 +478,6 @@ mod tests {
             .expect("live manifest must match private records");
     }
 }
+
+#[cfg(test)]
+mod double_tests;

--- a/crates/emburk-core/src/logical_record/double_tests.rs
+++ b/crates/emburk-core/src/logical_record/double_tests.rs
@@ -121,14 +121,15 @@ fn parse_manifest(manifest: &str) -> Result<Vec<ParsedCase>, String> {
 fn compare(cases: &[ParsedCase]) -> Result<(), String> {
     for (name, supplied, reference) in cases {
         let matches = supplied.records().zip(reference).all(|(record, expected)| {
-            record.cells().zip(expected).all(|(actual, wanted)| {
-                matches!((actual, wanted), (LogicalValue::Null, ReferenceValue::Null))
-                    || matches!(
-                        (actual, wanted),
-                        (LogicalValue::Float64(value), ReferenceValue::Double(bits))
-                            if value.bits() == *bits && value.to_float().to_bits() == *bits
-                    )
-            })
+            record.cells().len() == expected.len()
+                && record.cells().zip(expected).all(|(actual, wanted)| {
+                    matches!((actual, wanted), (LogicalValue::Null, ReferenceValue::Null))
+                        || matches!(
+                            (actual, wanted),
+                            (LogicalValue::Float64(value), ReferenceValue::Double(bits))
+                                if value.bits() == *bits && value.to_float().to_bits() == *bits
+                        )
+                })
         });
         if !matches || supplied.records().len() != reference.len() {
             return Err(format!(
@@ -206,15 +207,51 @@ fn structural_identity_is_bitwise_not_numeric_equality() {
 
 #[test]
 fn null_is_distinct_and_record_order_is_preserved() {
-    let records = LogicalRecords::new(vec![LogicalRecord::new(vec![
-        LogicalValue::Float64(Float64Bits::from_float(-0.0)),
-        LogicalValue::Null,
-        LogicalValue::Float64(Float64Bits::from_float(f64::INFINITY)),
-    ])]);
-    let values: Vec<_> = records.records().next().unwrap().cells().cloned().collect();
-    assert!(matches!(values[0], LogicalValue::Float64(_)));
-    assert_eq!(values[1], LogicalValue::Null);
-    assert!(matches!(values[2], LogicalValue::Float64(_)));
+    let records = LogicalRecords::new(vec![
+        LogicalRecord::new(vec![
+            LogicalValue::Float64(Float64Bits::from_float(-0.0)),
+            LogicalValue::Null,
+        ]),
+        LogicalRecord::new(vec![LogicalValue::Float64(Float64Bits::from_float(
+            f64::INFINITY,
+        ))]),
+    ]);
+    let values: Vec<Vec<_>> = records
+        .records()
+        .map(|record| record.cells().cloned().collect())
+        .collect();
+    assert_eq!(values.len(), 2);
+    assert_eq!(
+        values[0][0],
+        LogicalValue::Float64(Float64Bits(0x8000_0000_0000_0000))
+    );
+    assert_eq!(values[0][1], LogicalValue::Null);
+    assert_eq!(
+        values[1][0],
+        LogicalValue::Float64(Float64Bits(0x7ff0_0000_0000_0000))
+    );
+}
+
+#[test]
+fn comparison_rejects_missing_and_extra_actual_cells() {
+    let reference = vec![vec![ReferenceValue::Double(0)]];
+    for actual in [
+        Vec::new(),
+        vec![
+            LogicalValue::Float64(Float64Bits(0)),
+            LogicalValue::Float64(Float64Bits(1)),
+        ],
+    ] {
+        let cases = vec![(
+            "shape".to_owned(),
+            LogicalRecords::new(vec![LogicalRecord::new(actual)]),
+            reference.clone(),
+        )];
+        assert_eq!(
+            compare(&cases),
+            Err("reference differs from private double storage for shape".into())
+        );
+    }
 }
 
 #[test]

--- a/crates/emburk-core/src/logical_record/double_tests.rs
+++ b/crates/emburk-core/src/logical_record/double_tests.rs
@@ -1,0 +1,307 @@
+use super::{Float64Bits, LogicalRecord, LogicalRecords, LogicalValue};
+
+const HEADER: &str = "T0012-S10\t1";
+const CASES: [(&str, usize); 2] = [("finite-null", 7), ("nonfinite", 5)];
+const CAP: usize = 1024;
+const MANIFEST_CAP: u64 = 65_536;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReferenceValue {
+    Null,
+    Double(u64),
+}
+
+type ParsedCase = (String, LogicalRecords, Vec<Vec<ReferenceValue>>);
+
+fn parse_count(text: &str, label: &str) -> Result<usize, String> {
+    if text.is_empty()
+        || !text.bytes().all(|byte| byte.is_ascii_digit())
+        || (text.len() > 1 && text.starts_with('0'))
+    {
+        return Err(format!("malformed {label}"));
+    }
+    let value: usize = text.parse().map_err(|_| format!("malformed {label}"))?;
+    if value > CAP {
+        return Err(format!("{label} exceeds cap"));
+    }
+    Ok(value)
+}
+
+fn parse_cell(tag: &str, payload: &str) -> Result<LogicalValue, String> {
+    match tag {
+        "N" if payload == "-" => Ok(LogicalValue::Null),
+        "N" => Err("null payload must be -".into()),
+        "D" if payload.len() == 16
+            && payload
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)) =>
+        {
+            let bits = u64::from_str_radix(payload, 16)
+                .map_err(|_| "malformed double payload".to_owned())?;
+            Ok(LogicalValue::Float64(Float64Bits::from_float(
+                f64::from_bits(bits),
+            )))
+        }
+        "D" => Err("malformed double payload".into()),
+        _ => Err("unknown double value tag".into()),
+    }
+}
+
+fn parse_reference(tag: &str, payload: &str) -> Result<ReferenceValue, String> {
+    match tag {
+        "N" if payload == "-" => Ok(ReferenceValue::Null),
+        "N" => Err("null payload must be -".into()),
+        "D" if payload.len() == 16
+            && payload
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)) =>
+        {
+            Ok(ReferenceValue::Double(
+                u64::from_str_radix(payload, 16)
+                    .map_err(|_| "malformed double payload".to_owned())?,
+            ))
+        }
+        "D" => Err("malformed double payload".into()),
+        _ => Err("unknown double value tag".into()),
+    }
+}
+
+fn parse_manifest(manifest: &str) -> Result<Vec<ParsedCase>, String> {
+    if manifest.len() as u64 > MANIFEST_CAP {
+        return Err("manifest exceeds cap".into());
+    }
+    if !manifest.ends_with('\n') || manifest.contains('\r') {
+        return Err("manifest is not canonical TSV".into());
+    }
+    let mut lines = manifest.lines();
+    if lines.next() != Some(HEADER) {
+        return Err("unsupported manifest header".into());
+    }
+    let mut cases = Vec::new();
+    for (expected_name, expected_rows) in CASES {
+        let fields: Vec<_> = lines
+            .next()
+            .ok_or("missing case row")?
+            .split('\t')
+            .collect();
+        if fields.len() != 4 || fields[0] != "CASE" || fields[1] != expected_name {
+            return Err("case manifest is not exact and ordered".into());
+        }
+        let rows = parse_count(fields[2], "row count")?;
+        let cells = parse_count(fields[3], "cell count")?;
+        if rows != expected_rows || cells != 1 {
+            return Err("unsupported selected dimensions".into());
+        }
+        let mut supplied = Vec::with_capacity(rows);
+        let mut reference = Vec::with_capacity(rows);
+        for row_index in 0..rows {
+            let row: Vec<_> = lines.next().ok_or("truncated row")?.split('\t').collect();
+            if row.as_slice() != ["ROW", &row_index.to_string()] {
+                return Err("row order or index mismatch".into());
+            }
+            let cell: Vec<_> = lines.next().ok_or("truncated cell")?.split('\t').collect();
+            if cell.len() != 6 || cell[0] != "CELL" || cell[1] != "0" {
+                return Err("cell order or index mismatch".into());
+            }
+            supplied.push(LogicalRecord::new(vec![parse_cell(cell[2], cell[3])?]));
+            reference.push(vec![parse_reference(cell[4], cell[5])?]);
+        }
+        cases.push((
+            expected_name.to_owned(),
+            LogicalRecords::new(supplied),
+            reference,
+        ));
+    }
+    if lines.next().is_some() {
+        return Err("trailing manifest records".into());
+    }
+    Ok(cases)
+}
+
+fn compare(cases: &[ParsedCase]) -> Result<(), String> {
+    for (name, supplied, reference) in cases {
+        let matches = supplied.records().zip(reference).all(|(record, expected)| {
+            record.cells().zip(expected).all(|(actual, wanted)| {
+                matches!((actual, wanted), (LogicalValue::Null, ReferenceValue::Null))
+                    || matches!(
+                        (actual, wanted),
+                        (LogicalValue::Float64(value), ReferenceValue::Double(bits))
+                            if value.bits() == *bits && value.to_float().to_bits() == *bits
+                    )
+            })
+        });
+        if !matches || supplied.records().len() != reference.len() {
+            return Err(format!(
+                "reference differs from private double storage for {name}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn valid_manifest() -> String {
+    let finite = [
+        "7fefffffffffffff",
+        "ffefffffffffffff",
+        "0000000000000001",
+        "8000000000000001",
+        "0000000000000000",
+        "8000000000000000",
+        "-",
+    ];
+    let nonfinite = [
+        "7ff0000000000000",
+        "fff0000000000000",
+        "7ff8000000000000",
+        "7ff8000000000042",
+        "fff8000000000042",
+    ];
+    let mut output = format!("{HEADER}\n");
+    for (name, values) in [
+        ("finite-null", finite.as_slice()),
+        ("nonfinite", nonfinite.as_slice()),
+    ] {
+        output.push_str(&format!("CASE\t{name}\t{}\t1\n", values.len()));
+        for (row, value) in values.iter().enumerate() {
+            let tag = if *value == "-" { "N" } else { "D" };
+            output.push_str(&format!(
+                "ROW\t{row}\nCELL\t0\t{tag}\t{value}\t{tag}\t{value}\n"
+            ));
+        }
+    }
+    output
+}
+
+#[test]
+fn stores_arbitrary_selected_bit_patterns_and_reconstructs_them() {
+    let bits = [
+        0,
+        1,
+        0x8000_0000_0000_0001,
+        0xffef_ffff_ffff_ffff,
+        0x8000_0000_0000_0000,
+        0x7ff0_0000_0000_0000,
+        0xfff0_0000_0000_0000,
+        0x7ff8_0000_0000_0042,
+        0xfff8_0000_0000_0042,
+        0x7fef_ffff_ffff_ffff,
+    ];
+    for expected in bits {
+        let stored = Float64Bits::from_float(f64::from_bits(expected));
+        assert_eq!(stored.bits(), expected);
+        assert_eq!(stored.to_float().to_bits(), expected);
+    }
+}
+
+#[test]
+fn structural_identity_is_bitwise_not_numeric_equality() {
+    let positive_zero = Float64Bits::from_float(0.0);
+    let negative_zero = Float64Bits::from_float(-0.0);
+    assert_ne!(positive_zero, negative_zero);
+    assert_eq!(positive_zero.to_float(), negative_zero.to_float());
+    let nan = Float64Bits::from_float(f64::from_bits(0x7ff8_0000_0000_0042));
+    assert_eq!(nan, nan);
+    assert_ne!(nan.to_float(), nan.to_float());
+}
+
+#[test]
+fn null_is_distinct_and_record_order_is_preserved() {
+    let records = LogicalRecords::new(vec![LogicalRecord::new(vec![
+        LogicalValue::Float64(Float64Bits::from_float(-0.0)),
+        LogicalValue::Null,
+        LogicalValue::Float64(Float64Bits::from_float(f64::INFINITY)),
+    ])]);
+    let values: Vec<_> = records.records().next().unwrap().cells().cloned().collect();
+    assert!(matches!(values[0], LogicalValue::Float64(_)));
+    assert_eq!(values[1], LogicalValue::Null);
+    assert!(matches!(values[2], LogicalValue::Float64(_)));
+}
+
+#[test]
+fn manifest_rejects_transport_and_value_errors() {
+    let valid = valid_manifest();
+    assert!(compare(&parse_manifest(&valid).unwrap()).is_ok());
+    let rejects = |text: &str, diagnostic: &str| {
+        assert_eq!(parse_manifest(text), Err(diagnostic.to_owned()));
+    };
+    rejects(valid.trim_end(), "manifest is not canonical TSV");
+    rejects(
+        &valid.replacen(HEADER, "T0012-S10\t2", 1),
+        "unsupported manifest header",
+    );
+    rejects(
+        &valid.replacen("CASE\tfinite-null", "CASE\tunknown", 1),
+        "case manifest is not exact and ordered",
+    );
+    rejects(
+        &valid.replacen("CASE\tnonfinite", "CASE\tfinite-null", 1),
+        "case manifest is not exact and ordered",
+    );
+    rejects(
+        &valid.replacen("CASE\tfinite-null", "CASE\tnonfinite", 1),
+        "case manifest is not exact and ordered",
+    );
+    rejects(
+        &valid.replacen("CASE\tfinite-null\t7\t1", "CASE\tfinite-null\t8\t1", 1),
+        "unsupported selected dimensions",
+    );
+    rejects(
+        &valid.replacen("CASE\tfinite-null\t7\t1", "CASE\tfinite-null\t01\t1", 1),
+        "malformed row count",
+    );
+    rejects(
+        &valid.replacen("CASE\tfinite-null\t7\t1", "CASE\tfinite-null\t1025\t1", 1),
+        "row count exceeds cap",
+    );
+    rejects(
+        &valid.replacen("ROW\t0", "ROW\t1", 1),
+        "row order or index mismatch",
+    );
+    rejects(
+        &valid.replacen("\tD\t7fefffffffffffff", "\tD\t7FEFFFFFFFFFFFFF", 1),
+        "malformed double payload",
+    );
+    rejects(
+        &valid.replacen("\tN\t-\tN\t-", "\tN\t0\tN\t-", 1),
+        "null payload must be -",
+    );
+    rejects(
+        &valid.replacen("\tD\t7fefffffffffffff", "\tX\t7fefffffffffffff", 1),
+        "unknown double value tag",
+    );
+    rejects(
+        &valid.replacen("7fefffffffffffff", "7feffffffffffff", 1),
+        "malformed double payload",
+    );
+    rejects(&format!("{valid}ROW\t0\n"), "trailing manifest records");
+    rejects(
+        &"x".repeat(MANIFEST_CAP as usize + 1),
+        "manifest exceeds cap",
+    );
+}
+
+#[test]
+fn expected_only_mutation_fails_without_changing_supplied_values() {
+    let valid = valid_manifest();
+    let changed = valid.replacen(
+        "CELL\t0\tD\t0000000000000000\tD\t0000000000000000",
+        "CELL\t0\tD\t0000000000000000\tD\t8000000000000000",
+        1,
+    );
+    let baseline = parse_manifest(&valid).unwrap();
+    let mutated = parse_manifest(&changed).unwrap();
+    assert_eq!(mutated[0].1, baseline[0].1);
+    assert!(compare(&mutated).is_err());
+}
+
+#[test]
+#[ignore = "requires the external T-0012/S10 double-value driver"]
+fn live_double_value_differential() {
+    let path =
+        std::env::var("T0012_S10_MANIFEST").expect("T0012_S10_MANIFEST must name driver output");
+    let metadata = std::fs::metadata(&path).expect("stat S10 manifest");
+    assert!(metadata.is_file() && metadata.len() <= MANIFEST_CAP);
+    let manifest = std::fs::read_to_string(path).expect("read S10 manifest");
+    compare(&parse_manifest(&manifest).expect("validate S10 manifest"))
+        .expect("selected doubles must match private storage");
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,9 +134,12 @@ PR #91 is in Review; final-head acceptance and integration remain required.
 
 S09 final-head Demo passed at `59f1b2e`; PR #91 integrated as `34757c8`.
 Its selected reference observations are accepted; parent T-0012 remains open.
-S10 is Ready under accepted ADR-0012 and its reviewed packet, separating
-bitwise storage identity from numeric equality. No Rust Float64 implementation
-or schema/public/production policy is claimed by the planning record.
+S10 implements the private bit-preserving representation permitted by ADR-0012.
+Frozen source `3df2a88` passed implementer and independent Tester acceptance:
+12 selected double/null cells, five bridge controls and unchanged S09/S08/S06
+regressions. Its private equality is storage identity, not numeric equality.
+Primary final acceptance and PR integration remain required. No public value,
+schema coupling, physical encoding, whole-domain or production claim follows.
 
 
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -188,9 +188,12 @@ PR #91 is in Review; final-head acceptance and integration remain required.
 
 S09 final-head Demo passed at `59f1b2e`; PR #91 integrated as `34757c8`.
 Its selected reference observations are accepted; parent T-0012 remains open.
-S10 is Ready under accepted ADR-0012 and its reviewed packet, separating
-bitwise storage identity from numeric equality. No Rust Float64 implementation
-or schema/public/production policy is claimed by the planning record.
+S10 implements the private bit-preserving representation permitted by ADR-0012.
+Frozen source `3df2a88` passed implementer and independent Tester acceptance:
+12 selected double/null cells, five bridge controls and unchanged S09/S08/S06
+regressions. Its private equality is storage identity, not numeric equality.
+Primary final acceptance and PR integration remain required. No public value,
+schema coupling, physical encoding, whole-domain or production claim follows.
 
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -159,9 +159,12 @@ PR #91 is in Review; final-head acceptance and integration remain required.
 
 S09 final-head Demo passed at `59f1b2e`; PR #91 integrated as `34757c8`.
 Its selected reference observations are accepted; parent T-0012 remains open.
-S10 is Ready under accepted ADR-0012 and its reviewed packet, separating
-bitwise storage identity from numeric equality. No Rust Float64 implementation
-or schema/public/production policy is claimed by the planning record.
+S10 implements the private bit-preserving representation permitted by ADR-0012.
+Frozen source `3df2a88` passed implementer and independent Tester acceptance:
+12 selected double/null cells, five bridge controls and unchanged S09/S08/S06
+regressions. Its private equality is storage identity, not numeric equality.
+Primary final acceptance and PR integration remain required. No public value,
+schema coupling, physical encoding, whole-domain or production claim follows.
 
 
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -344,9 +344,12 @@ PR #91 is in Review; final-head acceptance and integration remain required.
 
 S09 final-head Demo passed at `59f1b2e`; PR #91 integrated as `34757c8`.
 Its selected reference observations are accepted; parent T-0012 remains open.
-S10 is Ready under accepted ADR-0012 and its reviewed packet, separating
-bitwise storage identity from numeric equality. No Rust Float64 implementation
-or schema/public/production policy is claimed by the planning record.
+S10 implements the private bit-preserving representation permitted by ADR-0012.
+Frozen source `3df2a88` passed implementer and independent Tester acceptance:
+12 selected double/null cells, five bridge controls and unchanged S09/S08/S06
+regressions. Its private equality is storage identity, not numeric equality.
+Primary final acceptance and PR integration remain required. No public value,
+schema coupling, physical encoding, whole-domain or production claim follows.
 
 
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -45,7 +45,7 @@ captured 114/93 events with exact selected double bits preserved; primary
 reproduction and complete raw review authorize Stage B strict validation.
 The slice integrated through PR #91 as `34757c8`. S10's private double-storage
 decision passed readiness review and integrated through PR #92. S10 is now
-In Progress with one source owner and combined active WIP one of two. T-0012, T-0013 and
+in Review after source acceptance, with combined active WIP one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
@@ -54,7 +54,7 @@ T-0021 parent contracts remain open.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S10 | In Progress | Private double bit storage and two selected comparisons |
+| T-0012/S10 | Review | Private double bit storage and two selected comparisons |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S01–S05 integrated; remaining runtime contracts |
 
@@ -337,6 +337,9 @@ PR #91 is in Review; final-head acceptance and integration remain required.
 
 S09 final-head Demo passed at `59f1b2e`; PR #91 integrated as `34757c8`.
 Its selected reference observations are accepted; parent T-0012 remains open.
-S10 is Ready under accepted ADR-0012 and its reviewed packet, separating
-bitwise storage identity from numeric equality. No Rust Float64 implementation
-or schema/public/production policy is claimed by the planning record.
+S10 implements the private bit-preserving representation permitted by ADR-0012.
+Frozen source `3df2a88` passed implementer and independent Tester acceptance:
+12 selected double/null cells, five bridge controls and unchanged S09/S08/S06
+regressions. Its private equality is storage identity, not numeric equality.
+Primary final acceptance and PR integration remain required. No public value,
+schema coupling, physical encoding, whole-domain or production claim follows.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -44,7 +44,8 @@ T-0012/S09 after the reference-execution explanation. Stage A at `7e46379`
 captured 114/93 events with exact selected double bits preserved; primary
 reproduction and complete raw review authorize Stage B strict validation.
 The slice integrated through PR #91 as `34757c8`. S10's private double-storage
-decision passed readiness review; no implementation is active. T-0012, T-0013 and
+decision passed readiness review and integrated through PR #92. S10 is now
+In Progress with one source owner and combined active WIP one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
@@ -53,7 +54,7 @@ T-0021 parent contracts remain open.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S10 | Ready | Accepted private double-storage decision; implementation next |
+| T-0012/S10 | In Progress | Private double bit storage and two selected comparisons |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S01–S05 integrated; remaining runtime contracts |
 

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -278,6 +278,10 @@ PR #91 is in Review; final-head acceptance and integration remain required.
 
 S09 final-head Demo passed at `59f1b2e`; PR #91 integrated as `34757c8`.
 Its selected reference observations are accepted; parent T-0012 remains open.
-S10 is Ready under accepted ADR-0012 and its reviewed packet, separating
-bitwise storage identity from numeric equality. No Rust Float64 implementation
-or schema/public/production policy is claimed by the planning record.
+S10 subsequently implemented private bit storage at `3df2a88`. Implementer,
+independent Tester and primary exact Demo runs passed, including 12 selected
+double/null cells, five bridge controls and unchanged S09/S08/S06 regressions.
+Review corrected independent expected bits and exact cell/record checks.
+Workspace tests pass 41 with seven intentionally ignored live tests; format
+and strict Clippy pass. The source enters Review; final PR-head acceptance and
+integration remain required. No public numeric/schema/production claim follows.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -27,4 +27,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S07 bounded Page value observation](T-0012-page-value-probe.md) | Done (bounded reference slice; PR #81, `203d7da`) |
 | [T-0012/S08 private record values](T-0012-private-record-values.md) | Done (bounded slice; PR #82, `b428305`) |
 | [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | Done (bounded reference slice; PR #91, `34757c8`) |
-| [T-0012/S10 private double values](T-0012-private-double-values.md) | Ready; ADR-0012 accepted and readiness review passed |
+| [T-0012/S10 private double values](T-0012-private-double-values.md) | In Progress; accepted ADR-0012 and packet in PR #92 |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -27,4 +27,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S07 bounded Page value observation](T-0012-page-value-probe.md) | Done (bounded reference slice; PR #81, `203d7da`) |
 | [T-0012/S08 private record values](T-0012-private-record-values.md) | Done (bounded slice; PR #82, `b428305`) |
 | [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | Done (bounded reference slice; PR #91, `34757c8`) |
-| [T-0012/S10 private double values](T-0012-private-double-values.md) | In Progress; accepted ADR-0012 and packet in PR #92 |
+| [T-0012/S10 private double values](T-0012-private-double-values.md) | Review; primary and independent source acceptance passed |

--- a/docs/provenance/T-0012-private-double-values.md
+++ b/docs/provenance/T-0012-private-double-values.md
@@ -1,8 +1,8 @@
 # T-0012/S10 private double-value storage and selected comparison
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: Ready; independent readiness review passed, implementation not started
-- Branch: `feat/t-0012-private-double-values` (implementation, not yet created)
+- State: In Progress; implementing the accepted private storage/comparison slice
+- Branch: `feat/t-0012-private-double-values`
 - Owner: Rust Core Implementer; PM owns decisions, records and integration
 - Priority: P0; parent task T-0012; parent epic T-0010
 - Estimate: 5 SP (implementation 2, uncertainty 1, verification 1, environment 1)
@@ -21,6 +21,8 @@ acceptance at `3f18966` and exact final-head acceptance at `59f1b2e`. S08 is
 integrated through PR #82. ADR-0012 is accepted after independent readiness
 review found the four-path scope, actual storage comparison and non-claims
 coherent. No runtime evidence follows from readiness.
+The decision and packet integrated through PR #92 as `74ac118`; implementation
+now uses a fresh dedicated worktree from that accepted revision.
 One active Project item and one serial source owner; preserve user worktrees.
 
 ## Branch and allowlist

--- a/docs/provenance/T-0012-private-double-values.md
+++ b/docs/provenance/T-0012-private-double-values.md
@@ -1,7 +1,7 @@
 # T-0012/S10 private double-value storage and selected comparison
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: In Progress; implementing the accepted private storage/comparison slice
+- State: Review; source acceptance passed, final PR-head gate and integration pending
 - Branch: `feat/t-0012-private-double-values`
 - Owner: Rust Core Implementer; PM owns decisions, records and integration
 - Priority: P0; parent task T-0012; parent epic T-0010
@@ -117,3 +117,51 @@ legal, redistribution and production supply-chain limits remain unreviewed.
 Return to PM before changing fixtures, equality meaning, schema/public scope,
 allowlist, APIs/artifacts/dependencies or source-reuse boundaries, or on material
 security/IP uncertainty. Routine retrieval/test failures are fixed in scope.
+
+## Source review and verification
+
+Frozen source: `3df2a888bf37d9871769a291436df4bcabe56cb6`, following
+implementation `0aca08c`. Only the four authorized source paths changed.
+Review corrected the independent expected-value representation, manifest size
+caps, exact negative diagnostics, missing/extra cell rejection and exact ordered
+bit/null assertions. Expected values are raw reference bits, never passed through
+the candidate storage constructor. The local wrapper requires all six named
+passing tests and one intentionally ignored live test.
+
+The implementer ran the exact Demo successfully at the frozen source, retaining
+complete stdout/stderr/exit in `/private/tmp/t0012-s10-demo.yptvkV`.
+Independent Tester reproduction passed at the same source, retaining complete
+logs in `/private/tmp/t0012-s10-independent.sSUB2B`; stdout SHA-256 is
+`98997be62b80183a0116efd2dadd805e2e1e397f30dfbd22b410ce697a257019` and
+stderr is empty. Both compared 12 selected double/null cells, rejected five
+bridge mutations, reran all 45 S09 raw and two artifact controls, and passed
+the unchanged S08/S06 regressions.
+
+Independent quality logs: `/private/tmp/t0012-s10-quality.YjVnNB`.
+Format, workspace tests (41 passed, seven intentionally ignored live tests),
+strict all-target Clippy, Bash syntax, external-cache Python compilation and
+diff checks passed. Implementer quality logs are separately retained in
+`/private/tmp/t0012-s10-quality.RAzbKw`, including 19 Project Python tests.
+Environment: macOS ARM64, Temurin 17.0.20, Rust/Cargo 1.98.1, Python 3.14.6,
+Bash 3.2.57. These are test harness results, not runtime isolation evidence.
+
+Source SHA-256 in allowlist order:
+
+- `logical_record.rs`: `3ac865360e2a89fba0c15a8f4d8e72da08ebd869eb6f66b5a61b23fe1d19fbe3`
+- `double_tests.rs`: `c099422d00b3c2d4757aa0b54bd250d47b6bd431e26903453f860add4741af19`
+- driver: `f19e71fc15ce54de9a84a54d84411c48911bd8cfc72b3fec13470856cbc9a34d`
+- wrapper: `eb7b4ef68ccf404ecef3c93a63e121e045e810ec4e525cfeea01e4f9dc607aa2`
+
+The earlier successful Demo at `0aca08c` is superseded and retained at
+`/private/tmp/t0012-s10-demo.AnDoic`; it is not corrected-source acceptance.
+Temporary evidence is local and must be reproduced if removed. Final PR-head
+acceptance and integration are still required before slice completion.
+
+Primary exact Demo at the same frozen source passed with exit 0, retaining
+complete logs at `/private/tmp/t0012-s10-primary.zigMIH`; stdout SHA-256 is
+`7d49dacd73891711ddda7ce205b978e11cb36fa386c9741808c1abe98b4a9b8e`
+and stderr is empty. Primary inspection confirmed independent reference bits,
+exact record/cell shape checks and unchanged prior storage tests. Primary
+format, workspace tests (41 passed/seven ignored), strict Clippy and diff checks
+also passed. Evidence is Unit/Contract plus Differential for the two selected
+projections only, pending integration; the parent remains open.

--- a/tests/t0012_double_value_differential_test.sh
+++ b/tests/t0012_double_value_differential_test.sh
@@ -18,6 +18,7 @@ cargo test --manifest-path "$root/Cargo.toml" -p emburk-core \
 printf '%s\n' "$rust_status" > "$evidence/rust-controls.exit.txt"
 [[ "$rust_status" == 0 ]]
 for test_name in \
+  comparison_rejects_missing_and_extra_actual_cells \
   expected_only_mutation_fails_without_changing_supplied_values \
   manifest_rejects_transport_and_value_errors \
   null_is_distinct_and_record_order_is_preserved \
@@ -27,7 +28,7 @@ do
   grep -Fqx "test logical_record::double_tests::$test_name ... ok" \
     "$evidence/rust-controls.stdout.log"
 done
-grep -Eq '^test result: ok\. 5 passed; 0 failed; 1 ignored;' \
+grep -Eq '^test result: ok\. 6 passed; 0 failed; 1 ignored;' \
   "$evidence/rust-controls.stdout.log"
 
 driver_status=0

--- a/tests/t0012_double_value_differential_test.sh
+++ b/tests/t0012_double_value_differential_test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# LogicalValue equality exercised here is private bitwise storage identity; this
+# wrapper does not establish a public or numeric floating-point equality policy.
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+driver="$root/tools/t0012-double-value-differential"
+evidence=${T0012_S10_EVIDENCE_DIR:-$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-s10.XXXXXX")}
+evidence=$(cd -- "$evidence" && pwd -P)
+printf 'T0012_S10_EVIDENCE_DIR=%s\n' "$evidence"
+
+PYTHONPYCACHEPREFIX="$evidence/pycache" python3 -m py_compile "$driver"
+bash -n "$0"
+rust_status=0
+cargo test --manifest-path "$root/Cargo.toml" -p emburk-core \
+  logical_record::double_tests -- --nocapture \
+  > "$evidence/rust-controls.stdout.log" 2> "$evidence/rust-controls.stderr.log" || rust_status=$?
+printf '%s\n' "$rust_status" > "$evidence/rust-controls.exit.txt"
+[[ "$rust_status" == 0 ]]
+for test_name in \
+  expected_only_mutation_fails_without_changing_supplied_values \
+  manifest_rejects_transport_and_value_errors \
+  null_is_distinct_and_record_order_is_preserved \
+  stores_arbitrary_selected_bit_patterns_and_reconstructs_them \
+  structural_identity_is_bitwise_not_numeric_equality
+do
+  grep -Fqx "test logical_record::double_tests::$test_name ... ok" \
+    "$evidence/rust-controls.stdout.log"
+done
+grep -Eq '^test result: ok\. 5 passed; 0 failed; 1 ignored;' \
+  "$evidence/rust-controls.stdout.log"
+
+driver_status=0
+"$driver" --output "$evidence/live.tsv" \
+  > "$evidence/driver.stdout.log" 2> "$evidence/driver.stderr.log" || driver_status=$?
+printf '%s\n' "$driver_status" > "$evidence/driver.exit.txt"
+[[ "$driver_status" == 0 ]]
+grep -Fq 'T0012_DOUBLE_FULL_PROBE=passed|evidence=' "$evidence/driver.stdout.log"
+grep -Eq '^T0012_S10_PROJECTED_CASES=2\|evidence=.+\|manifest=.+' \
+  "$evidence/driver.stdout.log"
+[[ ! -s "$evidence/driver.stderr.log" ]]
+grep -Fqx $'T0012-S10\t1' "$evidence/live.tsv"
+[[ $(grep -c $'^CASE\t' "$evidence/live.tsv") == 2 ]]
+[[ $(grep -c $'^ROW\t' "$evidence/live.tsv") == 12 ]]
+[[ $(grep -c $'^CELL\t' "$evidence/live.tsv") == 12 ]]
+
+raw_evidence=$(sed -n \
+  's/^T0012_S10_PROJECTED_CASES=2|evidence=\([^|]*\)|manifest=.*$/\1/p' \
+  "$evidence/driver.stdout.log")
+[[ -d "$raw_evidence" ]]
+
+copy_raw() {
+  local destination=$1
+  python3 - "$raw_evidence" "$destination" <<'PY'
+import pathlib
+import shutil
+import sys
+
+source = pathlib.Path(sys.argv[1])
+destination = pathlib.Path(sys.argv[2])
+destination.mkdir()
+for item in source.iterdir():
+    if item.is_symlink() or not item.is_file():
+        raise ValueError("unsafe S09 evidence member: " + item.name)
+    shutil.copy2(item, destination / item.name)
+PY
+}
+
+mutated_raw() {
+  local action=$1 copy
+  copy=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-s10-raw-parent.XXXXXX")
+  copy=$(cd -- "$copy" && pwd -P)/evidence
+  copy_raw "$copy"
+  python3 - "$action" "$copy" <<'PY'
+import base64
+import hashlib
+import pathlib
+import sys
+
+action = sys.argv[1]
+root = pathlib.Path(sys.argv[2])
+
+def repair(fixture):
+    trace = root / f"{fixture}.trace.raw"
+    rows = trace.read_text(encoding="utf-8").splitlines()
+    material = ("\n".join(rows) + "\n").encode()
+    trace.write_bytes(material)
+    raw = root / f"{fixture}.raw.log"
+    other = [line for line in raw.read_text(encoding="utf-8").splitlines()
+             if not line.startswith("DOUBLETRACE|")]
+    raw.write_text("\n".join(rows + other) + "\n", encoding="utf-8")
+    cases = (root / "double-cases.raw").read_text(encoding="utf-8").splitlines()
+    index = 0 if fixture == "finite-null" else 1
+    fields = cases[index].split("|")
+    fields[3] = str(len(rows))
+    fields[4] = hashlib.sha256(material).hexdigest()
+    cases[index] = "|".join(fields)
+    (root / "double-cases.raw").write_text("\n".join(cases) + "\n", encoding="utf-8")
+    combined = []
+    for selected in ("finite-null", "nonfinite"):
+        combined.extend((root / f"{selected}.trace.raw").read_text(encoding="utf-8").splitlines())
+    (root / "double-traces.raw").write_text("\n".join(combined) + "\n", encoding="utf-8")
+
+def repair_hashes():
+    names = (
+        "double-cases.raw", "double-traces.raw", "finite-null.raw.log",
+        "nonfinite.raw.log", "finite-null.trace.raw", "nonfinite.trace.raw",
+    )
+    text = "".join(
+        f"{name}={hashlib.sha256((root / name).read_bytes()).hexdigest()}\n"
+        for name in names
+    )
+    (root / "raw-evidence-hashes.txt").write_text(text, encoding="utf-8")
+
+if action == "case":
+    (root / "double-cases.raw").unlink()
+elif action == "hash":
+    (root / "raw-evidence-hashes.txt").write_text("broken\n", encoding="utf-8")
+elif action == "source":
+    (root / "runner-source-path.txt").write_text("tools/wrong/run.sh\n", encoding="utf-8")
+elif action in ("capture", "projection"):
+    trace = root / "finite-null.trace.raw"
+    rows = trace.read_text(encoding="utf-8").splitlines()
+    if action == "capture":
+        fields = rows[1].split("|")
+        fields[2] = "12345678-1234-4234-9234-123456789abc"
+    else:
+        index = next(i for i, row in enumerate(rows)
+                     if row.split("|")[4] == "reader-get-double-return")
+        fields = rows[index].split("|")
+        fields[-1] = base64.b64encode(b"0000000000000000").decode()
+        rows[index] = "|".join(fields)
+    if action == "capture":
+        rows[1] = "|".join(fields)
+    trace.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    repair("finite-null")
+    repair_hashes()
+else:
+    raise ValueError(action)
+PY
+  printf '%s\n' "$copy"
+}
+
+raw_fails() {
+  local action=$1 diagnostic=$2 copy attempt status=0
+  copy=$(mutated_raw "$action")
+  attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-s10-negative.XXXXXX")
+  attempt=$(cd -- "$attempt" && pwd -P)
+  "$driver" --validate-evidence "$copy" --log-directory "$attempt" \
+    > "$attempt/stdout.log" 2> "$attempt/stderr.log" || status=$?
+  printf '%s\n' "$status" > "$attempt/exit.txt"
+  [[ "$status" == 4 && ! -s "$attempt/stdout.log" ]]
+  grep -Fqx "T0012_S10_VALIDATION_ERROR|S09-strict-exit:4" "$attempt/stderr.log"
+  grep -Fqx "T0012_DOUBLE_VALIDATION_ERROR|$diagnostic" \
+    "$attempt/strict-validate.stderr.log"
+  printf 'T0012_S10_RAW_CONTROL=%s|copy=%s|attempt=%s\n' \
+    "$action" "$copy" "$attempt"
+}
+
+raw_fails case missing-artifact
+raw_fails hash hash-manifest-grammar
+raw_fails source source-path
+raw_fails capture single-capture
+raw_fails projection expected-input-getter
+
+live_status=0
+T0012_S10_MANIFEST="$evidence/live.tsv" cargo test \
+  --manifest-path "$root/Cargo.toml" -p emburk-core \
+  logical_record::double_tests::live_double_value_differential -- --ignored --exact \
+  > "$evidence/live-rust.stdout.log" 2> "$evidence/live-rust.stderr.log" || live_status=$?
+printf '%s\n' "$live_status" > "$evidence/live-rust.exit.txt"
+[[ "$live_status" == 0 ]]
+grep -Fqx 'test logical_record::double_tests::live_double_value_differential ... ok' \
+  "$evidence/live-rust.stdout.log"
+
+git -C "$root" rev-parse HEAD > "$evidence/source-revision.txt"
+printf '%s\n' "$raw_evidence" > "$evidence/raw-evidence-path.txt"
+shasum -a 256 \
+  "$root/crates/emburk-core/src/logical_record.rs" \
+  "$root/crates/emburk-core/src/logical_record/double_tests.rs" \
+  "$driver" "$0" > "$evidence/source.sha256"
+shasum -a 256 "$evidence/live.tsv" > "$evidence/manifest.sha256"
+cp "$raw_evidence/raw-evidence-hashes.txt" "$evidence/raw-evidence-hashes.txt"
+
+printf 'T0012/S10: compared 12 selected double/null cells with private bit storage; 5 bridge controls passed|evidence=%s\n' \
+  "$evidence"

--- a/tools/t0012-double-value-differential
+++ b/tools/t0012-double-value-differential
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Project the two accepted S09 double observations into a private S10 manifest."""
+
+import argparse
+import base64
+import binascii
+import hashlib
+import os
+import pathlib
+import subprocess
+import sys
+import uuid
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+S09_RUNNER = ROOT / "tools/t0012-double-value-probe/run.sh"
+S09_WRAPPER = ROOT / "tests/t0012_double_value_probe_test.sh"
+FIXTURES = (("finite-null", 7, 114), ("nonfinite", 5, 93))
+CAP = 1024
+
+
+class InvalidEvidence(ValueError):
+    pass
+
+
+def require(condition, label):
+    if not condition:
+        raise InvalidEvidence(label)
+
+
+def canonical_external(path):
+    require(path.is_absolute() and path.exists() and not path.is_symlink(), "external-path")
+    resolved = path.resolve(strict=True)
+    require(resolved == path, "external-path")
+    require(ROOT.resolve() not in resolved.parents and resolved != ROOT.resolve(), "external-path")
+    allowed = tuple(pathlib.Path(value) for value in (
+        "/tmp", "/private/tmp", "/var/folders", "/private/var/folders"
+    ))
+    require(any(resolved == root or root in resolved.parents for root in allowed), "external-path")
+    return resolved
+
+
+def decode(value):
+    if value == "-":
+        return None
+    try:
+        raw = base64.b64decode(value, validate=True)
+        decoded = raw.decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError) as error:
+        raise InvalidEvidence("projection-base64") from error
+    require(base64.b64encode(raw).decode("ascii") == value, "projection-base64")
+    return decoded
+
+
+def strict_s09_gate(evidence, log_directory):
+    completed = subprocess.run(
+        ["bash", str(S09_RUNNER)], cwd=ROOT, text=True, capture_output=True,
+        env={
+            **os.environ,
+            "T0012_DOUBLE_MODE": "validate",
+            "T0012_DOUBLE_STRICT_VALIDATE": "1",
+            "T0012_DOUBLE_EVIDENCE_DIR": str(evidence),
+        },
+    )
+    log_directory.joinpath("strict-validate.stdout.log").write_text(
+        completed.stdout, encoding="utf-8"
+    )
+    log_directory.joinpath("strict-validate.stderr.log").write_text(
+        completed.stderr, encoding="utf-8"
+    )
+    log_directory.joinpath("strict-validate.exit.txt").write_text(
+        f"{completed.returncode}\n", encoding="utf-8"
+    )
+    require(completed.returncode == 0, f"S09-strict-exit:{completed.returncode}")
+    require(
+        completed.stdout == "T0012_DOUBLE_VALIDATE_ONLY=passed\n"
+        and completed.stderr == "",
+        "S09-strict-output",
+    )
+
+
+def read_cases(evidence):
+    path = evidence / "double-cases.raw"
+    require(path.is_file() and not path.is_symlink() and path.stat().st_size <= 65536,
+            "raw-case-file")
+    lines = path.read_text(encoding="utf-8").splitlines()
+    require(len(lines) == len(FIXTURES), "raw-case-count")
+    captures = {}
+    for (name, _, event_count), line in zip(FIXTURES, lines, strict=True):
+        fields = line.split("|")
+        require(
+            len(fields) == 5 and fields[:2] == ["DOUBLECASE", name]
+            and fields[2] == "0" and fields[3] == str(event_count),
+            "raw-case-identity",
+        )
+        require(len(fields[4]) == 64 and all(c in "0123456789abcdef" for c in fields[4]),
+                "raw-case-hash")
+        captures[name] = fields[4]
+    return captures
+
+
+def read_trace(evidence, name, rows, event_count, expected_hash):
+    path = evidence / f"{name}.trace.raw"
+    require(path.is_file() and not path.is_symlink() and path.stat().st_size <= 1024 * 1024,
+            "trace-file")
+    material = path.read_bytes()
+    require(material.endswith(b"\n") and hashlib.sha256(material).hexdigest() == expected_hash,
+            "trace-hash")
+    lines = material.decode("utf-8").splitlines()
+    require(len(lines) == event_count, "trace-count")
+    capture = None
+    events = []
+    for sequence, line in enumerate(lines, 1):
+        fields = line.split("|")
+        require(len(fields) >= 5 and fields[:2] == ["DOUBLETRACE", name], "trace-grammar")
+        try:
+            parsed = uuid.UUID(fields[2])
+        except ValueError as error:
+            raise InvalidEvidence("trace-capture") from error
+        require(str(parsed) == fields[2] and parsed.version == 4, "trace-capture")
+        capture = capture or fields[2]
+        require(fields[2] == capture and fields[3] == str(sequence), "trace-sequence")
+        events.append((fields[4], [decode(field) for field in fields[5:]]))
+    return project(events, rows)
+
+
+def project(events, rows):
+    supplied = {}
+    nulls = {}
+    getters = {}
+    next_results = []
+    for event, values in events:
+        if event == "input-cell":
+            require(len(values) == 4 and values[1] == "0", "projection-input")
+            row = int(values[0])
+            require(row not in supplied and 0 <= row < rows, "projection-input")
+            supplied[row] = ("N", "-") if values[2] == "null" else ("D", values[3])
+        elif event == "reader-is-null-return":
+            require(len(values) == 5 and values[3] == "0", "projection-null")
+            row = int(values[2])
+            require(row not in nulls and values[4] in ("true", "false"), "projection-null")
+            nulls[row] = values[4] == "true"
+        elif event == "reader-get-double-return":
+            require(len(values) == 5 and values[3] == "0", "projection-getter")
+            row = int(values[2])
+            require(row not in getters, "projection-getter")
+            getters[row] = values[4]
+        elif event == "reader-next-record-return":
+            require(len(values) == 3, "projection-exhaustion")
+            next_results.append(values)
+    require(set(supplied) == set(range(rows)) and set(nulls) == set(range(rows)),
+            "projection-completeness")
+    require(
+        next_results == [["0", str(row), "true"] for row in range(rows)]
+        + [["0", str(rows), "false"]],
+        "projection-exhaustion",
+    )
+    output = []
+    for row in range(rows):
+        input_tag, input_payload = supplied[row]
+        if nulls[row]:
+            require(row not in getters, "projection-null-getter")
+            reference = ("N", "-")
+        else:
+            require(row in getters, "projection-getter")
+            reference = ("D", getters[row])
+        output.append((input_tag, input_payload, *reference))
+    require(set(getters) == {row for row in range(rows) if not nulls[row]},
+            "projection-getter-completeness")
+    return output
+
+
+def validate_and_project(evidence, log_directory):
+    evidence = canonical_external(evidence)
+    strict_s09_gate(evidence, log_directory)
+    case_hashes = read_cases(evidence)
+    projected = {}
+    for name, rows, event_count in FIXTURES:
+        projected[name] = read_trace(evidence, name, rows, event_count, case_hashes[name])
+    return projected
+
+
+def write_manifest(projected, output):
+    lines = ["T0012-S10\t1"]
+    for name, rows, _ in FIXTURES:
+        values = projected[name]
+        require(len(values) == rows and rows <= CAP, "manifest-dimensions")
+        lines.append(f"CASE\t{name}\t{rows}\t1")
+        for row, value in enumerate(values):
+            lines.append(f"ROW\t{row}")
+            lines.append("\t".join(("CELL", "0", *value)))
+    material = ("\n".join(lines) + "\n").encode("utf-8")
+    require(len(material) <= 65536, "manifest-size")
+    hash_path = output.with_suffix(".sha256")
+    require(not output.exists() and not output.is_symlink(), "output-exists")
+    require(not hash_path.exists() and not hash_path.is_symlink(), "output-exists")
+    with output.open("xb") as stream:
+        stream.write(material)
+    with hash_path.open("x", encoding="utf-8") as stream:
+        stream.write(hashlib.sha256(material).hexdigest() + "\n")
+
+
+def record_source_identity(logs):
+    revision = subprocess.run(
+        ["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+        check=True, text=True, capture_output=True,
+    ).stdout
+    logs.joinpath("source-revision.txt").write_text(revision, encoding="utf-8")
+    paths = (
+        ROOT / "crates/emburk-core/src/logical_record.rs",
+        ROOT / "crates/emburk-core/src/logical_record/double_tests.rs",
+        ROOT / "tools/t0012-double-value-differential",
+        ROOT / "tests/t0012_double_value_differential_test.sh",
+    )
+    rows = []
+    for path in paths:
+        relative = path.relative_to(ROOT)
+        rows.append(f"{relative}={hashlib.sha256(path.read_bytes()).hexdigest()}")
+    logs.joinpath("source-hashes.txt").write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def run_live(output):
+    logs = canonical_external(output.parent)
+    completed = subprocess.run(
+        ["bash", str(S09_WRAPPER)], cwd=ROOT, text=True, capture_output=True,
+        env={**os.environ, "T0012_DOUBLE_MODE": "full"},
+    )
+    logs.joinpath("s09-wrapper.stdout.log").write_text(completed.stdout, encoding="utf-8")
+    logs.joinpath("s09-wrapper.stderr.log").write_text(completed.stderr, encoding="utf-8")
+    logs.joinpath("s09-wrapper.exit.txt").write_text(
+        f"{completed.returncode}\n", encoding="utf-8"
+    )
+    sys.stdout.write(completed.stdout)
+    sys.stderr.write(completed.stderr)
+    require(completed.returncode == 0, f"S09-full-exit:{completed.returncode}")
+    prefix = "T0012_DOUBLE_FULL_PROBE=passed|evidence="
+    markers = [line for line in completed.stdout.splitlines() if line.startswith(prefix)]
+    require(len(markers) == 1, "S09-full-marker-count")
+    require("T0012_DOUBLE_VALIDATE_ONLY=passed" not in completed.stdout,
+            "S09-live-marker-mix")
+    return pathlib.Path(markers[0][len(prefix):])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--output", type=pathlib.Path)
+    group.add_argument("--validate-evidence", type=pathlib.Path)
+    parser.add_argument("--log-directory", type=pathlib.Path)
+    arguments = parser.parse_args()
+    try:
+        if arguments.validate_evidence is not None:
+            require(arguments.log_directory is not None, "log-directory-required")
+            logs = canonical_external(arguments.log_directory)
+            validate_and_project(arguments.validate_evidence, logs)
+            print(f"T0012_S10_RAW_VALIDATE_ONLY=passed|evidence={arguments.validate_evidence}")
+            return 0
+        require(arguments.output is not None, "output-required")
+        require(not arguments.output.exists() and not arguments.output.is_symlink(), "output-exists")
+        parent = canonical_external(arguments.output.parent.resolve(strict=True))
+        output = parent / arguments.output.name
+        require(output.name not in ("", ".", ".."), "output-name")
+        record_source_identity(parent)
+        evidence = run_live(output)
+        projected = validate_and_project(evidence, output.parent)
+        write_manifest(projected, output)
+        print(f"T0012_S10_PROJECTED_CASES=2|evidence={evidence}|manifest={output}")
+    except (InvalidEvidence, OSError, UnicodeError, ValueError) as error:
+        print(f"T0012_S10_VALIDATION_ERROR|{error}", file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #15. Implements T-0012/S10 under ADR-0012: private bit-preserving double storage, two actual reference projections, independent expected bits, and five bridge negative controls. Primary and independent exact Demo passed at 3df2a88; 41 workspace tests, format and strict Clippy pass. Canonical evidence and non-claims: docs/provenance/T-0012-private-double-values.md. Final PR-head Demo will be recorded before integration. No public numeric equality, schema, transfer or parent completion claim.