### PR TITLE
test(t-0012): automate bounded schema-value observation validation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,8 @@ Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93; T-0012, T-0013, T-0021 and all other
 unfinished items are `Backlog`. T-0021/S06 is integrated through PR #96.
-Combined active implementation WIP is zero of two.
+T-0012/S11 Stage A is now In Progress after PR #98 readiness integration.
+Combined active implementation WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -37,7 +38,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S11 schema/value observation ready) | Ready | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
+| T-0012 | Specify configuration, schema, and value semantics (S11 Stage A schema/value observation) | In Progress | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93; T-0012, T-0013, T-0021 and all other
 unfinished items are `Backlog`. T-0021/S06 is integrated through PR #96.
-T-0012/S11 Stage A is now In Progress after PR #98 readiness integration.
+T-0012/S11 Stage B is now In Progress after reviewed capture and explicit owner approval.
 Combined active implementation WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -38,7 +38,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S11 Stage A schema/value observation) | In Progress | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
+| T-0012 | Specify configuration, schema, and value semantics (S11 Stage B strict observation validation) | In Progress | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
@@ -408,3 +408,7 @@ Independent readiness review passed. Estimate 5 SP; Current refines 34 to
 remaining configuration/time/JSON/schema uncertainty exceed 34. No points are
 awarded by planning. Stage A raw capture must precede PM-reviewed expectations;
 unset/mismatched-setter observations cannot automatically become Rust policy.
+Stage A at `a95e350` has now passed primary reproduction and full raw review:
+289 events across five cases. Stage B automation passes primary and separate reproduction at `b556ce0`,
+including 39 repaired-copy and two artifact controls. Final PR-head acceptance
+and integration remain required; no slice points are awarded yet.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,8 @@ API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
 T-0012/S11 is the next decision-producing candidate: five isolated schema/value
 coupling observations using the admitted Page APIs. Independent readiness
-review passed; the slice is Ready, with no runtime evidence yet.
+review passed and PR #98 integrated the packet. Stage A is In Progress, with
+no runtime evidence yet.
 Stage A captures before expectations; diagnostic unset/mismatched-setter results
 do not select native defaults or validation. A separate reviewed decision must
 precede any schema-bound record implementation.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,13 +152,14 @@ passed at `8cb13ff`; PR #96 integrated as `56ef9e9`. S06 is Done.
 Evidence is Unit/Contract only, not a public
 API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
-T-0012/S11 is the next decision-producing candidate: five isolated schema/value
-coupling observations using the admitted Page APIs. Independent readiness
-review passed and PR #98 integrated the packet. Stage A is In Progress, with
-no runtime evidence yet.
-Stage A captures before expectations; diagnostic unset/mismatched-setter results
-do not select native defaults or validation. A separate reviewed decision must
-precede any schema-bound record implementation.
+T-0012/S11 Stage A at `a95e350` captured five outcomes and 289 events,
+independently reproduced and fully reviewed by PM. Matching/null/duplicate-name
+cases read selected values; fresh unset text fails at addRecord and string-to-long
+misuse fails at the setter. Stage B automation passes at `b556ce0`: five exact vectors, 39 repaired-copy
+controls and two artifact controls. Primary and separate reproduction pass;
+final PR-head acceptance and integration remain required.
+These diagnostic observations do not select native defaults or validation.
+A separate reviewed decision must precede schema-bound record implementation.
 
 
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -206,13 +206,14 @@ passed at `8cb13ff`; PR #96 integrated as `56ef9e9`. S06 is Done.
 Evidence is Unit/Contract only, not a public
 API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
-T-0012/S11 is the next decision-producing candidate: five isolated schema/value
-coupling observations using the admitted Page APIs. Independent readiness
-review passed and PR #98 integrated the packet. Stage A is In Progress, with
-no runtime evidence yet.
-Stage A captures before expectations; diagnostic unset/mismatched-setter results
-do not select native defaults or validation. A separate reviewed decision must
-precede any schema-bound record implementation.
+T-0012/S11 Stage A at `a95e350` captured five outcomes and 289 events,
+independently reproduced and fully reviewed by PM. Matching/null/duplicate-name
+cases read selected values; fresh unset text fails at addRecord and string-to-long
+misuse fails at the setter. Stage B automation passes at `b556ce0`: five exact vectors, 39 repaired-copy
+controls and two artifact controls. Primary and separate reproduction pass;
+final PR-head acceptance and integration remain required.
+These diagnostic observations do not select native defaults or validation.
+A separate reviewed decision must precede schema-bound record implementation.
 
 
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -208,7 +208,8 @@ API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
 T-0012/S11 is the next decision-producing candidate: five isolated schema/value
 coupling observations using the admitted Page APIs. Independent readiness
-review passed; the slice is Ready, with no runtime evidence yet.
+review passed and PR #98 integrated the packet. Stage A is In Progress, with
+no runtime evidence yet.
 Stage A captures before expectations; diagnostic unset/mismatched-setter results
 do not select native defaults or validation. A separate reviewed decision must
 precede any schema-bound record implementation.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -177,13 +177,14 @@ passed at `8cb13ff`; PR #96 integrated as `56ef9e9`. S06 is Done.
 Evidence is Unit/Contract only, not a public
 API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
-T-0012/S11 is the next decision-producing candidate: five isolated schema/value
-coupling observations using the admitted Page APIs. Independent readiness
-review passed and PR #98 integrated the packet. Stage A is In Progress, with
-no runtime evidence yet.
-Stage A captures before expectations; diagnostic unset/mismatched-setter results
-do not select native defaults or validation. A separate reviewed decision must
-precede any schema-bound record implementation.
+T-0012/S11 Stage A at `a95e350` captured five outcomes and 289 events,
+independently reproduced and fully reviewed by PM. Matching/null/duplicate-name
+cases read selected values; fresh unset text fails at addRecord and string-to-long
+misuse fails at the setter. Stage B automation passes at `b556ce0`: five exact vectors, 39 repaired-copy
+controls and two artifact controls. Primary and separate reproduction pass;
+final PR-head acceptance and integration remain required.
+These diagnostic observations do not select native defaults or validation.
+A separate reviewed decision must precede schema-bound record implementation.
 
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -179,7 +179,8 @@ API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
 T-0012/S11 is the next decision-producing candidate: five isolated schema/value
 coupling observations using the admitted Page APIs. Independent readiness
-review passed; the slice is Ready, with no runtime evidence yet.
+review passed and PR #98 integrated the packet. Stage A is In Progress, with
+no runtime evidence yet.
 Stage A captures before expectations; diagnostic unset/mismatched-setter results
 do not select native defaults or validation. A separate reviewed decision must
 precede any schema-bound record implementation.

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -364,7 +364,8 @@ API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
 T-0012/S11 is the next decision-producing candidate: five isolated schema/value
 coupling observations using the admitted Page APIs. Independent readiness
-review passed; the slice is Ready, with no runtime evidence yet.
+review passed and PR #98 integrated the packet. Stage A is In Progress, with
+no runtime evidence yet.
 Stage A captures before expectations; diagnostic unset/mismatched-setter results
 do not select native defaults or validation. A separate reviewed decision must
 precede any schema-bound record implementation.

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -362,13 +362,14 @@ passed at `8cb13ff`; PR #96 integrated as `56ef9e9`. S06 is Done.
 Evidence is Unit/Contract only, not a public
 API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
-T-0012/S11 is the next decision-producing candidate: five isolated schema/value
-coupling observations using the admitted Page APIs. Independent readiness
-review passed and PR #98 integrated the packet. Stage A is In Progress, with
-no runtime evidence yet.
-Stage A captures before expectations; diagnostic unset/mismatched-setter results
-do not select native defaults or validation. A separate reviewed decision must
-precede any schema-bound record implementation.
+T-0012/S11 Stage A at `a95e350` captured five outcomes and 289 events,
+independently reproduced and fully reviewed by PM. Matching/null/duplicate-name
+cases read selected values; fresh unset text fails at addRecord and string-to-long
+misuse fails at the setter. Stage B automation passes at `b556ce0`: five exact vectors, 39 repaired-copy
+controls and two artifact controls. Primary and separate reproduction pass;
+final PR-head acceptance and integration remain required.
+These diagnostic observations do not select native defaults or validation.
+A separate reviewed decision must precede schema-bound record implementation.
 
 
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -359,7 +359,8 @@ API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
 T-0012/S11 is the next decision-producing candidate: five isolated schema/value
 coupling observations using the admitted Page APIs. Independent readiness
-review passed; the slice is Ready, with no runtime evidence yet.
+review passed and PR #98 integrated the packet. Stage A is In Progress, with
+no runtime evidence yet.
 Stage A captures before expectations; diagnostic unset/mismatched-setter results
 do not select native defaults or validation. A separate reviewed decision must
 precede any schema-bound record implementation.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -46,7 +46,7 @@ reproduction and complete raw review authorize Stage B strict validation.
 The slice integrated through PR #91 as `34757c8`. S10's private double-storage
 decision passed readiness review and integrated through PR #92. S10 is now
 Done through PR #93. T-0021/S06 is Done through PR #96 after primary,
-independent and final-head acceptance. T-0012/S11 Stage A is now active after
+independent and final-head acceptance. T-0012/S11 Stage B is now active after
 PR #98 readiness integration; combined active WIP is one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
@@ -56,7 +56,7 @@ T-0021 parent contracts remain open.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S11 | In Progress | Stage A schema/value coupling capture before expectations |
+| T-0012/S11 | In Progress | Stage B strict validation after reviewed raw capture |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 
@@ -357,10 +357,11 @@ passed at `8cb13ff`; PR #96 integrated as `56ef9e9`. S06 is Done.
 Evidence is Unit/Contract only, not a public
 API, schema/lifecycle policy, resource guarantee or Embulk compatibility claim.
 
-T-0012/S11 is the next decision-producing candidate: five isolated schema/value
-coupling observations using the admitted Page APIs. Independent readiness
-review passed and PR #98 integrated the packet. Stage A is In Progress, with
-no runtime evidence yet.
-Stage A captures before expectations; diagnostic unset/mismatched-setter results
-do not select native defaults or validation. A separate reviewed decision must
-precede any schema-bound record implementation.
+T-0012/S11 Stage A at `a95e350` captured five outcomes and 289 events,
+independently reproduced and fully reviewed by PM. Matching/null/duplicate-name
+cases read selected values; fresh unset text fails at addRecord and string-to-long
+misuse fails at the setter. Stage B automation passes at `b556ce0`: five exact vectors, 39 repaired-copy
+controls and two artifact controls. Primary and separate reproduction pass;
+final PR-head acceptance and integration remain required.
+These diagnostic observations do not select native defaults or validation.
+A separate reviewed decision must precede schema-bound record implementation.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -46,7 +46,8 @@ reproduction and complete raw review authorize Stage B strict validation.
 The slice integrated through PR #91 as `34757c8`. S10's private double-storage
 decision passed readiness review and integrated through PR #92. S10 is now
 Done through PR #93. T-0021/S06 is Done through PR #96 after primary,
-independent and final-head acceptance; combined active WIP is zero of two. T-0012, T-0013 and
+independent and final-head acceptance. T-0012/S11 Stage A is now active after
+PR #98 readiness integration; combined active WIP is one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
@@ -55,7 +56,7 @@ T-0021 parent contracts remain open.
 | T-0011 | Done | Pinned Embulk core and SPI references; no external plugin admitted |
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
-| T-0012/S11 | Ready | Five bounded schema/value coupling observations |
+| T-0012/S11 | In Progress | Stage A schema/value coupling capture before expectations |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -288,3 +288,19 @@ integration were subsequently satisfied: final-head Demo at `994c68c` passed,
 then PR #93 integrated as `742274f`. S10 is Done and parent T-0012 returns
 to Backlog; 5 slice SP accepted, known S03–S10 total 30 SP. No public
 numeric/schema/production or parent completion claim follows.
