### PR TITLE
feat(t-0021): add private synchronous owned-record handoff

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@ Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 `T-0013/S08`, `T-0012/S08` and `T-0021/S05` are integrated. T-0012/S09 is
 integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93; T-0012, T-0013, T-0021 and all other
-unfinished items are `Backlog`, except T-0021/S06, now `In Progress` following
+unfinished items are `Backlog`, except T-0021/S06, now `Review` following
 PR #95 readiness integration. Combined active implementation WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -46,7 +46,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
-| T-0021 | Define workspace boundaries and core traits (S06 private owned-record handoff) | In Progress | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
+| T-0021 | Define workspace boundaries and core traits (S06 private owned-record handoff) | Review | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
@@ -390,6 +390,9 @@ Initial 5 remain unchanged. Parent #15 remains open and returns to Backlog.
 Next candidate: T-0021/S06, a private synchronous owned-record handoff seam
 under accepted ADR-0013 and its [packet](docs/provenance/T-0021-owned-record-handoff.md).
 Estimate 2 SP within Current 13 / Initial 5; prior accepted S01–S05 total 11 SP.
-Independent readiness review passed; the slice is Ready. It will connect existing private records to original
+Independent readiness review passed; implementation is now in Review. It connects existing private records to original
 fake consumers without selecting schema, lifecycle or public plugin policy.
-Parent T-0021 and all delivery gates remain open.
+Parent T-0021 and all delivery gates remain open. Source `8fe820b` passes
+primary and independent exact Demo: five handoff tests, 46 workspace passes,
+seven intentional live ignores, format and strict Clippy. Final-head acceptance
+and integration remain required; no new slice points are awarded yet.

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,8 @@ Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 `T-0013/S08`, `T-0012/S08` and `T-0021/S05` are integrated. T-0012/S09 is
 integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93; T-0012, T-0013, T-0021 and all other
-unfinished items are `Backlog`. Combined active implementation WIP is zero of two.
+unfinished items are `Backlog`, except T-0021/S06, now `In Progress` following
+PR #95 readiness integration. Combined active implementation WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -45,7 +46,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
-| T-0021 | Define workspace boundaries and core traits (S01–S05 integrated; remaining contracts queued) | Backlog | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
+| T-0021 | Define workspace boundaries and core traits (S06 private owned-record handoff) | In Progress | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -21,6 +21,13 @@ mod logical_schema;
 )]
 mod logical_record;
 
+// This remains a private ownership experiment, not a plugin or lifecycle API.
+#[allow(
+    dead_code,
+    reason = "T-0021/S06 is an internal synchronous owned-record handoff seam"
+)]
+mod record_handoff;
+
 // This is deliberately private: it is a bounded fake-fixture coordinator, not
 // a public plugin API or a production lifecycle contract.
 #[allow(

--- a/crates/emburk-core/src/logical_record.rs
+++ b/crates/emburk-core/src/logical_record.rs
@@ -8,7 +8,7 @@ impl Float64Bits {
         Self(value.to_bits())
     }
 