+
+T-0021/S06 subsequently added a private synchronous owned-record handoff under
+ADR-0013. Primary, implementer and independent acceptance at `8fe820b` passed
+five focused tests and 46 workspace tests/seven intentional live ignores,
+format and strict Clippy. Final-head Demo at `8cb13ff` passed; PR #96 integrated
+as `56ef9e9`, with canonical closeout PR #97 as `201e280`. The 2-SP slice is
+Done; parent #18 remains open. No public API, lifecycle/schema policy, resource
+bound or File-to-File claim follows from the original fake consumers.
+
+Librarian and independent Tester reviewed T-0012/S11's five-case schema/value
+observation packet using existing S05/S07/S09 interface provenance. PR #98
+integrated the Ready packet as `b98d044`; Stage A is now active on a separate
+worktree. Expected outcomes are not authored before raw capture and PM review.
+Unset/mismatched setter behavior may be unsupported and cannot automatically
+define Rust defaults or validation. Parent Current refines 34 to 55, Initial 5
+unchanged; slice 5 SP, no points awarded. Project is private with WIP one of two.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -28,5 +28,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S08 private record values](T-0012-private-record-values.md) | Done (bounded slice; PR #82, `b428305`) |
 | [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | Done (bounded reference slice; PR #91, `34757c8`) |
 | [T-0012/S10 private double values](T-0012-private-double-values.md) | Done (bounded private slice; PR #93, `742274f`) |
-| [T-0012/S11 schema/value coupling](T-0012-schema-value-coupling-probe.md) | In Progress; Stage A capture only, PR #98 packet |
+| [T-0012/S11 schema/value coupling](T-0012-schema-value-coupling-probe.md) | In Progress; Stage B authorized after full primary raw review |
 | [T-0021/S06 owned-record handoff](T-0021-owned-record-handoff.md) | Done (bounded private slice; PR #96, `56ef9e9`) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -28,5 +28,5 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S08 private record values](T-0012-private-record-values.md) | Done (bounded slice; PR #82, `b428305`) |
 | [T-0012/S09 double-value observation](T-0012-double-value-probe.md) | Done (bounded reference slice; PR #91, `34757c8`) |
 | [T-0012/S10 private double values](T-0012-private-double-values.md) | Done (bounded private slice; PR #93, `742274f`) |
-| [T-0012/S11 schema/value coupling](T-0012-schema-value-coupling-probe.md) | Ready; independent readiness review passed |
+| [T-0012/S11 schema/value coupling](T-0012-schema-value-coupling-probe.md) | In Progress; Stage A capture only, PR #98 packet |
 | [T-0021/S06 owned-record handoff](T-0021-owned-record-handoff.md) | Done (bounded private slice; PR #96, `56ef9e9`) |

--- a/docs/provenance/T-0012-schema-value-coupling-probe.md
+++ b/docs/provenance/T-0012-schema-value-coupling-probe.md
@@ -1,7 +1,7 @@
 # T-0012/S11 bounded schema/value coupling observation
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: Ready; independent readiness and existing-interface provenance review passed
+- State: In Progress, Stage A only; approved packet integrated through PR #98 as `b98d044`
 - Branch: `research/t-0012-schema-value-coupling`
 - Owner: Compatibility Host Implementer; PM owns records and adoption decisions
 - Priority: P0; estimate 5 SP (implementation 2, uncertainty 1, verification 1,

--- a/docs/provenance/T-0012-schema-value-coupling-probe.md
+++ b/docs/provenance/T-0012-schema-value-coupling-probe.md
@@ -1,7 +1,7 @@
 # T-0012/S11 bounded schema/value coupling observation
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: In Progress, Stage A only; approved packet integrated through PR #98 as `b98d044`
+- State: In Progress, Stage B authorized after primary raw capture review
 - Branch: `research/t-0012-schema-value-coupling`
 - Owner: Compatibility Host Implementer; PM owns records and adoption decisions
 - Priority: P0; estimate 5 SP (implementation 2, uncertainty 1, verification 1,
@@ -81,6 +81,63 @@ Freeze source before capture. No full-success or validate-success marker may
 be emitted by capture-only mode. Stage A is not slice acceptance.
 
 ## Stage B: strict evidence gates
+
+### Stage A reviewed observations (2026-09-06)
+
+Frozen capture source: `a95e3507dd91bdf005b09e4ebfb5582c4ed21164`.
+Implementer exact capture command exited 0 with complete outer logs at
+`/private/tmp/t0012-s11-stage-a.iaeqSO`; raw evidence:
+`/private/var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/t0012-schema-value-coupling/run.vHxMGd/evidence`.
+Primary independently reproduced the command (exit 0), retaining complete logs
+at `/private/tmp/t0012-s11-primary-stage-a.GWcWHc` and raw evidence at
+`/private/var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/t0012-schema-value-coupling/run.FfEXas/evidence`.
+Primary read all 289 decoded events and compared both physical-order streams
+with only UUIDs replaced by ordinal context identities: all five matched.
+
+| Fixture | Process exit / events | Actual operation and outcome | Policy limit |
+|---|---|---|---|
+| matching | 0 / 78 | One four-cell row read as true, 37, raw double `8000000000000000`, `A\|B`; all null flags false | Selected matching assignments only |
+| explicit-null | 0 / 74 | One row; four true null flags; no typed getter invoked | Explicit null, not unset/default equivalence |
+| unset-text | 1 / 46 | `builder-add-record` throws `java.lang.NullPointerException`; no collector add/read, no run success | Fresh unset text only, not a general width/default rule |
+| wrong-setter | 1 / 31 | `builder-set-string` on long column throws `java.lang.IllegalStateException`; addRecord never called | One setter/type misuse only |
+| duplicate-name | 0 / 60 | One row; distinct positions read long 37 and string `right`, both non-null | Position-specific selected observation, not name lookup |
+
+Exact observed NPE message: `Cannot invoke "String.length()" because "value" is null`.
+Exact IllegalStateException message: `Setting a STRING value to a LONG column: number, long`.
+These diagnostics are tied to the observed executable/JVM environment, not a
+portable/public Rust diagnostic contract. Normal cases have one page/row in this
+capture, exact finish/close/reader exhaustion and one task/one cleanup report.
+Both error cases close the test-local collector/reader at zero pages/rows,
+propagate the same exception through run/control/transaction, emit an exception
+terminal and have cleanup task 1/report 0. Do not generalize Page counts.
+
+Normal cases use one UUID context with contiguous sequence including cleanup.
+Error cases have the primary context ending at terminal, then a distinct UUID
+context containing only cleanup-entry/cleanup-return with sequence 1/2. Stage B
+must preserve and validate these exact physical segments; reject reused, extra,
+interleaved or reordered contexts. This is an observed trace shape, not proof
+of class-loader/process/ownership mechanics. No internal runtime was inspected.
+
+The initial capture at `7bd305a` failed its single-context transport assumption:
+outer logs `/private/tmp/t0012-s11-stage-a.9Vc2k3`, exit 1; raw evidence
+`/private/var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/t0012-schema-value-coupling/run.ts0jwr/evidence`.
+It remains retained, not acceptance. Non-amended correction `a95e350` preserves
+observed contexts and uses only previously admitted positional schema APIs.
+
+Primary stdout SHA-256:
+`83767caad542703e5b82c9dd281c883bab6170167bdf621746d75052481b83f0`.
+Primary stderr SHA-256:
+`5ff3a462e0bad90363979ae1e680321e1b9bfa61e0adaa45734f0d4d66f0d306`;
+retained diagnostics are executable ZIP-prefix warnings and Java deprecation
+notes. LICENSE/NOTICE hashes match the admitted values in both runs.
+Java source SHA-256 `3458f499a93ad307c75395950c8ee1e3478c5eaeba706a645909124e53a305e3`;
+capture runner `598ae1c811c5bd14b8356849cef5fb65fd1f7f5bcc008be353c9c88434e071d7`;
+unavailable Stage B wrapper `f7e051f8f1f9cff08ad27b45bd7bd6d0fc1055ae24a83a4e0c6e4a9648e14cd3`.
+Temporary evidence must be reproduced if removed.
+
+PM authorizes only Stage B strict validation/control implementation from these
+reviewed full vectors. Java fixture semantics remain frozen. No native policy,
+full acceptance, Differential result or parent completion follows from Stage A.
 
 After PM records actual expectations, implement strict full and validate-only
 modes. Full runs fresh captures and artifact controls; validate-only checks

--- a/docs/provenance/T-0012-schema-value-coupling-probe.md
+++ b/docs/provenance/T-0012-schema-value-coupling-probe.md
@@ -15,6 +15,11 @@ Standing owner authority permits bounded reference instrumentation and accepted
 PR integration. One source owner; independent read-only Tester and Librarian.
 At most one active item for this serial lane; preserve all user worktrees.
 
+After an editing-policy gate rejected capture-only to full/validate expansion,
+the owner explicitly approved that expansion, including default behavior changes,
+and requested automation on 2026-09-06. This authorizes the scoped Stage B
+implementation below; it does not waive evidence, review or provenance gates.
+
 ## Dependencies
 
 T-0011 pins and S05/S07/S09 public-interface provenance are integrated.
@@ -135,12 +140,31 @@ capture runner `598ae1c811c5bd14b8356849cef5fb65fd1f7f5bcc008be353c9c88434e071d7
 unavailable Stage B wrapper `f7e051f8f1f9cff08ad27b45bd7bd6d0fc1055ae24a83a4e0c6e4a9648e14cd3`.
 Temporary evidence must be reproduced if removed.
 
+Stage B vector representation is UTF-8 JSON with compact separators and
+unescaped Unicode, no trailing newline: ordered rows contain first-occurrence
+UUID ordinal (starting at 1), integer sequence, event name and decoded payload
+array (null token becomes JSON null). No event or payload is omitted. PM
+independently recomputed these hashes from its retained Stage A capture:
+
+| Fixture | Normalized vector SHA-256 |
+|---|---|
+| matching | `db8a49da05d479051bc36b14c5a409679d09866cf9b46fb1b686aa1068e3e7de` |
+| explicit-null | `0d24d2b54aaf18ea9dbaada67e8d16d24c6e6711346cff7162979eb7e25cbeec` |
+| unset-text | `e72894c14d5558e0b56132e9506e498507568b396e130e7fd2d728d17ce7d1d1` |
+| wrong-setter | `8cbf19bd93e6c3b69f1dc1da7275bdf3b9e60790906b4400cb6d70ae064df081` |
+| duplicate-name | `90128852fbb049c8ad82d0d788e4be85cbfac3a995f7016c770bc67685d3210e` |
+
+Canonical raw spelling, UUID uniqueness, exact physical segments and provenance
+must be checked separately; normalization cannot excuse invalid raw transport.
+
 PM authorizes only Stage B strict validation/control implementation from these
 reviewed full vectors. Java fixture semantics remain frozen. No native policy,
 full acceptance, Differential result or parent completion follows from Stage A.
 
 After PM records actual expectations, implement strict full and validate-only
-modes. Full runs fresh captures and artifact controls; validate-only checks
+modes. The default full runner captures and strictly validates fresh outcomes;
+the acceptance wrapper additionally runs artifact and repaired-evidence controls.
+Validate-only checks
 existing evidence and cannot admit a runtime or emit a live/full marker.
 Bind metadata to the historical source revision and exact source paths/hashes,
 fresh capture IDs, fixture matrix, physical event order, schema/cell positions,
@@ -176,6 +200,53 @@ This is the final Stage B acceptance command, not Stage A authorization.
 
 Reference Observation / Integration plus validator Unit/Contract only.
 No native Differential comparison is added by this slice.
+
+## Stage B source acceptance
+
+Frozen source: `b556ce01bb311b96a260a2a656bb4b18056b36e2`.
+The user-approved default is `full`; explicit `capture` remains observation-only,
+and `validate` checks existing evidence without executing the reference runtime.
+The wrapper automates five exact outcome vectors, a positive validate-only
+check, 39 distinct structured rejection controls and corrupt/unavailable runtime
+controls (expected exits 3/56). Each malformed copy must change its target and
+produce exactly one specified diagnostic with exit 4 and empty stdout.
+
+Primary exact four-wrapper Demo passed with exit 0. Complete logs:
+`/private/tmp/t0012-s11-primary-demo.Tod1kD`; stdout SHA-256
+`d0d6d90bfdbf22ea5bd86e6e27193a080d0b956b960d7105e287ce1b81cee184`;
+stderr is empty. Fresh S11 evidence:
+`/private/var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/t0012-schema-value-coupling/run.quDR3j/evidence`.
+Primary separately verified all 39 distinct retained stdout/stderr/exit triplets.
+Existing S10 (12 cells/five bridge controls plus full S09), S08 (two projections/
+18 controls), and S06 (three schemas) passed unchanged.
+
+Primary quality logs: `/private/tmp/t0012-s11-primary-quality.Sl0MZJ`, exit 0:
+workspace format, 46 Rust passes/seven intentional live ignores, strict
+all-target Clippy, Bash syntax and diff check. Java compilation occurs in each
+fresh capture. Read-only final-delta review found no additional blocker.
+Separate read-only reproduction passed at the same frozen revision:
+`/private/tmp/t0012-s11-tester.TXT3jc`, five traces/39 controls/two artifact
+controls and unchanged S10/S08/S06 wrappers, all exit 0. Workspace tests
+(46 passed/seven ignored), format, strict Clippy, syntax and diff checks passed.
+The interrupted initial chained logging attempt is excluded; completed individual
+reruns supply the reproduction evidence. Reviewers previously authored intermediate
+source, so this is separate reproduction, not a blind-review claim.
+Final PR-head acceptance and integration remain required.
+
+Source SHA-256:
+
+- Java: `3458f499a93ad307c75395950c8ee1e3478c5eaeba706a645909124e53a305e3` (unchanged from Stage A);
+- runner: `442a51465f7d8ee878e08c5e49f899479a14ac6f82d48a85771b1a9a4ce5e8fa`;
+- wrapper: `bab01b3190c924403ccebad79399cf882e978572e70ac83fc4a37b7ae1722d21`.
+
+Intermediate revisions `7657195`, `1d7da8e` and `9c1ca21` did not satisfy the
+complete acceptance matrix. The initial generic control grid was replaced,
+not counted as passing coverage. Intermediate live results (including
+`/private/tmp/t0012-s11-stage-b.b4bbEm`) remain retained and superseded.
+Final controls preserve historical revision-to-source-blob checks and separately
+test canonical paths/transport, provenance, contexts and semantic alterations.
+Hash manifests detect accidental or tested changes; they are not signatures or
+proof against a malicious local process rewriting the entire evidence set.
 
 ## Provenance and admission
 

--- a/tests/t0012_schema_value_coupling_probe_test.sh
+++ b/tests/t0012_schema_value_coupling_probe_test.sh
@@ -14,6 +14,7 @@ evidence=$(sed -n 's/^T0012_COUPLING_FULL_RUN=passed|evidence=//p' "$attempt/std
 [[ -d "$evidence" && $(grep -c '^COUPLINGCASE|' "$evidence/coupling-cases.raw") == 5 ]]
 
 control=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-coupling-negative.XXXXXX")
+control=$(cd -- "$control" && pwd -P)
 cp -R "$evidence" "$control/evidence"
 printf '%s\n' 0 > "$control/evidence/matching.exit.txt"
 printf '%s\n' 1 > "$control/evidence/explicit-null.exit.txt"

--- a/tests/t0012_schema_value_coupling_probe_test.sh
+++ b/tests/t0012_schema_value_coupling_probe_test.sh
@@ -31,81 +31,261 @@ artifact_control() {
 artifact_control corrupt-hash 3
 artifact_control unavailable-runtime 56
 
-rebuild_integrity() {
-  local dir=$1 file name
-  for file in "$dir"/coupling-cases.raw "$dir"/coupling-traces.raw "$dir"/*.stdout.log \
-    "$dir"/*.stderr.log "$dir"/*.trace.raw "$dir"/*.exit.txt
-  do
-    [[ -f "$file" ]] || continue
-    name=${file##*/}
-    shasum -a 256 "$file" | awk -v name="$name" '{print name "=" $1}'
-  done | LC_ALL=C sort > "$dir/raw-evidence-hashes.txt"
-  find "$dir" -maxdepth 1 -type f ! -name integrity-manifest.txt ! -name integrity-manifest.sha256 -print |
-    LC_ALL=C sort | while IFS= read -r file
-  do
-    name=${file##*/}
-    shasum -a 256 "$file" | awk -v name="$name" '{print name "=" $1}'
-  done > "$dir/integrity-manifest.txt"
-  shasum -a 256 "$dir/integrity-manifest.txt" | awk '{print $1}' > "$dir/integrity-manifest.sha256"
-}
+# Validate-only must succeed without claiming runtime admission or a full run.
+validation="$attempt/validate"
+mkdir "$validation"
+validation_status=0
+T0012_COUPLING_MODE=validate T0012_COUPLING_EVIDENCE_DIR="$evidence" "$runner" \
+  > "$validation/stdout.log" 2> "$validation/stderr.log" || validation_status=$?
+printf '%s\n' "$validation_status" > "$validation/exit.txt"
+[[ "$validation_status" == 0 && ! -s "$validation/stderr.log" ]]
+grep -Fqx "T0012_COUPLING_VALIDATE_ONLY=passed|evidence=$evidence" "$validation/stdout.log"
+[[ $(wc -l < "$validation/stdout.log") == 1 ]]
 
-repair_and_reject() {
-  local kind=$1 change=$2 expected=$3 control status=0 dir
-  control=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-coupling-negative.XXXXXX")
-  control=$(cd -- "$control" && pwd -P)
-  dir="$control/evidence"
-  cp -R "$evidence" "$dir"
-  case "$kind:$change" in
-    fixture:missing) rm "$dir/duplicate-name.trace.raw" ;;
-    fixture:duplicate) sed -n '1p' "$dir/coupling-cases.raw" >> "$dir/coupling-cases.raw" ;;
-    fixture:reordered) { sed -n '2p' "$dir/coupling-cases.raw"; sed -n '1p' "$dir/coupling-cases.raw"; sed -n '3,5p' "$dir/coupling-cases.raw"; } > "$dir/cases.tmp"; mv "$dir/cases.tmp" "$dir/coupling-cases.raw" ;;
-    fixture:mutated) sed -i '' '1s/matching/not-matching/' "$dir/coupling-cases.raw" ;;
-    schema:missing) sed -i '' '1d' "$dir/matching.trace.raw" ;;
-    schema:duplicate) sed -n '1p' "$dir/matching.trace.raw" >> "$dir/matching.trace.raw" ;;
-    schema:reordered) { sed -n '2p' "$dir/matching.trace.raw"; sed -n '1p' "$dir/matching.trace.raw"; sed -n '3,$p' "$dir/matching.trace.raw"; } > "$dir/trace.tmp"; mv "$dir/trace.tmp" "$dir/matching.trace.raw" ;;
-    schema:mutated) sed -i '' 's/c2NoZW1hLWNvbHVtbg==/bm90LXNjaGVtYQ==/' "$dir/matching.trace.raw" ;;
-    event:missing) sed -i '' '10d' "$dir/matching.trace.raw" ;;
-    event:duplicate) sed -n '10p' "$dir/matching.trace.raw" >> "$dir/matching.trace.raw" ;;
-    event:reordered) { sed -n '11p' "$dir/matching.trace.raw"; sed -n '10p' "$dir/matching.trace.raw"; sed -n '1,9p' "$dir/matching.trace.raw"; sed -n '12,$p' "$dir/matching.trace.raw"; } > "$dir/trace.tmp"; mv "$dir/trace.tmp" "$dir/matching.trace.raw" ;;
-    event:mutated) sed -i '' '10s/.$/A/' "$dir/matching.trace.raw" ;;
-    capture:missing) sed -i '' '1d' "$dir/unset-text.trace.raw" ;;
-    capture:duplicate) sed -n '1p' "$dir/unset-text.trace.raw" >> "$dir/unset-text.trace.raw" ;;
-    capture:reordered) { sed -n '2p' "$dir/unset-text.trace.raw"; sed -n '1p' "$dir/unset-text.trace.raw"; sed -n '3,$p' "$dir/unset-text.trace.raw"; } > "$dir/trace.tmp"; mv "$dir/trace.tmp" "$dir/unset-text.trace.raw" ;;
-    capture:mutated) sed -i '' '1s/[0-9a-f]\{8\}-[0-9a-f-]\{27\}/00000000-0000-4000-8000-000000000000/' "$dir/unset-text.trace.raw" ;;
-    source:missing) rm "$dir/runner-source-path.txt" ;;
-    source:duplicate) printf '%s\n' extra >> "$dir/runner-source-path.txt" ;;
-    source:reordered) sed -i '' 's#tools/#tests/#' "$dir/runner-source-path.txt" ;;
-    source:mutated) printf '%s\n' deadbeef > "$dir/runner-source.sha256" ;;
-    hash:missing) rm "$dir/raw-evidence-hashes.txt" ;;
-    hash:duplicate) sed -n '1p' "$dir/raw-evidence-hashes.txt" >> "$dir/raw-evidence-hashes.txt" ;;
-    hash:reordered) { sed -n '2p' "$dir/raw-evidence-hashes.txt"; sed -n '1p' "$dir/raw-evidence-hashes.txt"; sed -n '3,$p' "$dir/raw-evidence-hashes.txt"; } > "$dir/hash.tmp"; mv "$dir/hash.tmp" "$dir/raw-evidence-hashes.txt" ;;
-    hash:mutated) sed -i '' '1s/.$/0/' "$dir/raw-evidence-hashes.txt" ;;
-    value:*) sed -i '' 's/QXxC/QXxD/' "$dir/matching.trace.raw" ;;
-    exception:*) sed -i '' 's/TnVsbFBvaW50ZXJFeGNlcHRpb24=/SWxsZWdhbFN0YXRlRXhjZXB0aW9u/' "$dir/unset-text.trace.raw" ;;
-    terminal:*) sed -i '' 's/dGVybWluYWw=/bm90LXRlcm1pbmFs/' "$dir/matching.trace.raw" ;;
-    cleanup:*) sed -i '' '$s/.$/A/' "$dir/wrong-setter.trace.raw" ;;
-  esac
-  rebuild_integrity "$dir"
-  T0012_COUPLING_MODE=validate T0012_COUPLING_EVIDENCE_DIR="$dir" "$runner" \
-    > "$control/stdout.log" 2> "$control/stderr.log" || status=$?
-  printf '%s\n' "$status" > "$control/exit.txt"
-  [[ "$status" == 4 && ! -s "$control/stdout.log" ]]
-  grep -Eq "^T0012_COUPLING_VALIDATION_ERROR\\|(${expected})$" "$control/stderr.log"
-  printf 'T0012_COUPLING_REPAIRED_CONTROL=%s:%s|attempt=%s|diagnostic=%s\n' "$kind" "$change" "$control" "$expected"
-}
+# Mutate structured fields, repair dependent transport hashes, and require one
+# exact diagnostic. Hash/manifest tests deliberately leave their target broken.
+PYTHONDONTWRITEBYTECODE=1 python3 - "$evidence" "$runner" "$root" <<'PY'
+import base64
+import hashlib
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
 
-# Each malformed copy has its raw and complete integrity manifests repaired, so
-# rejection reaches the intended contract check rather than an unrelated hash.
-for kind in fixture schema event capture source hash value exception terminal cleanup; do
-  for change in missing duplicate reordered mutated; do
-    case "$kind" in
-      fixture) expected='missing-artifact|case-count|case-grammar' ;;
-      schema|event|value|exception|terminal|cleanup) expected='event-count|sequence|expected-vector' ;;
-      capture) expected='event-count|sequence|capture-id' ;;
-      source) expected='missing-artifact|metadata-line|source-path|source-hash' ;;
-      hash) expected='missing-artifact|hash-manifest-grammar|hash-manifest-order|raw-hash' ;;
-    esac
-    repair_and_reject "$kind" "$change" "$expected"
-  done
-done
-printf 'T0012/S11: five exact reviewed traces and 40 repaired-copy diagnostic rejections passed|evidence=%s\n' "$evidence"
+source, runner, repository = map(pathlib.Path, __import__("sys").argv[1:])
+fixtures = ("matching", "explicit-null", "unset-text", "wrong-setter", "duplicate-name")
+raw_names = sorted(["coupling-cases.raw", "coupling-traces.raw"] + [
+    f"{fixture}.{suffix}" for fixture in fixtures
+    for suffix in ("stdout.log", "stderr.log", "trace.raw", "exit.txt")
+])
+controls = [
+    ("fixture-missing", "case-count"),
+    ("fixture-duplicate", "case-count"),
+    ("fixture-reordered", "case-grammar"),
+    ("fixture-unknown", "case-grammar"),
+    ("schema-type", "expected-vector"),
+    ("event-missing", "event-count"),
+    ("event-duplicate", "event-count"),
+    ("event-reordered", "expected-vector"),
+    ("value", "expected-vector"),
+    ("exception", "expected-vector"),
+    ("terminal", "expected-vector"),
+    ("cleanup", "expected-vector"),
+    ("capture-invalid", "capture-id"),
+    ("capture-shared", "capture-cross-fixture-uniqueness"),
+    ("capture-interleaved", "context-segments"),
+    ("sequence-leading-zero", "sequence"),
+    ("trace-no-newline", "canonical-newline"),
+    ("trace-crlf", "canonical-newline"),
+    ("foreign-trace", "foreign-trace"),
+    ("process-exit", "process-exit"),
+    ("combined-order", "combined-order"),
+    ("source-missing", "missing-artifact"),
+    ("source-path", "source-path"),
+    ("source-hash", "source-hash"),
+    ("source-revision", "source-revision"),
+    ("metadata-duplicate", "metadata-line"),
+    ("runtime-empty", "runtime-metadata"),
+    ("url", "executable-url"),
+    ("license", "license-hash"),
+    ("raw-hash-missing", "missing-artifact"),
+    ("raw-hash-duplicate", "hash-manifest-grammar"),
+    ("raw-hash-order", "hash-manifest-order"),
+    ("raw-hash-digest", "raw-hash"),
+    ("integrity-member", "integrity-hash"),
+    ("integrity-seal", "integrity-seal"),
+    ("leaf-symlink", "evidence-path"),
+    ("ancestor-symlink", "evidence-path"),
+    ("repository-path", "evidence-path"),
+    ("outside-temp", "evidence-temp"),
+]
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+def fingerprint(directory):
+    return sorted((p.name, digest(p)) for p in directory.iterdir() if p.is_file())
+
+def manifest(directory, name, names):
+    (directory / name).write_text(
+        "".join(f"{n}={digest(directory / n)}\n" for n in sorted(names)),
+        encoding="utf-8",
+    )
+
+def seal(directory):
+    names = [p.name for p in directory.iterdir()
+             if p.is_file() and p.name not in ("integrity-manifest.txt", "integrity-manifest.sha256")]
+    manifest(directory, "integrity-manifest.txt", names)
+    (directory / "integrity-manifest.sha256").write_text(
+        digest(directory / "integrity-manifest.txt") + "\n", encoding="ascii")
+
+def trace(directory, fixture):
+    return [line.split("|") for line in
+            (directory / f"{fixture}.trace.raw").read_text().splitlines()]
+
+def encode(value):
+    return base64.b64encode(value.encode()).decode()
+
+def event(rows, name):
+    matches = [i for i, row in enumerate(rows) if row[4] == name]
+    assert len(matches) == 1, (name, matches)
+    return matches[0]
+
+def put_trace(directory, fixture, rows):
+    lines = ["|".join(row) for row in rows]
+    material = "\n".join(lines) + "\n"
+    (directory / f"{fixture}.trace.raw").write_text(material)
+    log = directory / f"{fixture}.stdout.log"
+    other = [line for line in log.read_text().splitlines()
+             if not line.startswith("COUPLINGTRACE|")]
+    log.write_text("\n".join(other + lines) + "\n")
+    cases = [line.split("|") for line in (directory / "coupling-cases.raw").read_text().splitlines()]
+    cases[fixtures.index(fixture)][4] = hashlib.sha256(material.encode()).hexdigest()
+    (directory / "coupling-cases.raw").write_text(
+        "\n".join("|".join(row) for row in cases) + "\n")
+    (directory / "coupling-traces.raw").write_text("".join(
+        (directory / f"{f}.trace.raw").read_text() for f in fixtures))
+
+for name, expected in controls:
+    attempt = pathlib.Path(tempfile.mkdtemp(prefix="t0012-coupling-control.")).resolve()
+    directory = attempt / "evidence"
+    shutil.copytree(source, directory)
+    before = fingerprint(directory)
+    target = directory
+    fixture = "unset-text" if name in ("exception", "capture-interleaved") else "matching"
+    rows = trace(directory, fixture)
+    trace_changed = False
+
+    if name.startswith("fixture-"):
+        p = directory / "coupling-cases.raw"
+        cases = p.read_text().splitlines()
+        if name == "fixture-missing":
+            cases.pop()
+        elif name == "fixture-duplicate":
+            cases.append(cases[0])
+        elif name == "fixture-reordered":
+            cases[0], cases[1] = cases[1], cases[0]
+        else:
+            cases[0] = cases[0].replace("|matching|", "|unknown|")
+        p.write_text("\n".join(cases) + "\n")
+    elif name == "schema-type":
+        index = next(i for i, row in enumerate(rows) if row[4] == "schema-column")
+        rows[index][-1] = encode("long")
+        trace_changed = True
+    elif name in ("event-missing", "event-duplicate"):
+        index = event(rows, "builder-set-long-return")
+        if name == "event-missing":
+            rows.pop(index)
+        else:
+            rows.insert(index, rows[index].copy())
+        trace_changed = True
+    elif name == "event-reordered":
+        a, b = event(rows, "builder-set-long-entry"), event(rows, "builder-set-long-return")
+        rows[a], rows[b] = rows[b], rows[a]
+        for i, row in enumerate(rows, 1):
+            row[3] = str(i)
+        trace_changed = True
+    elif name in ("value", "exception", "terminal", "cleanup"):
+        key = {"value": "reader-get-string-return", "exception": "builder-add-record-exception",
+               "terminal": "terminal", "cleanup": "cleanup-return"}[name]
+        rows[event(rows, key)][-1] = encode("changed")
+        trace_changed = True
+    elif name == "capture-invalid":
+        rows[0][2] = "invalid"
+        trace_changed = True
+    elif name == "capture-shared":
+        shared = rows[0][2]
+        fixture = "explicit-null"
+        rows = trace(directory, fixture)
+        for row in rows:
+            row[2] = shared
+        trace_changed = True
+    elif name == "capture-interleaved":
+        rows[-3], rows[-2] = rows[-2], rows[-3]
+        trace_changed = True
+    elif name == "sequence-leading-zero":
+        rows[0][3] = "01"
+        trace_changed = True
+    elif name in ("trace-no-newline", "trace-crlf"):
+        p = directory / "matching.trace.raw"
+        material = p.read_bytes()
+        p.write_bytes(material[:-1] if name == "trace-no-newline" else material.replace(b"\n", b"\r\n"))
+    elif name == "foreign-trace":
+        p = directory / "matching.stdout.log"
+        p.write_text(p.read_text() + "|".join(trace(directory, "explicit-null")[0]) + "\n")
+    elif name == "process-exit":
+        (directory / "matching.exit.txt").write_text("1\n")
+    elif name == "combined-order":
+        p = directory / "coupling-traces.raw"
+        p.write_text("\n".join(reversed(p.read_text().splitlines())) + "\n")
+    elif name == "source-missing":
+        (directory / "runner-source-path.txt").unlink()
+    elif name == "source-path":
+        (directory / "runner-source-path.txt").write_text("unexpected/path\n")
+    elif name == "source-hash":
+        (directory / "runner-source.sha256").write_text("0" * 64 + "\n")
+    elif name == "source-revision":
+        (directory / "source-revision.txt").write_text("0" * 40 + "\n")
+    elif name == "metadata-duplicate":
+        p = directory / "runner-source-path.txt"
+        p.write_text(p.read_text() + "extra\n")
+    elif name == "runtime-empty":
+        (directory / "java-version.txt").write_text("")
+    elif name == "url":
+        (directory / "executable-url.txt").write_text("https://invalid.example/\n")
+    elif name == "license":
+        (directory / "LICENSE-executable").write_text("changed\n")
+    elif name == "integrity-member":
+        p = directory / "java-version.txt"
+        p.write_text(p.read_text() + "changed\n")
+    elif name == "leaf-symlink":
+        target = attempt / "alias"
+        target.symlink_to(directory, target_is_directory=True)
+    elif name == "ancestor-symlink":
+        parent = attempt / "alias-parent"
+        parent.symlink_to(attempt, target_is_directory=True)
+        target = parent / "evidence"
+    elif name == "repository-path":
+        target = repository
+    elif name == "outside-temp":
+        target = pathlib.Path("/")
+
+    if trace_changed:
+        put_trace(directory, fixture, rows)
+    manifest(directory, "raw-evidence-hashes.txt",
+             [n for n in raw_names if (directory / n).is_file()])
+    p = directory / "raw-evidence-hashes.txt"
+    if name == "raw-hash-missing":
+        p.unlink()
+    elif name == "raw-hash-duplicate":
+        lines = p.read_text().splitlines()
+        p.write_text("\n".join(lines + [lines[0]]) + "\n")
+    elif name == "raw-hash-order":
+        p.write_text("\n".join(reversed(p.read_text().splitlines())) + "\n")
+    elif name == "raw-hash-digest":
+        lines = p.read_text().splitlines()
+        lines[0] = lines[0].split("=")[0] + "=" + "0" * 64
+        p.write_text("\n".join(lines) + "\n")
+    if name != "integrity-member":
+        seal(directory)
+    if name == "integrity-seal":
+        (directory / "integrity-manifest.sha256").write_text("0" * 64 + "\n")
+
+    assert target != directory or fingerprint(directory) != before, f"no-op control: {name}"
+    completed = subprocess.run(
+        ["bash", str(runner)], cwd=repository, capture_output=True,
+        env={**os.environ, "T0012_COUPLING_MODE": "validate",
+             "T0012_COUPLING_EVIDENCE_DIR": str(target)})
+    (attempt / "stdout.log").write_bytes(completed.stdout)
+    (attempt / "stderr.log").write_bytes(completed.stderr)
+    (attempt / "exit.txt").write_text(f"{completed.returncode}\n")
+    print(f"T0012_COUPLING_CONTROL_ATTEMPT={name}|attempt={attempt}", flush=True)
+    assert completed.returncode == 4, (name, completed.returncode)
+    assert completed.stdout == b"", (name, completed.stdout)
+    assert completed.stderr == f"T0012_COUPLING_VALIDATION_ERROR|{expected}\n".encode(), (
+        name, expected, completed.stderr)
+    print(f"T0012_COUPLING_REPAIRED_CONTROL={name}|diagnostic={expected}|attempt={attempt}", flush=True)
+
+print(f"T0012/S11: five exact reviewed traces and {len(controls)} diagnostic rejections passed|evidence={source}")
+PY

--- a/tests/t0012_schema_value_coupling_probe_test.sh
+++ b/tests/t0012_schema_value_coupling_probe_test.sh
@@ -13,6 +13,24 @@ printf 'T0012_COUPLING_FULL_ATTEMPT=%s|exit=%s\n' "$attempt" "$status"
 evidence=$(sed -n 's/^T0012_COUPLING_FULL_RUN=passed|evidence=//p' "$attempt/stdout.log")
 [[ -d "$evidence" && $(grep -c '^COUPLINGCASE|' "$evidence/coupling-cases.raw") == 5 ]]
 
+artifact_control() {
+  local name=$1 expected=$2 log status=0
+  log=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-coupling-artifact.XXXXXX")
+  log=$(cd -- "$log" && pwd -P)
+  T0012_COUPLING_MODE=full T0012_COUPLING_NEGATIVE="$name" "$runner" \
+    > "$log/stdout.log" 2> "$log/stderr.log" || status=$?
+  printf '%s\n' "$status" > "$log/exit.txt"
+  [[ "$status" == "$expected" ]]
+  if [[ "$name" == corrupt-hash ]]; then
+    grep -Fqx 'pinned executable checksum mismatch' "$log/stderr.log"
+  else
+    grep -Fq 'unable to retrieve pinned executable:' "$log/stderr.log"
+  fi
+  printf 'T0012_COUPLING_ARTIFACT_CONTROL=%s|attempt=%s\n' "$name" "$log"
+}
+artifact_control corrupt-hash 3
+artifact_control unavailable-runtime 56
+
 control=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-coupling-negative.XXXXXX")
 control=$(cd -- "$control" && pwd -P)
 cp -R "$evidence" "$control/evidence"

--- a/tests/t0012_schema_value_coupling_probe_test.sh
+++ b/tests/t0012_schema_value_coupling_probe_test.sh
@@ -1,5 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-printf '%s\n' 'T-0012/S11 Stage B acceptance wrapper is unavailable pending Stage A raw review' >&2
-exit 2
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+runner="$root/tools/t0012-schema-value-coupling-probe/run.sh"
+attempt=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-coupling-full.XXXXXX")
+attempt=$(cd -- "$attempt" && pwd -P)
+status=0
+T0012_COUPLING_MODE=full "$runner" > "$attempt/stdout.log" 2> "$attempt/stderr.log" || status=$?
+printf '%s\n' "$status" > "$attempt/exit.txt"
+printf 'T0012_COUPLING_FULL_ATTEMPT=%s|exit=%s\n' "$attempt" "$status"
+[[ "$status" == 0 ]]
+evidence=$(sed -n 's/^T0012_COUPLING_FULL_RUN=passed|evidence=//p' "$attempt/stdout.log")
+[[ -d "$evidence" && $(grep -c '^COUPLINGCASE|' "$evidence/coupling-cases.raw") == 5 ]]
+
+control=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-coupling-negative.XXXXXX")
+cp -R "$evidence" "$control/evidence"
+printf '%s\n' 0 > "$control/evidence/matching.exit.txt"
+printf '%s\n' 1 > "$control/evidence/explicit-null.exit.txt"
+control_status=0
+T0012_COUPLING_MODE=validate T0012_COUPLING_EVIDENCE_DIR="$control/evidence" "$runner" \
+  > "$control/stdout.log" 2> "$control/stderr.log" || control_status=$?
+printf '%s\n' "$control_status" > "$control/exit.txt"
+[[ "$control_status" == 4 && ! -s "$control/stdout.log" ]]
+grep -Eq '^T0012_COUPLING_VALIDATION_ERROR\|(process-exit|raw-hash)$' "$control/stderr.log"
+printf 'T0012/S11: five exact reviewed traces and one repaired-copy rejection passed|evidence=%s|control=%s\n' "$evidence" "$control"

--- a/tests/t0012_schema_value_coupling_probe_test.sh
+++ b/tests/t0012_schema_value_coupling_probe_test.sh
@@ -31,15 +31,81 @@ artifact_control() {
 artifact_control corrupt-hash 3
 artifact_control unavailable-runtime 56
 
-control=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-coupling-negative.XXXXXX")
-control=$(cd -- "$control" && pwd -P)
-cp -R "$evidence" "$control/evidence"
-printf '%s\n' 0 > "$control/evidence/matching.exit.txt"
-printf '%s\n' 1 > "$control/evidence/explicit-null.exit.txt"
-control_status=0
-T0012_COUPLING_MODE=validate T0012_COUPLING_EVIDENCE_DIR="$control/evidence" "$runner" \
-  > "$control/stdout.log" 2> "$control/stderr.log" || control_status=$?
-printf '%s\n' "$control_status" > "$control/exit.txt"
-[[ "$control_status" == 4 && ! -s "$control/stdout.log" ]]
-grep -Eq '^T0012_COUPLING_VALIDATION_ERROR\|(process-exit|raw-hash)$' "$control/stderr.log"
-printf 'T0012/S11: five exact reviewed traces and one repaired-copy rejection passed|evidence=%s|control=%s\n' "$evidence" "$control"
+rebuild_integrity() {
+  local dir=$1 file name
+  for file in "$dir"/coupling-cases.raw "$dir"/coupling-traces.raw "$dir"/*.stdout.log \
+    "$dir"/*.stderr.log "$dir"/*.trace.raw "$dir"/*.exit.txt
+  do
+    [[ -f "$file" ]] || continue
+    name=${file##*/}
+    shasum -a 256 "$file" | awk -v name="$name" '{print name "=" $1}'
+  done | LC_ALL=C sort > "$dir/raw-evidence-hashes.txt"
+  find "$dir" -maxdepth 1 -type f ! -name integrity-manifest.txt ! -name integrity-manifest.sha256 -print |
+    LC_ALL=C sort | while IFS= read -r file
+  do
+    name=${file##*/}
+    shasum -a 256 "$file" | awk -v name="$name" '{print name "=" $1}'
+  done > "$dir/integrity-manifest.txt"
+  shasum -a 256 "$dir/integrity-manifest.txt" | awk '{print $1}' > "$dir/integrity-manifest.sha256"
+}
+
+repair_and_reject() {
+  local kind=$1 change=$2 expected=$3 control status=0 dir
+  control=$(mktemp -d "${TMPDIR:-/private/tmp}/t0012-coupling-negative.XXXXXX")
+  control=$(cd -- "$control" && pwd -P)
+  dir="$control/evidence"
+  cp -R "$evidence" "$dir"
+  case "$kind:$change" in
+    fixture:missing) rm "$dir/duplicate-name.trace.raw" ;;
+    fixture:duplicate) sed -n '1p' "$dir/coupling-cases.raw" >> "$dir/coupling-cases.raw" ;;
+    fixture:reordered) { sed -n '2p' "$dir/coupling-cases.raw"; sed -n '1p' "$dir/coupling-cases.raw"; sed -n '3,5p' "$dir/coupling-cases.raw"; } > "$dir/cases.tmp"; mv "$dir/cases.tmp" "$dir/coupling-cases.raw" ;;
+    fixture:mutated) sed -i '' '1s/matching/not-matching/' "$dir/coupling-cases.raw" ;;
+    schema:missing) sed -i '' '1d' "$dir/matching.trace.raw" ;;
+    schema:duplicate) sed -n '1p' "$dir/matching.trace.raw" >> "$dir/matching.trace.raw" ;;
+    schema:reordered) { sed -n '2p' "$dir/matching.trace.raw"; sed -n '1p' "$dir/matching.trace.raw"; sed -n '3,$p' "$dir/matching.trace.raw"; } > "$dir/trace.tmp"; mv "$dir/trace.tmp" "$dir/matching.trace.raw" ;;
+    schema:mutated) sed -i '' 's/c2NoZW1hLWNvbHVtbg==/bm90LXNjaGVtYQ==/' "$dir/matching.trace.raw" ;;
+    event:missing) sed -i '' '10d' "$dir/matching.trace.raw" ;;
+    event:duplicate) sed -n '10p' "$dir/matching.trace.raw" >> "$dir/matching.trace.raw" ;;
+    event:reordered) { sed -n '11p' "$dir/matching.trace.raw"; sed -n '10p' "$dir/matching.trace.raw"; sed -n '1,9p' "$dir/matching.trace.raw"; sed -n '12,$p' "$dir/matching.trace.raw"; } > "$dir/trace.tmp"; mv "$dir/trace.tmp" "$dir/matching.trace.raw" ;;
+    event:mutated) sed -i '' '10s/.$/A/' "$dir/matching.trace.raw" ;;
+    capture:missing) sed -i '' '1d' "$dir/unset-text.trace.raw" ;;
+    capture:duplicate) sed -n '1p' "$dir/unset-text.trace.raw" >> "$dir/unset-text.trace.raw" ;;
+    capture:reordered) { sed -n '2p' "$dir/unset-text.trace.raw"; sed -n '1p' "$dir/unset-text.trace.raw"; sed -n '3,$p' "$dir/unset-text.trace.raw"; } > "$dir/trace.tmp"; mv "$dir/trace.tmp" "$dir/unset-text.trace.raw" ;;
+    capture:mutated) sed -i '' '1s/[0-9a-f]\{8\}-[0-9a-f-]\{27\}/00000000-0000-4000-8000-000000000000/' "$dir/unset-text.trace.raw" ;;
+    source:missing) rm "$dir/runner-source-path.txt" ;;
+    source:duplicate) printf '%s\n' extra >> "$dir/runner-source-path.txt" ;;
+    source:reordered) sed -i '' 's#tools/#tests/#' "$dir/runner-source-path.txt" ;;
+    source:mutated) printf '%s\n' deadbeef > "$dir/runner-source.sha256" ;;
+    hash:missing) rm "$dir/raw-evidence-hashes.txt" ;;
+    hash:duplicate) sed -n '1p' "$dir/raw-evidence-hashes.txt" >> "$dir/raw-evidence-hashes.txt" ;;
+    hash:reordered) { sed -n '2p' "$dir/raw-evidence-hashes.txt"; sed -n '1p' "$dir/raw-evidence-hashes.txt"; sed -n '3,$p' "$dir/raw-evidence-hashes.txt"; } > "$dir/hash.tmp"; mv "$dir/hash.tmp" "$dir/raw-evidence-hashes.txt" ;;
+    hash:mutated) sed -i '' '1s/.$/0/' "$dir/raw-evidence-hashes.txt" ;;
+    value:*) sed -i '' 's/QXxC/QXxD/' "$dir/matching.trace.raw" ;;
+    exception:*) sed -i '' 's/TnVsbFBvaW50ZXJFeGNlcHRpb24=/SWxsZWdhbFN0YXRlRXhjZXB0aW9u/' "$dir/unset-text.trace.raw" ;;
+    terminal:*) sed -i '' 's/dGVybWluYWw=/bm90LXRlcm1pbmFs/' "$dir/matching.trace.raw" ;;
+    cleanup:*) sed -i '' '$s/.$/A/' "$dir/wrong-setter.trace.raw" ;;
+  esac
+  rebuild_integrity "$dir"
+  T0012_COUPLING_MODE=validate T0012_COUPLING_EVIDENCE_DIR="$dir" "$runner" \
+    > "$control/stdout.log" 2> "$control/stderr.log" || status=$?
+  printf '%s\n' "$status" > "$control/exit.txt"
+  [[ "$status" == 4 && ! -s "$control/stdout.log" ]]
+  grep -Eq "^T0012_COUPLING_VALIDATION_ERROR\\|(${expected})$" "$control/stderr.log"
+  printf 'T0012_COUPLING_REPAIRED_CONTROL=%s:%s|attempt=%s|diagnostic=%s\n' "$kind" "$change" "$control" "$expected"
+}
+
+# Each malformed copy has its raw and complete integrity manifests repaired, so
+# rejection reaches the intended contract check rather than an unrelated hash.
+for kind in fixture schema event capture source hash value exception terminal cleanup; do
+  for change in missing duplicate reordered mutated; do
+    case "$kind" in
+      fixture) expected='missing-artifact|case-count|case-grammar' ;;
+      schema|event|value|exception|terminal|cleanup) expected='event-count|sequence|expected-vector' ;;
+      capture) expected='event-count|sequence|capture-id' ;;
+      source) expected='missing-artifact|metadata-line|source-path|source-hash' ;;
+      hash) expected='missing-artifact|hash-manifest-grammar|hash-manifest-order|raw-hash' ;;
+    esac
+    repair_and_reject "$kind" "$change" "$expected"
+  done
+done
+printf 'T0012/S11: five exact reviewed traces and 40 repaired-copy diagnostic rejections passed|evidence=%s\n' "$evidence"

--- a/tests/t0012_schema_value_coupling_probe_test.sh
+++ b/tests/t0012_schema_value_coupling_probe_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' 'T-0012/S11 Stage B acceptance wrapper is unavailable pending Stage A raw review' >&2
+exit 2

--- a/tools/t0012-schema-value-coupling-probe/run.sh
+++ b/tools/t0012-schema-value-coupling-probe/run.sh
@@ -86,6 +86,8 @@ PY
 if [[ "$mode" == validate ]]; then
   evidence=${T0012_COUPLING_EVIDENCE_DIR:-}
   if [[ -z "$evidence" ]] || ! diagnostic=$(validate_evidence "$evidence" strict 2>&1); then
+    diagnostic=${diagnostic##*$'\n'}
+    diagnostic=${diagnostic##*: }
     printf 'T0012_COUPLING_VALIDATION_ERROR|%s\n' "${diagnostic:-missing-evidence}" >&2; exit 4
   fi
   printf 'T0012_COUPLING_VALIDATE_ONLY=passed|evidence=%s\n' "$evidence"; exit 0
@@ -222,6 +224,8 @@ cat "$evidence/coupling-cases.raw"
 if [[ "$mode" == capture ]]; then
   printf 'T0012_COUPLING_CAPTURE_ONLY=collected|evidence=%s\n' "$evidence"
 elif ! diagnostic=$(validate_evidence "$evidence" live 2>&1); then
+  diagnostic=${diagnostic##*$'\n'}
+  diagnostic=${diagnostic##*: }
   printf 'T0012_COUPLING_VALIDATION_ERROR|%s\n' "$diagnostic" >&2; exit 4
 else
   printf 'T0012_COUPLING_FULL_RUN=passed|evidence=%s\n' "$evidence"

--- a/tools/t0012-schema-value-coupling-probe/run.sh
+++ b/tools/t0012-schema-value-coupling-probe/run.sh
@@ -116,17 +116,26 @@ for fixture in fixtures:
     if not lines:
         raise SystemExit("missing trace for " + fixture)
     capture = None
+    seen = set()
+    expected_sequence = 0
     terminals = 0
-    for sequence, line in enumerate(lines, 1):
+    for line in lines:
         fields = line.split("|")
-        if len(fields) < 5 or fields[:2] != ["COUPLINGTRACE", fixture] or fields[3] != str(sequence):
+        if len(fields) < 5 or fields[:2] != ["COUPLINGTRACE", fixture]:
             raise SystemExit("invalid capture transport for " + fixture)
         parsed = uuid.UUID(fields[2])
         if str(parsed) != fields[2] or parsed.version != 4:
             raise SystemExit("invalid capture id for " + fixture)
-        capture = capture or fields[2]
         if fields[2] != capture:
-            raise SystemExit("multiple capture ids for " + fixture)
+            if fields[2] in seen:
+                raise SystemExit("reused capture id for " + fixture)
+            seen.add(fields[2])
+            capture = fields[2]
+            expected_sequence = 1
+        else:
+            expected_sequence += 1
+        if fields[3] != str(expected_sequence):
+            raise SystemExit("invalid capture sequence for " + fixture)
         terminals += fields[4] == "terminal"
     if terminals != 1:
         raise SystemExit("terminal count for " + fixture)

--- a/tools/t0012-schema-value-coupling-probe/run.sh
+++ b/tools/t0012-schema-value-coupling-probe/run.sh
@@ -41,7 +41,11 @@ def text(n,cap=8388608): return data(n,cap).decode()
 def one(n):
  s=text(n,4096); need('metadata-line',s.endswith('\n') and s.count('\n')==1); return s[:-1]
 def sha(n): return hashlib.sha256(data(n)).hexdigest()
-need('evidence-path',e.is_absolute() and e.is_dir() and not e.is_symlink() and e.resolve()==e and repo not in e.parents)
+need('evidence-path',e.is_absolute() and e.is_dir() and not e.is_symlink() and e.resolve()==e and e != repo and repo not in e.parents)
+# A resolved leaf is insufficient: a symlinked ancestor can substitute the
+# whole evidence tree after the caller's path check.
+for ancestor in (e,)+tuple(e.parents):
+ need('evidence-ancestor',not ancestor.is_symlink())
 need('stage',one('stage.txt')==('full' if level in ('live','strict') else one('stage.txt')))
 rev=one('source-revision.txt'); need('source-revision',re.fullmatch('[0-9a-f]{40}',rev)!=None)
 for label,path in paths.items():
@@ -49,19 +53,27 @@ for label,path in paths.items():
  try: blob=subprocess.run(['git','-C',str(repo),'show',rev+':'+path],check=True,stdout=subprocess.PIPE,stderr=subprocess.DEVNULL).stdout
  except subprocess.CalledProcessError: raise Bad('source-revision')
  need('source-hash',one(label+'-source.sha256')==hashlib.sha256(blob).hexdigest())
+need('fixture-source-hash',one('plugin-source.sha256')=='3458f499a93ad307c75395950c8ee1e3478c5eaeba706a645909124e53a305e3')
+need('executable-url',one('executable-url.txt')=='https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar')
+need('license-locators',one('executable-license-notice-locators.txt')=='META-INF/LICENSE|META-INF/NOTICE')
+need('plugin-coordinate',one('plugin-coordinate.txt')=='source=maven|group=org.embulk.t0012|name=t0012_coupling|version=0.0.1|artifact=embulk-input-t0012_coupling|local-only')
+for n in ('executable-manifest.txt','java-version.txt','javac-version.txt','jar-version.txt','python-version.txt','bash-version.txt','os-version.txt'):
+ need('runtime-metadata',bool(text(n,65536).strip()))
 need('executable-pin',one('executable.sha256')=='e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47')
 need('license-hash',sha('LICENSE-executable')=='cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30')
 need('notice-hash',sha('NOTICE-executable')=='27f0e45afdf10e406ee8bf478bfce38279e9087338a7981942a4a2762bcd5be8')
 need('jar-path',one('plugin-jar-path.txt')=='plugin-under-test.jar'); need('jar-hash',one('plugin-jar.sha256')==sha('plugin-under-test.jar'))
-cases=text('coupling-cases.raw').splitlines(); need('case-count',len(cases)==5); combined=[]
+case_bytes=data('coupling-cases.raw'); need('canonical-newline',case_bytes.endswith(b'\n') and b'\n\n' not in case_bytes)
+cases=case_bytes.decode().splitlines(); need('case-count',len(cases)==5); combined=[]; capture_ids=set()
 for i,f in enumerate(fs):
  row=cases[i].split('|'); ex,n=counts[f]; need('case-grammar',len(row)==5 and row[:2]==['COUPLINGCASE',f]); need('case-exit',row[2]==str(ex)); need('case-count',row[3]==str(n))
- rows=text(f+'.trace.raw').splitlines(); need('event-count',len(rows)==n); ctx={}; norm=[]
+ trace_bytes=data(f+'.trace.raw'); need('canonical-newline',trace_bytes.endswith(b'\n') and b'\n\n' not in trace_bytes)
+ rows=trace_bytes.decode().splitlines(); need('event-count',len(rows)==n); ctx={}; norm=[]
  for line in rows:
   a=line.split('|'); need('trace-grammar',len(a)>=5 and a[:2]==['COUPLINGTRACE',f])
   try: u=uuid.UUID(a[2])
   except ValueError: raise Bad('capture-id')
-  need('capture-id',str(u)==a[2] and u.version==4); ctx.setdefault(a[2],len(ctx)+1); o=ctx[a[2]]
+  need('capture-id',str(u)==a[2] and u.version==4); ctx.setdefault(a[2],len(ctx)+1); o=ctx[a[2]]; capture_ids.add(a[2])
   need('sequence',a[3].isdigit() and int(a[3])==1+sum(x[0]==o for x in norm))
   vals=[]
   for x in a[5:]:
@@ -72,14 +84,28 @@ for i,f in enumerate(fs):
  need('context-segments',len(ctx)==(2 if f in ('unset-text','wrong-setter') else 1) and (len(ctx)==1 or [x[0] for x in norm[-2:]]==[2,2]))
  need('expected-vector',hashlib.sha256(json.dumps(norm,separators=(',',':'),ensure_ascii=False).encode()).hexdigest()==vectors[f])
  material=('\n'.join(rows)+'\n').encode(); need('case-digest',row[4]==hashlib.sha256(material).hexdigest()); need('process-exit',one(f+'.exit.txt')==str(ex))
- raw=[x for x in text(f+'.stdout.log').splitlines() if x.startswith('COUPLINGTRACE|'+f+'|')]; need('raw-log',raw==rows); text(f+'.stderr.log'); combined+=rows
+ stdout=text(f+'.stdout.log').splitlines()
+ raw=[x for x in stdout if x.startswith('COUPLINGTRACE|')]
+ need('foreign-trace',raw==rows); text(f+'.stderr.log'); combined+=rows
 need('combined-order',text('coupling-traces.raw').splitlines()==combined)
+need('capture-cross-fixture-uniqueness',len(capture_ids)==sum(2 if f in ('unset-text','wrong-setter') else 1 for f in fs))
 manifest={}
 for line in text('raw-evidence-hashes.txt',65536).splitlines():
  a=line.split('='); need('hash-manifest-grammar',len(a)==2 and a[0] not in manifest and re.fullmatch('[0-9a-f]{64}',a[1])); manifest[a[0]]=a[1]
 names=['coupling-cases.raw','coupling-traces.raw']+[f+'.'+s for f in fs for s in ('stdout.log','stderr.log','trace.raw','exit.txt')]
 need('hash-manifest-count',set(names)==set(manifest))
+need('hash-manifest-order',list(manifest)==sorted(names))
 for n in names: need('raw-hash',manifest[n]==sha(n))
+# The complete integrity manifest covers every metadata and raw artifact.  Its
+# detached digest avoids a self-referential hash while still binding the list.
+integrity={}
+for line in text('integrity-manifest.txt',262144).splitlines():
+ a=line.split('=',1); need('integrity-grammar',len(a)==2 and a[0] not in integrity and re.fullmatch('[0-9a-f]{64}',a[1])); integrity[a[0]]=a[1]
+actual={p.name for p in e.iterdir() if p.is_file() and p.name not in ('integrity-manifest.txt','integrity-manifest.sha256')}
+need('integrity-count',set(integrity)==actual)
+need('integrity-order',list(integrity)==sorted(actual))
+for n,h in integrity.items(): need('integrity-hash',h==sha(n))
+need('integrity-seal',one('integrity-manifest.sha256')==hashlib.sha256(data('integrity-manifest.txt')).hexdigest())
 PY
 }
 
@@ -227,7 +253,17 @@ for file in coupling-cases.raw coupling-traces.raw \
   duplicate-name.stdout.log duplicate-name.stderr.log duplicate-name.trace.raw duplicate-name.exit.txt
 do
   shasum -a 256 "$evidence/$file" | awk -v name="$file" '{print name "=" $1}'
-done > "$evidence/raw-evidence-hashes.txt"
+done | LC_ALL=C sort > "$evidence/raw-evidence-hashes.txt"
+
+# Cover raw records and all provenance/runtime metadata without self-hashing.
+# Keep the detached manifest digest separate so validation can detect edits to
+# the manifest itself as well as edits to its members.
+find "$evidence" -maxdepth 1 -type f ! -name integrity-manifest.txt ! -name integrity-manifest.sha256 -print | LC_ALL=C sort | while IFS= read -r file
+do
+  name=${file##*/}
+  shasum -a 256 "$file" | awk -v name="$name" '{print name "=" $1}'
+done > "$evidence/integrity-manifest.txt"
+shasum -a 256 "$evidence/integrity-manifest.txt" | awk '{print $1}' > "$evidence/integrity-manifest.sha256"
 
 cat "$evidence/coupling-cases.raw"
 if [[ "$mode" == capture ]]; then

--- a/tools/t0012-schema-value-coupling-probe/run.sh
+++ b/tools/t0012-schema-value-coupling-probe/run.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+root=$(cd -- "$script_dir/../.." && pwd)
+source_file="$script_dir/src/T0012SchemaValueCouplingInputPlugin.java"
+wrapper_file="$root/tests/t0012_schema_value_coupling_probe_test.sh"
+mode=${T0012_COUPLING_MODE:-capture}
+if [[ "$mode" != capture ]]; then
+  printf '%s\n' 'T-0012/S11 Stage B is not authorized; capture mode only' >&2
+  exit 2
+fi
+
+temporary_root=${T0012_COUPLING_TEMP_ROOT:-"${TMPDIR:-/private/tmp}/t0012-schema-value-coupling"}
+resolved_root=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve())' "$temporary_root")
+resolved_repository=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve())' "$root")
+case "$resolved_root" in
+  /tmp/* | /private/tmp/* | /var/folders/* | /private/var/folders/*) ;;
+  *) printf '%s\n' 'T0012_COUPLING_TEMP_ROOT must be external' >&2; exit 2 ;;
+esac
+case "$resolved_root/" in
+  "$resolved_repository/"*) printf '%s\n' 'temporary root resolves inside repository' >&2; exit 2 ;;
+esac
+[[ ! -L "$temporary_root" && -f "$source_file" && -f "$wrapper_file" ]] || exit 2
+temporary_root=$resolved_root
+mkdir -p -- "$temporary_root"
+run_dir=$(mktemp -d "$temporary_root/run.XXXXXX")
+evidence="$run_dir/evidence"
+plugin="$run_dir/plugin"
+export EMBULK_HOME="$run_dir/embulk-home"
+repository="$EMBULK_HOME/lib/m2/repository/org/embulk/t0012/embulk-input-t0012_coupling/0.0.1"
+mkdir -p "$evidence" "$plugin/classes" "$repository"
+trap 'printf "T0012_COUPLING_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
+
+executable="$run_dir/embulk.jar"
+url=https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
+expected=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
+if ! curl --connect-timeout 15 --max-time 120 --fail --location --proto '=https' \
+  --tlsv1.2 --silent --show-error --output "$executable" "$url"
+then
+  printf 'unable to retrieve pinned executable: %s\n' "$url" >&2
+  exit 56
+fi
+actual=$(shasum -a 256 "$executable" | awk '{print $1}')
+[[ "$actual" == "$expected" ]] || { printf '%s\n' 'pinned executable checksum mismatch' >&2; exit 3; }
+
+printf '%s\n' "$url" > "$evidence/executable-url.txt"
+printf '%s\n' "$actual" > "$evidence/executable.sha256"
+unzip -p "$executable" META-INF/MANIFEST.MF > "$evidence/executable-manifest.txt" || [[ -s "$evidence/executable-manifest.txt" ]]
+unzip -p "$executable" META-INF/LICENSE > "$evidence/LICENSE-executable" || [[ -s "$evidence/LICENSE-executable" ]]
+unzip -p "$executable" META-INF/NOTICE > "$evidence/NOTICE-executable" || [[ -s "$evidence/NOTICE-executable" ]]
+printf '%s\n' 'META-INF/LICENSE|META-INF/NOTICE' > "$evidence/executable-license-notice-locators.txt"
+java -XshowSettings:properties -version > "$evidence/java-version.txt" 2>&1
+javac -version > "$evidence/javac-version.txt" 2>&1
+jar --version > "$evidence/jar-version.txt" 2>&1
+python3 --version > "$evidence/python-version.txt" 2>&1
+bash --version > "$evidence/bash-version.txt" 2>&1
+uname -a > "$evidence/os-version.txt"
+git -C "$root" rev-parse HEAD > "$evidence/source-revision.txt"
+for item in \
+  "plugin:tools/t0012-schema-value-coupling-probe/src/T0012SchemaValueCouplingInputPlugin.java" \
+  "runner:tools/t0012-schema-value-coupling-probe/run.sh" \
+  "wrapper:tests/t0012_schema_value_coupling_probe_test.sh"
+do
+  label=${item%%:*}
+  relative=${item#*:}
+  printf '%s\n' "$relative" > "$evidence/$label-source-path.txt"
+  shasum -a 256 "$root/$relative" | awk '{print $1}' > "$evidence/$label-source.sha256"
+done
+printf '%s\n' capture > "$evidence/stage.txt"
+
+javac -cp "$executable" -d "$plugin/classes" "$source_file"
+printf '%s\n' \
+  'Manifest-Version: 1.0' \
+  'Embulk-Plugin-Main-Class: T0012SchemaValueCouplingInputPlugin' \
+  'Embulk-Plugin-Category: input' \
+  'Embulk-Plugin-Type: t0012_coupling' \
+  'Embulk-Plugin-Spi-Version: 0' > "$plugin/MANIFEST.MF"
+jar_file="$repository/embulk-input-t0012_coupling-0.0.1.jar"
+jar cfm "$jar_file" "$plugin/MANIFEST.MF" -C "$plugin/classes" .
+cp "$jar_file" "$evidence/plugin-under-test.jar"
+shasum -a 256 "$evidence/plugin-under-test.jar" | awk '{print $1}' > "$evidence/plugin-jar.sha256"
+printf '%s\n' 'plugin-under-test.jar' > "$evidence/plugin-jar-path.txt"
+printf '%s\n' '<project><modelVersion>4.0.0</modelVersion><groupId>org.embulk.t0012</groupId><artifactId>embulk-input-t0012_coupling</artifactId><version>0.0.1</version></project>' > "$repository/embulk-input-t0012_coupling-0.0.1.pom"
+printf '%s\n' 'source=maven|group=org.embulk.t0012|name=t0012_coupling|version=0.0.1|artifact=embulk-input-t0012_coupling|local-only' > "$evidence/plugin-coordinate.txt"
+
+: > "$evidence/coupling-cases.raw"
+: > "$evidence/coupling-traces.raw"
+for fixture in matching explicit-null unset-text wrong-setter duplicate-name; do
+  config="$run_dir/$fixture.yml"
+  stdout="$evidence/$fixture.stdout.log"
+  stderr="$evidence/$fixture.stderr.log"
+  trace_file="$evidence/$fixture.trace.raw"
+  printf '%s\n' 'in:' '  type:' '    source: maven' '    group: org.embulk.t0012' \
+    '    name: t0012_coupling' '    version: 0.0.1' 'out:' '  type: "null"' > "$config"
+  status=0
+  T0012_COUPLING_FIXTURE="$fixture" java -jar "$executable" \
+    "-Xembulk_home=$EMBULK_HOME" run "$config" > "$stdout" 2> "$stderr" || status=$?
+  printf '%s\n' "$status" > "$evidence/$fixture.exit.txt"
+  awk -v prefix="COUPLINGTRACE|$fixture|" 'index($0, prefix) == 1' "$stdout" > "$trace_file"
+  count=$(wc -l < "$trace_file" | tr -d ' ')
+  hash=$(shasum -a 256 "$trace_file" | awk '{print $1}')
+  printf 'COUPLINGCASE|%s|%s|%s|%s\n' "$fixture" "$status" "$count" "$hash" >> "$evidence/coupling-cases.raw"
+  cat "$trace_file" >> "$evidence/coupling-traces.raw"
+done
+
+python3 - "$evidence" <<'PY'
+import pathlib
+import sys
+import uuid
+
+root = pathlib.Path(sys.argv[1])
+fixtures = ("matching", "explicit-null", "unset-text", "wrong-setter", "duplicate-name")
+for fixture in fixtures:
+    lines = (root / f"{fixture}.trace.raw").read_text(encoding="utf-8").splitlines()
+    if not lines:
+        raise SystemExit("missing trace for " + fixture)
+    capture = None
+    terminals = 0
+    for sequence, line in enumerate(lines, 1):
+        fields = line.split("|")
+        if len(fields) < 5 or fields[:2] != ["COUPLINGTRACE", fixture] or fields[3] != str(sequence):
+            raise SystemExit("invalid capture transport for " + fixture)
+        parsed = uuid.UUID(fields[2])
+        if str(parsed) != fields[2] or parsed.version != 4:
+            raise SystemExit("invalid capture id for " + fixture)
+        capture = capture or fields[2]
+        if fields[2] != capture:
+            raise SystemExit("multiple capture ids for " + fixture)
+        terminals += fields[4] == "terminal"
+    if terminals != 1:
+        raise SystemExit("terminal count for " + fixture)
+PY
+
+for file in coupling-cases.raw coupling-traces.raw \
+  matching.stdout.log matching.stderr.log matching.trace.raw matching.exit.txt \
+  explicit-null.stdout.log explicit-null.stderr.log explicit-null.trace.raw explicit-null.exit.txt \
+  unset-text.stdout.log unset-text.stderr.log unset-text.trace.raw unset-text.exit.txt \
+  wrong-setter.stdout.log wrong-setter.stderr.log wrong-setter.trace.raw wrong-setter.exit.txt \
+  duplicate-name.stdout.log duplicate-name.stderr.log duplicate-name.trace.raw duplicate-name.exit.txt
+do
+  shasum -a 256 "$evidence/$file" | awk -v name="$file" '{print name "=" $1}'
+done > "$evidence/raw-evidence-hashes.txt"
+
+cat "$evidence/coupling-cases.raw"
+printf 'T0012_COUPLING_CAPTURE_ONLY=collected|evidence=%s\n' "$evidence"

--- a/tools/t0012-schema-value-coupling-probe/run.sh
+++ b/tools/t0012-schema-value-coupling-probe/run.sh
@@ -42,6 +42,7 @@ def one(n):
  s=text(n,4096); need('metadata-line',s.endswith('\n') and s.count('\n')==1); return s[:-1]
 def sha(n): return hashlib.sha256(data(n)).hexdigest()
 need('evidence-path',e.is_absolute() and e.is_dir() and not e.is_symlink() and e.resolve()==e and e != repo and repo not in e.parents)
+need('evidence-temp',any(pathlib.Path(p) in e.parents for p in ('/private/tmp','/private/var/folders')))
 # A resolved leaf is insufficient: a symlinked ancestor can substitute the
 # whole evidence tree after the caller's path check.
 for ancestor in (e,)+tuple(e.parents):
@@ -63,18 +64,18 @@ need('executable-pin',one('executable.sha256')=='e2f298db60c2fe1cc17c377edf7215c
 need('license-hash',sha('LICENSE-executable')=='cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30')
 need('notice-hash',sha('NOTICE-executable')=='27f0e45afdf10e406ee8bf478bfce38279e9087338a7981942a4a2762bcd5be8')
 need('jar-path',one('plugin-jar-path.txt')=='plugin-under-test.jar'); need('jar-hash',one('plugin-jar.sha256')==sha('plugin-under-test.jar'))
-case_bytes=data('coupling-cases.raw'); need('canonical-newline',case_bytes.endswith(b'\n') and b'\n\n' not in case_bytes)
-cases=case_bytes.decode().splitlines(); need('case-count',len(cases)==5); combined=[]; capture_ids=set()
+case_bytes=data('coupling-cases.raw'); need('canonical-newline',case_bytes.endswith(b'\n') and b'\r' not in case_bytes and b'\n\n' not in case_bytes)
+cases=case_bytes.decode().split('\n')[:-1]; need('case-count',len(cases)==5); combined=[]; capture_ids=set()
 for i,f in enumerate(fs):
  row=cases[i].split('|'); ex,n=counts[f]; need('case-grammar',len(row)==5 and row[:2]==['COUPLINGCASE',f]); need('case-exit',row[2]==str(ex)); need('case-count',row[3]==str(n))
- trace_bytes=data(f+'.trace.raw'); need('canonical-newline',trace_bytes.endswith(b'\n') and b'\n\n' not in trace_bytes)
- rows=trace_bytes.decode().splitlines(); need('event-count',len(rows)==n); ctx={}; norm=[]
+ trace_bytes=data(f+'.trace.raw'); need('canonical-newline',trace_bytes.endswith(b'\n') and b'\r' not in trace_bytes and b'\n\n' not in trace_bytes)
+ rows=trace_bytes.decode().split('\n')[:-1]; need('event-count',len(rows)==n); ctx={}; norm=[]
  for line in rows:
   a=line.split('|'); need('trace-grammar',len(a)>=5 and a[:2]==['COUPLINGTRACE',f])
   try: u=uuid.UUID(a[2])
   except ValueError: raise Bad('capture-id')
   need('capture-id',str(u)==a[2] and u.version==4); ctx.setdefault(a[2],len(ctx)+1); o=ctx[a[2]]; capture_ids.add(a[2])
-  need('sequence',a[3].isdigit() and int(a[3])==1+sum(x[0]==o for x in norm))
+  need('sequence',a[3]==str(1+sum(x[0]==o for x in norm)))
   vals=[]
   for x in a[5:]:
    if x=='-': vals.append(None); continue
@@ -84,10 +85,10 @@ for i,f in enumerate(fs):
  need('context-segments',len(ctx)==(2 if f in ('unset-text','wrong-setter') else 1) and (len(ctx)==1 or [x[0] for x in norm[-2:]]==[2,2]))
  need('expected-vector',hashlib.sha256(json.dumps(norm,separators=(',',':'),ensure_ascii=False).encode()).hexdigest()==vectors[f])
  material=('\n'.join(rows)+'\n').encode(); need('case-digest',row[4]==hashlib.sha256(material).hexdigest()); need('process-exit',one(f+'.exit.txt')==str(ex))
- stdout=text(f+'.stdout.log').splitlines()
+ stdout=text(f+'.stdout.log').split('\n')
  raw=[x for x in stdout if x.startswith('COUPLINGTRACE|')]
  need('foreign-trace',raw==rows); text(f+'.stderr.log'); combined+=rows
-need('combined-order',text('coupling-traces.raw').splitlines()==combined)
+need('combined-order',text('coupling-traces.raw')=='\n'.join(combined)+'\n')
 need('capture-cross-fixture-uniqueness',len(capture_ids)==sum(2 if f in ('unset-text','wrong-setter') else 1 for f in fs))
 manifest={}
 for line in text('raw-evidence-hashes.txt',65536).splitlines():

--- a/tools/t0012-schema-value-coupling-probe/run.sh
+++ b/tools/t0012-schema-value-coupling-probe/run.sh
@@ -104,11 +104,20 @@ trap 'printf "T0012_COUPLING_EVIDENCE_DIR=%s\n" "$evidence"' EXIT
 executable="$run_dir/embulk.jar"
 url=https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
 expected=e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47
-if ! curl --connect-timeout 15 --max-time 120 --fail --location --proto '=https' \
+timeout=120
+if [[ ${T0012_COUPLING_NEGATIVE:-} == unavailable-runtime ]]; then
+  url=https://127.0.0.1:1/unavailable
+  timeout=2
+fi
+if ! curl --connect-timeout 15 --max-time "$timeout" --fail --location --proto '=https' \
   --tlsv1.2 --silent --show-error --output "$executable" "$url"
 then
   printf 'unable to retrieve pinned executable: %s\n' "$url" >&2
   exit 56
+fi
+if [[ ${T0012_COUPLING_NEGATIVE:-} == corrupt-hash ]]; then
+  printf x >> "$executable"
+  printf '%s\n' corrupt-copy-injected > "$evidence/negative-control.txt"
 fi
 actual=$(shasum -a 256 "$executable" | awk '{print $1}')
 [[ "$actual" == "$expected" ]] || { printf '%s\n' 'pinned executable checksum mismatch' >&2; exit 3; }

--- a/tools/t0012-schema-value-coupling-probe/run.sh
+++ b/tools/t0012-schema-value-coupling-probe/run.sh
@@ -5,9 +5,9 @@ script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 root=$(cd -- "$script_dir/../.." && pwd)
 source_file="$script_dir/src/T0012SchemaValueCouplingInputPlugin.java"
 wrapper_file="$root/tests/t0012_schema_value_coupling_probe_test.sh"
-mode=${T0012_COUPLING_MODE:-capture}
-if [[ "$mode" != capture ]]; then
-  printf '%s\n' 'T-0012/S11 Stage B is not authorized; capture mode only' >&2
+mode=${T0012_COUPLING_MODE:-full}
+if [[ "$mode" != capture && "$mode" != full && "$mode" != validate ]]; then
+  printf '%s\n' 'T0012_COUPLING_MODE must be capture, full, or validate' >&2
   exit 2
 fi
 
@@ -23,6 +23,73 @@ case "$resolved_root/" in
 esac
 [[ ! -L "$temporary_root" && -f "$source_file" && -f "$wrapper_file" ]] || exit 2
 temporary_root=$resolved_root
+
+validate_evidence() {
+PYTHONDONTWRITEBYTECODE=1 python3 - "$1" "$2" "$root" <<'PY'
+import base64,hashlib,json,pathlib,re,subprocess,sys,uuid
+e=pathlib.Path(sys.argv[1]); level=sys.argv[2]; repo=pathlib.Path(sys.argv[3]).resolve()
+fs=('matching','explicit-null','unset-text','wrong-setter','duplicate-name')
+counts={'matching':(0,78),'explicit-null':(0,74),'unset-text':(1,46),'wrong-setter':(1,31),'duplicate-name':(0,60)}
+vectors={'matching':'db8a49da05d479051bc36b14c5a409679d09866cf9b46fb1b686aa1068e3e7de','explicit-null':'0d24d2b54aaf18ea9dbaada67e8d16d24c6e6711346cff7162979eb7e25cbeec','unset-text':'e72894c14d5558e0b56132e9506e498507568b396e130e7fd2d728d17ce7d1d1','wrong-setter':'8cbf19bd93e6c3b69f1dc1da7275bdf3b9e60790906b4400cb6d70ae064df081','duplicate-name':'90128852fbb049c8ad82d0d788e4be85cbfac3a995f7016c770bc67685d3210e'}
+paths={'plugin':'tools/t0012-schema-value-coupling-probe/src/T0012SchemaValueCouplingInputPlugin.java','runner':'tools/t0012-schema-value-coupling-probe/run.sh','wrapper':'tests/t0012_schema_value_coupling_probe_test.sh'}
+class Bad(Exception):pass
+def need(x,c):
+ if not c: raise Bad(x)
+def data(n,cap=8388608):
+ p=e/n; need('artifact-path',p.parent==e and not p.is_symlink()); need('missing-artifact',p.is_file()); need('artifact-size',p.stat().st_size<=cap); return p.read_bytes()
+def text(n,cap=8388608): return data(n,cap).decode()
+def one(n):
+ s=text(n,4096); need('metadata-line',s.endswith('\n') and s.count('\n')==1); return s[:-1]
+def sha(n): return hashlib.sha256(data(n)).hexdigest()
+need('evidence-path',e.is_absolute() and e.is_dir() and not e.is_symlink() and e.resolve()==e and repo not in e.parents)
+need('stage',one('stage.txt')==('full' if level in ('live','strict') else one('stage.txt')))
+rev=one('source-revision.txt'); need('source-revision',re.fullmatch('[0-9a-f]{40}',rev)!=None)
+for label,path in paths.items():
+ need('source-path',one(label+'-source-path.txt')==path)
+ try: blob=subprocess.run(['git','-C',str(repo),'show',rev+':'+path],check=True,stdout=subprocess.PIPE,stderr=subprocess.DEVNULL).stdout
+ except subprocess.CalledProcessError: raise Bad('source-revision')
+ need('source-hash',one(label+'-source.sha256')==hashlib.sha256(blob).hexdigest())
+need('executable-pin',one('executable.sha256')=='e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47')
+need('license-hash',sha('LICENSE-executable')=='cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30')
+need('notice-hash',sha('NOTICE-executable')=='27f0e45afdf10e406ee8bf478bfce38279e9087338a7981942a4a2762bcd5be8')
+need('jar-path',one('plugin-jar-path.txt')=='plugin-under-test.jar'); need('jar-hash',one('plugin-jar.sha256')==sha('plugin-under-test.jar'))
+cases=text('coupling-cases.raw').splitlines(); need('case-count',len(cases)==5); combined=[]
+for i,f in enumerate(fs):
+ row=cases[i].split('|'); ex,n=counts[f]; need('case-grammar',len(row)==5 and row[:2]==['COUPLINGCASE',f]); need('case-exit',row[2]==str(ex)); need('case-count',row[3]==str(n))
+ rows=text(f+'.trace.raw').splitlines(); need('event-count',len(rows)==n); ctx={}; norm=[]
+ for line in rows:
+  a=line.split('|'); need('trace-grammar',len(a)>=5 and a[:2]==['COUPLINGTRACE',f])
+  try: u=uuid.UUID(a[2])
+  except ValueError: raise Bad('capture-id')
+  need('capture-id',str(u)==a[2] and u.version==4); ctx.setdefault(a[2],len(ctx)+1); o=ctx[a[2]]
+  need('sequence',a[3].isdigit() and int(a[3])==1+sum(x[0]==o for x in norm))
+  vals=[]
+  for x in a[5:]:
+   if x=='-': vals.append(None); continue
+   try: raw=base64.b64decode(x,validate=True); need('canonical-base64',base64.b64encode(raw).decode()==x); vals.append(raw.decode())
+   except Exception: raise Bad('payload')
+  norm.append([o,int(a[3]),a[4],vals])
+ need('context-segments',len(ctx)==(2 if f in ('unset-text','wrong-setter') else 1) and (len(ctx)==1 or [x[0] for x in norm[-2:]]==[2,2]))
+ need('expected-vector',hashlib.sha256(json.dumps(norm,separators=(',',':'),ensure_ascii=False).encode()).hexdigest()==vectors[f])
+ material=('\n'.join(rows)+'\n').encode(); need('case-digest',row[4]==hashlib.sha256(material).hexdigest()); need('process-exit',one(f+'.exit.txt')==str(ex))
+ raw=[x for x in text(f+'.stdout.log').splitlines() if x.startswith('COUPLINGTRACE|'+f+'|')]; need('raw-log',raw==rows); text(f+'.stderr.log'); combined+=rows
+need('combined-order',text('coupling-traces.raw').splitlines()==combined)
+manifest={}
+for line in text('raw-evidence-hashes.txt',65536).splitlines():
+ a=line.split('='); need('hash-manifest-grammar',len(a)==2 and a[0] not in manifest and re.fullmatch('[0-9a-f]{64}',a[1])); manifest[a[0]]=a[1]
+names=['coupling-cases.raw','coupling-traces.raw']+[f+'.'+s for f in fs for s in ('stdout.log','stderr.log','trace.raw','exit.txt')]
+need('hash-manifest-count',set(names)==set(manifest))
+for n in names: need('raw-hash',manifest[n]==sha(n))
+PY
+}
+
+if [[ "$mode" == validate ]]; then
+  evidence=${T0012_COUPLING_EVIDENCE_DIR:-}
+  if [[ -z "$evidence" ]] || ! diagnostic=$(validate_evidence "$evidence" strict 2>&1); then
+    printf 'T0012_COUPLING_VALIDATION_ERROR|%s\n' "${diagnostic:-missing-evidence}" >&2; exit 4
+  fi
+  printf 'T0012_COUPLING_VALIDATE_ONLY=passed|evidence=%s\n' "$evidence"; exit 0
+fi
 mkdir -p -- "$temporary_root"
 run_dir=$(mktemp -d "$temporary_root/run.XXXXXX")
 evidence="$run_dir/evidence"
@@ -67,7 +134,7 @@ do
   printf '%s\n' "$relative" > "$evidence/$label-source-path.txt"
   shasum -a 256 "$root/$relative" | awk '{print $1}' > "$evidence/$label-source.sha256"
 done
-printf '%s\n' capture > "$evidence/stage.txt"
+printf '%s\n' "$mode" > "$evidence/stage.txt"
 
 javac -cp "$executable" -d "$plugin/classes" "$source_file"
 printf '%s\n' \
@@ -152,4 +219,10 @@ do
 done > "$evidence/raw-evidence-hashes.txt"
 
 cat "$evidence/coupling-cases.raw"
-printf 'T0012_COUPLING_CAPTURE_ONLY=collected|evidence=%s\n' "$evidence"
+if [[ "$mode" == capture ]]; then
+  printf 'T0012_COUPLING_CAPTURE_ONLY=collected|evidence=%s\n' "$evidence"
+elif ! diagnostic=$(validate_evidence "$evidence" live 2>&1); then
+  printf 'T0012_COUPLING_VALIDATION_ERROR|%s\n' "$diagnostic" >&2; exit 4
+else
+  printf 'T0012_COUPLING_FULL_RUN=passed|evidence=%s\n' "$evidence"
+fi

--- a/tools/t0012-schema-value-coupling-probe/src/T0012SchemaValueCouplingInputPlugin.java
+++ b/tools/t0012-schema-value-coupling-probe/src/T0012SchemaValueCouplingInputPlugin.java
@@ -138,7 +138,8 @@ public final class T0012SchemaValueCouplingInputPlugin implements InputPlugin {
 
     private static void traceSchema(String phase, Schema schema) {
         trace("schema-fingerprint", phase, Integer.toString(schema.getColumnCount()));
-        for (Column column : schema.getColumns()) {
+        for (int index = 0; index < schema.getColumnCount(); index++) {
+            Column column = schema.getColumn(index);
             trace("schema-column", phase, Integer.toString(column.getIndex()),
                     column.getName(), column.getType().getName());
         }
@@ -161,7 +162,8 @@ public final class T0012SchemaValueCouplingInputPlugin implements InputPlugin {
             return;
         }
         if ("explicit-null".equals(FIXTURE)) {
-            for (Column column : schema.getColumns()) {
+            for (int columnIndex = 0; columnIndex < schema.getColumnCount(); columnIndex++) {
+                Column column = schema.getColumn(columnIndex);
                 String index = Integer.toString(column.getIndex());
                 trace("input-cell", "0", index, "null", null);
                 operation("builder-set-null", new String[] {"0", index}, () -> builder.setNull(column));
@@ -264,7 +266,8 @@ public final class T0012SchemaValueCouplingInputPlugin implements InputPlugin {
         }
 
         private void readRow(int page, int pageRow, int totalRow) {
-            for (Column column : schema.getColumns()) {
+            for (int columnIndex = 0; columnIndex < schema.getColumnCount(); columnIndex++) {
+                Column column = schema.getColumn(columnIndex);
                 String[] position = {Integer.toString(page), Integer.toString(pageRow),
                         Integer.toString(totalRow), Integer.toString(column.getIndex())};
                 trace("reader-is-null-entry", position);

--- a/tools/t0012-schema-value-coupling-probe/src/T0012SchemaValueCouplingInputPlugin.java
+++ b/tools/t0012-schema-value-coupling-probe/src/T0012SchemaValueCouplingInputPlugin.java
@@ -1,0 +1,385 @@
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Column;
+import org.embulk.spi.Exec;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.Page;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.PageReader;
+import org.embulk.spi.Schema;
+import org.embulk.spi.type.Types;
+
+/** Original test-only fixture for T-0012/S11 Stage A capture. */
+public final class T0012SchemaValueCouplingInputPlugin implements InputPlugin {
+    private static final String FIXTURE = required("T0012_COUPLING_FIXTURE");
+    private static final String CAPTURE = UUID.randomUUID().toString();
+    private static int sequence;
+    private static boolean terminalEmitted;
+
+    @Override
+    public ConfigDiff transaction(ConfigSource config, Control control) {
+        trace("transaction-entry", "1");
+        try {
+            Schema schema = constructSchema();
+            traceSchema("transaction", schema);
+            trace("control-run-entry", "1");
+            try {
+                control.run(Exec.newTaskSource(), schema, 1);
+                trace("control-run-return", "1");
+            } catch (RuntimeException failure) {
+                traceException("control-run-exception", failure, "1");
+                throw failure;
+            }
+            ConfigDiff result = Exec.newConfigDiff();
+            trace("transaction-return", "1");
+            terminal("success", null);
+            return result;
+        } catch (RuntimeException failure) {
+            traceException("transaction-exception", failure, "1");
+            terminal("exception", failure);
+            throw failure;
+        }
+    }
+
+    @Override
+    public ConfigDiff resume(TaskSource taskSource, Schema schema, int taskCount, Control control) {
+        trace("resume-entry", Integer.toString(taskCount));
+        ConfigDiff result = Exec.newConfigDiff();
+        trace("resume-return", Integer.toString(taskCount));
+        return result;
+    }
+
+    @Override
+    public void cleanup(TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> reports) {
+        trace("cleanup-entry", Integer.toString(taskCount), Integer.toString(reports.size()));
+        trace("cleanup-return", Integer.toString(taskCount), Integer.toString(reports.size()));
+    }
+
+    @Override
+    public TaskReport run(TaskSource taskSource, Schema schema, int taskIndex, PageOutput output) {
+        String task = Integer.toString(taskIndex);
+        String columns = Integer.toString(schema.getColumnCount());
+        trace("run-entry", task, columns);
+        traceSchema("run", schema);
+        PageBuilder builder = null;
+        RuntimeException primaryFailure = null;
+        try {
+            trace("collector-construct-entry");
+            RecordingOutput collector = new RecordingOutput(schema);
+            trace("collector-construct-return");
+            trace("builder-construct-entry");
+            builder = new PageBuilder(Exec.getBufferAllocator(), schema, collector);
+            trace("builder-construct-return");
+            PageBuilder active = builder;
+            writeFixture(active, schema);
+            operation("builder-finish", active::finish);
+            operation("builder-close", active::close);
+            builder = null;
+            operation("runtime-output-finish", () -> output.finish());
+            TaskReport report = Exec.newTaskReport();
+            trace("run-return", task);
+            return report;
+        } catch (RuntimeException failure) {
+            primaryFailure = failure;
+            traceException("run-exception", failure, task, columns);
+            throw failure;
+        } finally {
+            if (builder != null) {
+                PageBuilder pending = builder;
+                try {
+                    operation("builder-close", pending::close);
+                } catch (RuntimeException closeFailure) {
+                    if (primaryFailure != null) {
+                        primaryFailure.addSuppressed(closeFailure);
+                    } else {
+                        throw closeFailure;
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public ConfigDiff guess(ConfigSource config) {
+        trace("guess-entry");
+        ConfigDiff result = Exec.newConfigDiff();
+        trace("guess-return");
+        return result;
+    }
+
+    private static Schema constructSchema() {
+        trace("schema-construct-entry");
+        try {
+            Schema.Builder builder = Schema.builder();
+            if ("wrong-setter".equals(FIXTURE)) {
+                builder.add("number", Types.LONG);
+            } else if ("duplicate-name".equals(FIXTURE)) {
+                builder.add("shared", Types.LONG).add("shared", Types.STRING);
+            } else {
+                builder.add("flag", Types.BOOLEAN).add("number", Types.LONG)
+                        .add("ratio", Types.DOUBLE).add("text", Types.STRING);
+            }
+            Schema schema = builder.build();
+            trace("schema-construct-return");
+            return schema;
+        } catch (RuntimeException failure) {
+            traceException("schema-construct-exception", failure);
+            throw failure;
+        }
+    }
+
+    private static void traceSchema(String phase, Schema schema) {
+        trace("schema-fingerprint", phase, Integer.toString(schema.getColumnCount()));
+        for (Column column : schema.getColumns()) {
+            trace("schema-column", phase, Integer.toString(column.getIndex()),
+                    column.getName(), column.getType().getName());
+        }
+    }
+
+    private static void writeFixture(PageBuilder builder, Schema schema) {
+        trace("input-row-count", "1");
+        if ("wrong-setter".equals(FIXTURE)) {
+            Column column = schema.getColumn(0);
+            trace("input-cell", "0", "0", "string", "wrong");
+            operation("builder-set-string", new String[] {"0", "0", "wrong"},
+                    () -> builder.setString(column, "wrong"));
+            addRecord(builder);
+            return;
+        }
+        if ("duplicate-name".equals(FIXTURE)) {
+            setLong(builder, schema.getColumn(0), 0, 37L);
+            setString(builder, schema.getColumn(1), 0, "right");
+            addRecord(builder);
+            return;
+        }
+        if ("explicit-null".equals(FIXTURE)) {
+            for (Column column : schema.getColumns()) {
+                String index = Integer.toString(column.getIndex());
+                trace("input-cell", "0", index, "null", null);
+                operation("builder-set-null", new String[] {"0", index}, () -> builder.setNull(column));
+            }
+            addRecord(builder);
+            return;
+        }
+        if (!"matching".equals(FIXTURE) && !"unset-text".equals(FIXTURE)) {
+            throw new IllegalArgumentException("unknown fixture: " + FIXTURE);
+        }
+        setBoolean(builder, schema.getColumn(0), 0, true);
+        setLong(builder, schema.getColumn(1), 0, 37L);
+        setDouble(builder, schema.getColumn(2), 0, 0x8000000000000000L);
+        if ("matching".equals(FIXTURE)) {
+            setString(builder, schema.getColumn(3), 0, "A|B");
+        } else {
+            trace("input-cell-omitted", "0", "3", "string");
+        }
+        addRecord(builder);
+    }
+
+    private static void setBoolean(PageBuilder builder, Column column, int row, boolean value) {
+        String text = Boolean.toString(value);
+        trace("input-cell", Integer.toString(row), Integer.toString(column.getIndex()), "boolean", text);
+        operation("builder-set-boolean", new String[] {Integer.toString(row), Integer.toString(column.getIndex()), text},
+                () -> builder.setBoolean(column, value));
+    }
+
+    private static void setLong(PageBuilder builder, Column column, int row, long value) {
+        String text = Long.toString(value);
+        trace("input-cell", Integer.toString(row), Integer.toString(column.getIndex()), "long", text);
+        operation("builder-set-long", new String[] {Integer.toString(row), Integer.toString(column.getIndex()), text},
+                () -> builder.setLong(column, value));
+    }
+
+    private static void setDouble(PageBuilder builder, Column column, int row, long bits) {
+        String text = String.format("%016x", bits);
+        trace("input-cell", Integer.toString(row), Integer.toString(column.getIndex()), "double-bits", text);
+        operation("builder-set-double", new String[] {Integer.toString(row), Integer.toString(column.getIndex()), text},
+                () -> builder.setDouble(column, Double.longBitsToDouble(bits)));
+    }
+
+    private static void setString(PageBuilder builder, Column column, int row, String value) {
+        trace("input-cell", Integer.toString(row), Integer.toString(column.getIndex()), "string", value);
+        operation("builder-set-string", new String[] {Integer.toString(row), Integer.toString(column.getIndex()), value},
+                () -> builder.setString(column, value));
+    }
+
+    private static void addRecord(PageBuilder builder) {
+        operation("builder-add-record", new String[] {"0"}, builder::addRecord);
+    }
+
+    private static final class RecordingOutput implements PageOutput {
+        private final Schema schema;
+        private final PageReader reader;
+        private int pages;
+        private int rows;
+
+        RecordingOutput(Schema schema) {
+            this.schema = schema;
+            trace("reader-construct-entry");
+            try {
+                this.reader = new PageReader(schema);
+                trace("reader-construct-return");
+            } catch (RuntimeException failure) {
+                traceException("reader-construct-exception", failure);
+                throw failure;
+            }
+        }
+
+        @Override
+        public void add(Page page) {
+            int pageIndex = pages++;
+            trace("collector-add-entry", Integer.toString(pageIndex));
+            try {
+                operation("reader-set-page", new String[] {Integer.toString(pageIndex)}, () -> reader.setPage(page));
+                int pageRow = 0;
+                while (next(pageIndex, pageRow)) {
+                    readRow(pageIndex, pageRow, rows);
+                    pageRow++;
+                    rows++;
+                }
+                trace("collector-add-return", Integer.toString(pageIndex), Integer.toString(pageRow), Integer.toString(rows));
+            } catch (RuntimeException failure) {
+                traceException("collector-add-exception", failure, Integer.toString(pageIndex));
+                throw failure;
+            }
+        }
+
+        private boolean next(int page, int row) {
+            trace("reader-next-record-entry", Integer.toString(page), Integer.toString(row));
+            try {
+                boolean result = reader.nextRecord();
+                trace("reader-next-record-return", Integer.toString(page), Integer.toString(row), Boolean.toString(result));
+                return result;
+            } catch (RuntimeException failure) {
+                traceException("reader-next-record-exception", failure, Integer.toString(page), Integer.toString(row));
+                throw failure;
+            }
+        }
+
+        private void readRow(int page, int pageRow, int totalRow) {
+            for (Column column : schema.getColumns()) {
+                String[] position = {Integer.toString(page), Integer.toString(pageRow),
+                        Integer.toString(totalRow), Integer.toString(column.getIndex())};
+                trace("reader-is-null-entry", position);
+                boolean isNull;
+                try {
+                    isNull = reader.isNull(column);
+                    trace("reader-is-null-return", position[0], position[1], position[2], position[3], Boolean.toString(isNull));
+                } catch (RuntimeException failure) {
+                    traceException("reader-is-null-exception", failure, position);
+                    throw failure;
+                }
+                if (isNull) {
+                    trace("cell-null", position);
+                } else {
+                    readValue(column, position);
+                }
+            }
+        }
+
+        private void readValue(Column column, String[] position) {
+            String type = column.getType().getName();
+            String event = "reader-get-" + type;
+            trace(event + "-entry", position);
+            try {
+                String value;
+                if (Types.BOOLEAN.equals(column.getType())) {
+                    value = Boolean.toString(reader.getBoolean(column));
+                } else if (Types.LONG.equals(column.getType())) {
+                    value = Long.toString(reader.getLong(column));
+                } else if (Types.DOUBLE.equals(column.getType())) {
+                    value = String.format("%016x", Double.doubleToRawLongBits(reader.getDouble(column)));
+                } else if (Types.STRING.equals(column.getType())) {
+                    value = reader.getString(column);
+                } else {
+                    throw new IllegalStateException("unsupported declared type: " + type);
+                }
+                trace(event + "-return", position[0], position[1], position[2], position[3], value);
+            } catch (RuntimeException failure) {
+                traceException(event + "-exception", failure, position);
+                throw failure;
+            }
+        }
+
+        @Override
+        public void finish() {
+            trace("collector-finish-entry", Integer.toString(pages), Integer.toString(rows));
+            trace("collector-finish-return", Integer.toString(pages), Integer.toString(rows));
+        }
+
+        @Override
+        public void close() {
+            trace("collector-close-entry", Integer.toString(pages), Integer.toString(rows));
+            try {
+                operation("reader-close", new String[] {Integer.toString(pages), Integer.toString(rows)}, reader::close);
+                trace("collector-close-return", Integer.toString(pages), Integer.toString(rows));
+            } catch (RuntimeException failure) {
+                traceException("collector-close-exception", failure, Integer.toString(pages), Integer.toString(rows));
+                throw failure;
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface Operation { void run(); }
+
+    private static void operation(String name, Operation operation) {
+        operation(name, new String[0], operation);
+    }
+
+    private static void operation(String name, String[] values, Operation operation) {
+        trace(name + "-entry", values);
+        try {
+            operation.run();
+            trace(name + "-return", values);
+        } catch (RuntimeException failure) {
+            traceException(name + "-exception", failure, values);
+            throw failure;
+        }
+    }
+
+    private static synchronized void terminal(String outcome, RuntimeException failure) {
+        if (terminalEmitted) return;
+        terminalEmitted = true;
+        trace("terminal", outcome, failure == null ? null : failure.getClass().getName(),
+                failure == null ? null : failure.getMessage());
+    }
+
+    private static void traceException(String event, RuntimeException failure, String... prefix) {
+        String[] values = new String[prefix.length + 2];
+        System.arraycopy(prefix, 0, values, 0, prefix.length);
+        values[prefix.length] = failure.getClass().getName();
+        values[prefix.length + 1] = failure.getMessage();
+        trace(event, values);
+    }
+
+    private static synchronized void trace(String event, String... values) {
+        StringBuilder line = new StringBuilder("COUPLINGTRACE|").append(FIXTURE).append('|')
+                .append(CAPTURE).append('|').append(++sequence).append('|').append(event);
+        for (String value : values) line.append('|').append(encode(value));
+        System.out.println(line);
+        if (System.out.checkError()) throw new EvidenceWriteError("unable to write coupling evidence");
+    }
+
+    private static String encode(String value) {
+        if (value == null) return "-";
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String required(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isEmpty()) throw new IllegalStateException("missing environment: " + name);
+        return value;
+    }
+
+    private static final class EvidenceWriteError extends Error {
+        EvidenceWriteError(String message) { super(message); }
+    }
+}


### PR DESCRIPTION
Refs #15. Implements T-0012/S11 under docs/provenance/T-0012-schema-value-coupling-probe.md. Adds default full capture and strict validation, validate-only mode, five exact reference vectors, 39 structured negative controls and two artifact controls. Primary and separate reproduction passed at b556ce0; 46 workspace tests passed, seven intentionally ignored; format and strict Clippy passed. Final-head Demo will be recorded before integration. No native schema policy, public API, parent completion, or legal clearance claim.