-    pub(super) fn to_float(self) -> f64 {
+    fn to_float(self) -> f64 {
         f64::from_bits(self.0)
     }
 

--- a/crates/emburk-core/src/logical_record.rs
+++ b/crates/emburk-core/src/logical_record.rs
@@ -1,24 +1,24 @@
 //! Private owned logical record values with no schema or physical encoding policy.
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct Float64Bits(u64);
+pub(super) struct Float64Bits(u64);
 
 impl Float64Bits {
-    fn from_float(value: f64) -> Self {
+    pub(super) fn from_float(value: f64) -> Self {
         Self(value.to_bits())
     }
 
-    fn to_float(self) -> f64 {
+    pub(super) fn to_float(self) -> f64 {
         f64::from_bits(self.0)
     }
 
-    fn bits(self) -> u64 {
+    pub(super) fn bits(self) -> u64 {
         self.0
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum LogicalValue {
+pub(super) enum LogicalValue {
     Null,
     Boolean(bool),
     Signed64(i64),
@@ -27,16 +27,16 @@ enum LogicalValue {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct LogicalRecord {
+pub(super) struct LogicalRecord {
     cells: Vec<LogicalValue>,
 }
 
 impl LogicalRecord {
-    fn new(cells: Vec<LogicalValue>) -> Self {
+    pub(super) fn new(cells: Vec<LogicalValue>) -> Self {
         Self { cells }
     }
 
-    fn cells(&self) -> impl ExactSizeIterator<Item = &LogicalValue> {
+    pub(super) fn cells(&self) -> impl ExactSizeIterator<Item = &LogicalValue> {
         self.cells.iter()
     }
 }

--- a/crates/emburk-core/src/record_handoff.rs
+++ b/crates/emburk-core/src/record_handoff.rs
@@ -1,0 +1,306 @@
+//! Private synchronous ownership handoff with no lifecycle or schema policy.
+
+use crate::logical_record::LogicalRecord;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SourceError(String);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SinkError(String);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum HandoffError {
+    Source(SourceError),
+    Sink(SinkError),
+}
+
+trait RecordSource {
+    fn next_record(&mut self) -> Result<Option<LogicalRecord>, SourceError>;
+}
+
+trait RecordSink {
+    fn accept(&mut self, record: LogicalRecord) -> Result<(), SinkError>;
+}
+
+fn handoff_owned_records<S, K>(source: &mut S, sink: &mut K) -> Result<usize, HandoffError>
+where
+    S: RecordSource,
+    K: RecordSink,
+{
+    let mut accepted = 0;
+    loop {
+        let Some(record) = source.next_record().map_err(HandoffError::Source)? else {
+            return Ok(accepted);
+        };
+        sink.accept(record).map_err(HandoffError::Sink)?;
+        accepted += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logical_record::{Float64Bits, LogicalValue};
+    use std::{cell::RefCell, rc::Rc, vec::IntoIter};
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum Event {
+        SourceCalled(usize),
+        SourceReturned(usize),
+        SourceExhausted(usize),
+        SourceFailed(usize, SourceError),
+        SinkCalled(usize),
+        SinkAccepted(usize),
+        SinkFailed(usize, SinkError),
+    }
+
+    struct SourceFake {
+        results: IntoIter<Result<LogicalRecord, SourceError>>,
+        calls: usize,
+        events: Rc<RefCell<Vec<Event>>>,
+    }
+
+    impl SourceFake {
+        fn new(
+            results: Vec<Result<LogicalRecord, SourceError>>,
+            events: Rc<RefCell<Vec<Event>>>,
+        ) -> Self {
+            Self {
+                results: results.into_iter(),
+                calls: 0,
+                events,
+            }
+        }
+
+        fn event(&self, event: Event) {
+            self.events.borrow_mut().push(event);
+        }
+    }
+
+    impl RecordSource for SourceFake {
+        fn next_record(&mut self) -> Result<Option<LogicalRecord>, SourceError> {
+            let call = self.calls;
+            self.calls += 1;
+            self.event(Event::SourceCalled(call));
+            match self.results.next() {
+                Some(Ok(record)) => {
+                    self.event(Event::SourceReturned(call));
+                    Ok(Some(record))
+                }
+                Some(Err(error)) => {
+                    self.event(Event::SourceFailed(call, error.clone()));
+                    Err(error)
+                }
+                None => {
+                    self.event(Event::SourceExhausted(call));
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    struct SinkFake {
+        records: Vec<LogicalRecord>,
+        calls: usize,
+        fail_at: Option<usize>,
+        events: Rc<RefCell<Vec<Event>>>,
+    }
+
+    impl SinkFake {
+        fn new(fail_at: Option<usize>, events: Rc<RefCell<Vec<Event>>>) -> Self {
+            Self {
+                records: Vec::new(),
+                calls: 0,
+                fail_at,
+                events,
+            }
+        }
+
+        fn event(&self, event: Event) {
+            self.events.borrow_mut().push(event);
+        }
+    }
+
+    impl RecordSink for SinkFake {
+        fn accept(&mut self, record: LogicalRecord) -> Result<(), SinkError> {
+            let call = self.calls;
+            self.calls += 1;
+            self.event(Event::SinkCalled(call));
+            if self.fail_at == Some(call) {
+                let error = SinkError(format!("sink-payload-{call}"));
+                self.event(Event::SinkFailed(call, error.clone()));
+                return Err(error);
+            }
+            self.records.push(record);
+            self.event(Event::SinkAccepted(call));
+            Ok(())
+        }
+    }
+
+    fn record(id: i64) -> LogicalRecord {
+        LogicalRecord::new(vec![LogicalValue::Signed64(id)])
+    }
+
+    fn run(
+        inputs: Vec<Result<LogicalRecord, SourceError>>,
+        sink_failure: Option<usize>,
+    ) -> (Result<usize, HandoffError>, Vec<LogicalRecord>, Vec<Event>) {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let mut source = SourceFake::new(inputs, Rc::clone(&events));
+        let mut sink = SinkFake::new(sink_failure, Rc::clone(&events));
+        let result = handoff_owned_records(&mut source, &mut sink);
+        let events = events.borrow().clone();
+        (result, sink.records, events)
+    }
+
+    #[test]
+    fn zero_records_calls_source_once_and_returns_zero() {
+        let (result, records, events) = run(Vec::new(), None);
+        assert_eq!(result, Ok(0));
+        assert!(records.is_empty());
+        assert_eq!(
+            events,
+            vec![Event::SourceCalled(0), Event::SourceExhausted(0)]
+        );
+    }
+
+    #[test]
+    fn multiple_records_move_in_order_and_count_only_after_exhaustion() {
+        let (result, records, events) = run(vec![Ok(record(10)), Ok(record(20))], None);
+        assert_eq!(result, Ok(2));
+        assert_eq!(records, vec![record(10), record(20)]);
+        assert_eq!(
+            events,
+            vec![
+                Event::SourceCalled(0),
+                Event::SourceReturned(0),
+                Event::SinkCalled(0),
+                Event::SinkAccepted(0),
+                Event::SourceCalled(1),
+                Event::SourceReturned(1),
+                Event::SinkCalled(1),
+                Event::SinkAccepted(1),
+                Event::SourceCalled(2),
+                Event::SourceExhausted(2),
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_all_selected_stored_values_and_owned_text() {
+        let mut original_text = String::from("owned 🦀\n");
+        let expected = LogicalRecord::new(vec![
+            LogicalValue::Null,
+            LogicalValue::Boolean(false),
+            LogicalValue::Signed64(i64::MIN),
+            LogicalValue::Signed64(i64::MAX),
+            LogicalValue::Text(original_text.clone()),
+            LogicalValue::Float64(Float64Bits::from_float(0.0)),
+            LogicalValue::Float64(Float64Bits::from_float(-0.0)),
+            LogicalValue::Float64(Float64Bits::from_float(f64::INFINITY)),
+            LogicalValue::Float64(Float64Bits::from_float(f64::from_bits(
+                0xfff8_0000_0000_0042,
+            ))),
+        ]);
+        let input = LogicalRecord::new(expected.cells().cloned().collect());
+        original_text.push_str("changed after construction");
+        let (result, records, events) = run(vec![Ok(input)], None);
+        assert_eq!(result, Ok(1));
+        assert_eq!(records, vec![expected]);
+        assert_eq!(
+            events,
+            vec![
+                Event::SourceCalled(0),
+                Event::SourceReturned(0),
+                Event::SinkCalled(0),
+                Event::SinkAccepted(0),
+                Event::SourceCalled(1),
+                Event::SourceExhausted(1),
+            ]
+        );
+        let values: Vec<_> = records[0].cells().collect();
+        assert_eq!(
+            values[5],
+            &LogicalValue::Float64(Float64Bits::from_float(0.0))
+        );
+        assert_eq!(
+            values[6],
+            &LogicalValue::Float64(Float64Bits::from_float(-0.0))
+        );
+        assert_eq!(
+            values[8],
+            &LogicalValue::Float64(Float64Bits::from_float(f64::from_bits(
+                0xfff8_0000_0000_0042
+            )))
+        );
+    }
+
+    #[test]
+    fn source_failures_at_first_and_later_positions_stop_immediately() {
+        let first = SourceError("source-payload-first".into());
+        let (result, records, events) = run(vec![Err(first.clone()), Ok(record(99))], None);
+        assert_eq!(result, Err(HandoffError::Source(first.clone())));
+        assert!(records.is_empty());
+        assert_eq!(
+            events,
+            vec![Event::SourceCalled(0), Event::SourceFailed(0, first)]
+        );
+
+        let later = SourceError("source-payload-later".into());
+        let (result, records, events) = run(
+            vec![Ok(record(10)), Err(later.clone()), Ok(record(99))],
+            None,
+        );
+        assert_eq!(result, Err(HandoffError::Source(later.clone())));
+        assert_eq!(records, vec![record(10)]);
+        assert_eq!(
+            events,
+            vec![
+                Event::SourceCalled(0),
+                Event::SourceReturned(0),
+                Event::SinkCalled(0),
+                Event::SinkAccepted(0),
+                Event::SourceCalled(1),
+                Event::SourceFailed(1, later),
+            ]
+        );
+    }
+
+    #[test]
+    fn sink_failures_at_first_and_later_positions_stop_immediately() {
+        let first = SinkError("sink-payload-0".into());
+        let (result, records, events) = run(vec![Ok(record(10)), Ok(record(99))], Some(0));
+        assert_eq!(result, Err(HandoffError::Sink(first.clone())));
+        assert!(records.is_empty());
+        assert_eq!(
+            events,
+            vec![
+                Event::SourceCalled(0),
+                Event::SourceReturned(0),
+                Event::SinkCalled(0),
+                Event::SinkFailed(0, first),
+            ]
+        );
+
+        let later = SinkError("sink-payload-1".into());
+        let (result, records, events) = run(
+            vec![Ok(record(10)), Ok(record(20)), Ok(record(99))],
+            Some(1),
+        );
+        assert_eq!(result, Err(HandoffError::Sink(later.clone())));
+        assert_eq!(records, vec![record(10)]);
+        assert_eq!(
+            events,
+            vec![
+                Event::SourceCalled(0),
+                Event::SourceReturned(0),
+                Event::SinkCalled(0),
+                Event::SinkAccepted(0),
+                Event::SourceCalled(1),
+                Event::SourceReturned(1),
+                Event::SinkCalled(1),
+                Event::SinkFailed(1, later),
+            ]
+        );
+    }
+}

--- a/crates/emburk-core/src/record_handoff.rs
+++ b/crates/emburk-core/src/record_handoff.rs
@@ -189,24 +189,37 @@ mod tests {
     #[test]
     fn preserves_all_selected_stored_values_and_owned_text() {
         let mut original_text = String::from("owned 🦀\n");
-        let expected = LogicalRecord::new(vec![
+        let expected_bits = [
+            0x7fef_ffff_ffff_ffff,
+            0xffef_ffff_ffff_ffff,
+            0x0000_0000_0000_0001,
+            0x8000_0000_0000_0001,
+            0x0000_0000_0000_0000,
+            0x8000_0000_0000_0000,
+            0x7ff0_0000_0000_0000,
+            0xfff0_0000_0000_0000,
+            0x7ff8_0000_0000_0000,
+            0x7ff8_0000_0000_0042,
+            0xfff8_0000_0000_0042,
+        ];
+        let mut cells = vec![
             LogicalValue::Null,
             LogicalValue::Boolean(false),
+            LogicalValue::Boolean(true),
             LogicalValue::Signed64(i64::MIN),
             LogicalValue::Signed64(i64::MAX),
             LogicalValue::Text(original_text.clone()),
-            LogicalValue::Float64(Float64Bits::from_float(0.0)),
-            LogicalValue::Float64(Float64Bits::from_float(-0.0)),
-            LogicalValue::Float64(Float64Bits::from_float(f64::INFINITY)),
-            LogicalValue::Float64(Float64Bits::from_float(f64::from_bits(
-                0xfff8_0000_0000_0042,
-            ))),
-        ]);
-        let input = LogicalRecord::new(expected.cells().cloned().collect());
+            LogicalValue::Text(String::new()),
+        ];
+        cells.extend(
+            expected_bits
+                .map(|bits| LogicalValue::Float64(Float64Bits::from_float(f64::from_bits(bits)))),
+        );
+        let input = LogicalRecord::new(cells);
         original_text.push_str("changed after construction");
         let (result, records, events) = run(vec![Ok(input)], None);
         assert_eq!(result, Ok(1));
-        assert_eq!(records, vec![expected]);
+        assert_eq!(records.len(), 1);
         assert_eq!(
             events,
             vec![
@@ -219,20 +232,21 @@ mod tests {
             ]
         );
         let values: Vec<_> = records[0].cells().collect();
-        assert_eq!(
-            values[5],
-            &LogicalValue::Float64(Float64Bits::from_float(0.0))
-        );
-        assert_eq!(
-            values[6],
-            &LogicalValue::Float64(Float64Bits::from_float(-0.0))
-        );
-        assert_eq!(
-            values[8],
-            &LogicalValue::Float64(Float64Bits::from_float(f64::from_bits(
-                0xfff8_0000_0000_0042
-            )))
-        );
+        assert_eq!(values[0], &LogicalValue::Null);
+        assert_eq!(values[1], &LogicalValue::Boolean(false));
+        assert_eq!(values[2], &LogicalValue::Boolean(true));
+        assert_eq!(values[3], &LogicalValue::Signed64(i64::MIN));
+        assert_eq!(values[4], &LogicalValue::Signed64(i64::MAX));
+        assert_eq!(values[5], &LogicalValue::Text("owned 🦀\n".into()));
+        assert_eq!(values[6], &LogicalValue::Text(String::new()));
+        let actual_bits: Vec<_> = values[7..]
+            .iter()
+            .map(|value| match value {
+                LogicalValue::Float64(value) => value.bits(),
+                other => panic!("expected Float64, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(actual_bits, expected_bits);
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,10 +143,13 @@ The S10 slice is Done with Unit/Contract and the two selected Differential
 projections. No public value, schema coupling, physical encoding, whole-domain
 or production claim follows; parent and delivery gates remain open.
 
-T-0021/S06 is Ready under accepted ADR-0013 after independent packet review:
-private synchronous owned-record handoff to original local fakes. There is
-no public API, schema validation, lifecycle policy, runtime resource guarantee
-or new compatibility claim follows from this planning step.
+T-0021/S06 implements the private synchronous owned-record handoff permitted by
+ADR-0013. Frozen source `8fe820b` passes primary and independent exact Demo:
+five handoff tests, 46 workspace passes/seven intentionally ignored live tests,
+format and strict Clippy. It moves records directly, preserves selected bits and
+typed errors, and stops callbacks on the first failure. Final PR-head acceptance
+and integration remain required. Evidence is Unit/Contract only, not a public
+API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
 
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -197,10 +197,13 @@ The S10 slice is Done with Unit/Contract and the two selected Differential
 projections. No public value, schema coupling, physical encoding, whole-domain
 or production claim follows; parent and delivery gates remain open.
 
-T-0021/S06 is Ready under accepted ADR-0013 after independent packet review:
-private synchronous owned-record handoff to original local fakes. There is
-no public API, schema validation, lifecycle policy, runtime resource guarantee
-or new compatibility claim follows from this planning step.
+T-0021/S06 implements the private synchronous owned-record handoff permitted by
+ADR-0013. Frozen source `8fe820b` passes primary and independent exact Demo:
+five handoff tests, 46 workspace passes/seven intentionally ignored live tests,
+format and strict Clippy. It moves records directly, preserves selected bits and
+typed errors, and stops callbacks on the first failure. Final PR-head acceptance
+and integration remain required. Evidence is Unit/Contract only, not a public
+API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -168,10 +168,13 @@ The S10 slice is Done with Unit/Contract and the two selected Differential
 projections. No public value, schema coupling, physical encoding, whole-domain
 or production claim follows; parent and delivery gates remain open.
 
-T-0021/S06 is Ready under accepted ADR-0013 after independent packet review:
-private synchronous owned-record handoff to original local fakes. There is
-no public API, schema validation, lifecycle policy, runtime resource guarantee
-or new compatibility claim follows from this planning step.
+T-0021/S06 implements the private synchronous owned-record handoff permitted by
+ADR-0013. Frozen source `8fe820b` passes primary and independent exact Demo:
+five handoff tests, 46 workspace passes/seven intentionally ignored live tests,
+format and strict Clippy. It moves records directly, preserves selected bits and
+typed errors, and stops callbacks on the first failure. Final PR-head acceptance
+and integration remain required. Evidence is Unit/Contract only, not a public
+API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
 
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -353,10 +353,13 @@ The S10 slice is Done with Unit/Contract and the two selected Differential
 projections. No public value, schema coupling, physical encoding, whole-domain
 or production claim follows; parent and delivery gates remain open.
 
-T-0021/S06 is Ready under accepted ADR-0013 after independent packet review:
-private synchronous owned-record handoff to original local fakes. There is
-no public API, schema validation, lifecycle policy, runtime resource guarantee
-or new compatibility claim follows from this planning step.
+T-0021/S06 implements the private synchronous owned-record handoff permitted by
+ADR-0013. Frozen source `8fe820b` passes primary and independent exact Demo:
+five handoff tests, 46 workspace passes/seven intentionally ignored live tests,
+format and strict Clippy. It moves records directly, preserves selected bits and
+typed errors, and stops callbacks on the first failure. Final PR-head acceptance
+and integration remain required. Evidence is Unit/Contract only, not a public
+API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
 
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -45,7 +45,8 @@ captured 114/93 events with exact selected double bits preserved; primary
 reproduction and complete raw review authorize Stage B strict validation.
 The slice integrated through PR #91 as `34757c8`. S10's private double-storage
 decision passed readiness review and integrated through PR #92. S10 is now
-Done through PR #93, with combined active WIP zero of two. T-0012, T-0013 and
+Done through PR #93. T-0021/S06 now starts after PR #95 integrated its reviewed
+packet; combined active WIP is one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
@@ -56,7 +57,7 @@ T-0021 parent contracts remain open.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S10 integrated; remaining configuration/value contracts |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
-| T-0021 | Backlog | S01–S05 integrated; remaining runtime contracts |
+| T-0021/S06 | In Progress | Private synchronous owned-record handoff |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -57,7 +57,7 @@ T-0021 parent contracts remain open.
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012 | Backlog | S10 integrated; remaining configuration/value contracts |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
-| T-0021/S06 | In Progress | Private synchronous owned-record handoff |
+| T-0021/S06 | Review | Private synchronous owned-record handoff |
 
 All other stable tasks in `TODO.md` remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
@@ -347,7 +347,10 @@ The S10 slice is Done with Unit/Contract and the two selected Differential
 projections. No public value, schema coupling, physical encoding, whole-domain
 or production claim follows; parent and delivery gates remain open.
 
-T-0021/S06 is Ready under accepted ADR-0013 after independent packet review:
-private synchronous owned-record handoff to original local fakes. There is
-no public API, schema validation, lifecycle policy, runtime resource guarantee
-or new compatibility claim follows from this planning step.
+T-0021/S06 implements the private synchronous owned-record handoff permitted by
+ADR-0013. Frozen source `8fe820b` passes primary and independent exact Demo:
+five handoff tests, 46 workspace passes/seven intentionally ignored live tests,
+format and strict Clippy. It moves records directly, preserves selected bits and
+typed errors, and stops callbacks on the first failure. Final PR-head acceptance
+and integration remain required. Evidence is Unit/Contract only, not a public
+API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -28,4 +28,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S08 private record values](T-0012-private-record-values.md) | Done (bounded slice; PR #82, `b428305`) |
 | [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | Done (bounded reference slice; PR #91, `34757c8`) |
 | [T-0012/S10 private double values](T-0012-private-double-values.md) | Done (bounded private slice; PR #93, `742274f`) |
-| [T-0021/S06 owned-record handoff](T-0021-owned-record-handoff.md) | Ready; independent packet review passed |
+| [T-0021/S06 owned-record handoff](T-0021-owned-record-handoff.md) | In Progress; readiness integrated through PR #95 |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -28,4 +28,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S08 private record values](T-0012-private-record-values.md) | Done (bounded slice; PR #82, `b428305`) |
 | [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | Done (bounded reference slice; PR #91, `34757c8`) |
 | [T-0012/S10 private double values](T-0012-private-double-values.md) | Done (bounded private slice; PR #93, `742274f`) |
-| [T-0021/S06 owned-record handoff](T-0021-owned-record-handoff.md) | In Progress; readiness integrated through PR #95 |
+| [T-0021/S06 owned-record handoff](T-0021-owned-record-handoff.md) | Review; primary and independent source acceptance passed |

--- a/docs/provenance/T-0021-owned-record-handoff.md
+++ b/docs/provenance/T-0021-owned-record-handoff.md
@@ -1,7 +1,7 @@
 # T-0021/S06 private synchronous owned-record handoff
 
 - Issue: [T-0021, #18](https://github.com/bhind/emburk/issues/18)
-- State: Ready; independent packet review passed, planning PR integration pending
+- State: In Progress; accepted packet integrated through PR #95 as `0dc3263`
 - Priority: P1; owner Rust Core Implementer; PM owns records and integration
 - Estimate: 2 SP (implementation 1, verification 1), within Current 13 / Initial 5
 - Prior accepted S01–S05: 11 SP. No parent completion or new points yet.

--- a/docs/provenance/T-0021-owned-record-handoff.md
+++ b/docs/provenance/T-0021-owned-record-handoff.md
@@ -1,7 +1,7 @@
 # T-0021/S06 private synchronous owned-record handoff
 
 - Issue: [T-0021, #18](https://github.com/bhind/emburk/issues/18)
-- State: In Progress; accepted packet integrated through PR #95 as `0dc3263`
+- State: Review; source acceptance passed, final PR-head gate and integration pending
 - Priority: P1; owner Rust Core Implementer; PM owns records and integration
 - Estimate: 2 SP (implementation 1, verification 1), within Current 13 / Initial 5
 - Prior accepted S01–S05: 11 SP. No parent completion or new points yet.
@@ -68,6 +68,42 @@ Existing S08/S10 storage tests must remain unchanged and pass in the workspace.
 ## Evidence class
 
 Unit/Contract only. Readiness is Planning, not runtime evidence.
+
+## Source review and acceptance
+
+Frozen source `8fe820bceadf62db89a5b7850abe1b9c9192be1f` follows initial
+implementation `f3b0e9f`. Review removed unused sibling visibility and made
+the selected-value test verify all eleven S10 double bit patterns against raw
+expected integers at the sink, plus null, both booleans, integer bounds and
+owned/empty text. Both first/later source and sink failures use complete ordered
+traces and typed original payload assertions. Primary inspection confirms one
+direct ownership move, no queue/clone, and no lifecycle/schema additions.
+
+The exact Demo passed with exit 0 for implementer, primary and independent
+Tester at the frozen source. Complete stdout/stderr/exit are retained at:
+
+- implementer: `/private/tmp/t0021-s06-demo.CSu34r`;
+- primary: `/private/tmp/t0021-s06-primary.9Ludl9`;
+- independent: `/private/tmp/t0021-s06-independent.4m3s3N`.
+
+Each ran five named handoff tests, 46 workspace passes/seven intentional live
+ignores, format, strict all-target Clippy and diff check. No live Differential
+test is claimed by this local Demo. Independent stdout SHA-256:
+`7d5bf1fed893a82aa0c46237445d9456fc2304c3ac6eb1662c5cedc0201f4ba8`;
+stderr (normal Cargo progress) SHA-256:
+`738f634ac47effc5b59c390d61aa96f3b9f77f05ebde075cad0da64f0156c1be`.
+Environment: macOS ARM64, Rust/Cargo 1.98.1. Local temporary logs must be
+reproduced if removed; their paths are not a durable published artifact store.
+
+Source SHA-256:
+
+- lib: `5213b2c72a317725f9eb52a108664838bee347db9bcd798f55a48f0e031f8f8c`;
+- logical record: `9398928aa5862a2b370729571b2b86ad0e6b388f43768a746eab7f46c12c3f3e`;
+- handoff: `6c8a9994455e110dffd5183cadfcee754ac4733a77d0f6e26e935facc45eb4fd`.
+
+Only the three authorized source paths changed. PM-owned documentation was
+separately unstaged during source acceptance and was not reverted by agents.
+Final-head Demo, record reconciliation and integration remain required.
 
 ## Stop rule
 


### PR DESCRIPTION
Refs #18. Implements the accepted T-0021/S06 three-file packet under ADR-0013. Direct owned-record moves, ordered fake callbacks, typed first-error propagation, and all selected existing values. Primary and independent exact Demo pass at 8fe820b: 5 handoff tests, 46 workspace passes/7 intentional live ignores, format, strict Clippy and diff check. Unit/Contract only; no public API, lifecycle/schema, resource guarantee or Embulk compatibility claim. Final PR-head gate will be recorded before integration.