### PR TITLE
feat(t-0023): add private positional logical batch admission

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,9 @@ Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93; T-0012, T-0013, T-0021 and all other
 unfinished items are `Backlog`. T-0021/S06 is integrated through PR #96.
-T-0012/S11 is Done through PR #99 after final-head acceptance.
-Combined active implementation WIP is zero of two.
+T-0012/S11 is Done through PR #99 after final-head acceptance. T-0023/S01 is
+In Progress under accepted ADR-0014 as the next pullable private batch-admission
+slice. Combined active implementation WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -49,7 +50,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
 | T-0021 | Define workspace boundaries and core traits (S01–S06 integrated; remaining contracts queued) | Backlog | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
-| T-0023 | Implement logical schema and Arrow-compatible batches | Backlog | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
+| T-0023 | Implement logical schema and Arrow-compatible batches (S01 In Progress) | In Progress | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0025 | Implement atomic transaction and resume state | Backlog | P1 | 8 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
 | T-0026 | Implement structured errors and observability | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |

--- a/TODO.md
+++ b/TODO.md
@@ -13,8 +13,8 @@ integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93; T-0012, T-0013, T-0021 and all other
 unfinished items are `Backlog`. T-0021/S06 is integrated through PR #96.
 T-0012/S11 is Done through PR #99 after final-head acceptance. T-0023/S01 is
-In Progress under accepted ADR-0014 as the next pullable private batch-admission
-slice. Combined active implementation WIP is one of two.
+Review in PR #101 at frozen source `9f842509`; final acceptance and separate
+Tester reproduction remain pending. Combined active implementation WIP is one of two.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
@@ -50,7 +50,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
 | T-0021 | Define workspace boundaries and core traits (S01–S06 integrated; remaining contracts queued) | Backlog | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
-| T-0023 | Implement logical schema and Arrow-compatible batches (S01 In Progress) | In Progress | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
+| T-0023 | Implement logical schema and Arrow-compatible batches (S01 Review) | Review | P1 | 8 | T-0012, T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0025 | Implement atomic transaction and resume state | Backlog | P1 | 8 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
 | T-0026 | Implement structured errors and observability | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -21,6 +21,14 @@ mod logical_schema;
 )]
 mod logical_record;
 
+// This is deliberately private: it validates only the selected internal
+// schema/value categories before any physical batch representation exists.
+#[allow(
+    dead_code,
+    reason = "T-0023/S01 is a private positional admission boundary without a consumer"
+)]
+mod logical_batch;
+
 // This remains a private ownership experiment, not a plugin or lifecycle API.
 #[allow(
     dead_code,

--- a/crates/emburk-core/src/logical_batch.rs
+++ b/crates/emburk-core/src/logical_batch.rs
@@ -1,0 +1,454 @@
+//! Private positional admission of accepted logical schema and record values.
+//!
+//! This has no physical encoding, source policy, public API, or lifecycle role.
+
+use crate::{
+    logical_record::{LogicalRecord, LogicalValue},
+    logical_schema::{LogicalSchema, LogicalType},
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LogicalValueCategory {
+    Null,
+    Boolean,
+    Signed64,
+    Float64,
+    Text,
+}
+
+impl LogicalValue {
+    fn category(&self) -> LogicalValueCategory {
+        match self {
+            Self::Null => LogicalValueCategory::Null,
+            Self::Boolean(_) => LogicalValueCategory::Boolean,
+            Self::Signed64(_) => LogicalValueCategory::Signed64,
+            Self::Float64(_) => LogicalValueCategory::Float64,
+            Self::Text(_) => LogicalValueCategory::Text,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum LogicalBatchError {
+    UnsupportedSchemaType {
+        column_index: usize,
+        actual: LogicalType,
+    },
+    RowWidth {
+        row_index: usize,
+        expected: usize,
+        actual: usize,
+    },
+    CellType {
+        row_index: usize,
+        column_index: usize,
+        expected: LogicalType,
+        actual: LogicalValueCategory,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LogicalBatch {
+    schema: LogicalSchema,
+    rows: Vec<LogicalRecord>,
+}
+
+impl LogicalBatch {
+    fn try_new(schema: LogicalSchema, rows: Vec<LogicalRecord>) -> Result<Self, LogicalBatchError> {
+        for (column_index, column) in schema.columns().enumerate() {
+            if matches!(
+                column.logical_type(),
+                LogicalType::Timestamp | LogicalType::Json
+            ) {
+                return Err(LogicalBatchError::UnsupportedSchemaType {
+                    column_index,
+                    actual: column.logical_type(),
+                });
+            }
+        }
+
+        let expected = schema.columns().len();
+        for (row_index, row) in rows.iter().enumerate() {
+            let actual = row.cells().len();
+            if actual != expected {
+                return Err(LogicalBatchError::RowWidth {
+                    row_index,
+                    expected,
+                    actual,
+                });
+            }
+        }
+
+        for (row_index, row) in rows.iter().enumerate() {
+            for (column_index, (column, cell)) in schema.columns().zip(row.cells()).enumerate() {
+                let actual = cell.category();
+                if actual != LogicalValueCategory::Null
+                    && !matches_type(column.logical_type(), actual)
+                {
+                    return Err(LogicalBatchError::CellType {
+                        row_index,
+                        column_index,
+                        expected: column.logical_type(),
+                        actual,
+                    });
+                }
+            }
+        }
+
+        Ok(Self { schema, rows })
+    }
+
+    fn schema(&self) -> &LogicalSchema {
+        &self.schema
+    }
+
+    fn rows(&self) -> impl ExactSizeIterator<Item = &LogicalRecord> {
+        self.rows.iter()
+    }
+}
+
+fn matches_type(expected: LogicalType, actual: LogicalValueCategory) -> bool {
+    matches!(
+        (expected, actual),
+        (LogicalType::Boolean, LogicalValueCategory::Boolean)
+            | (LogicalType::Signed64, LogicalValueCategory::Signed64)
+            | (LogicalType::Float64, LogicalValueCategory::Float64)
+            | (LogicalType::Text, LogicalValueCategory::Text)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        logical_record::Float64Bits,
+        logical_schema::{LogicalColumn, LogicalType},
+    };
+
+    fn schema(types: &[LogicalType]) -> LogicalSchema {
+        LogicalSchema::new(
+            types
+                .iter()
+                .enumerate()
+                .map(|(index, kind)| LogicalColumn::new(format!("column-{index}"), *kind))
+                .collect(),
+        )
+    }
+
+    fn row(cells: Vec<LogicalValue>) -> LogicalRecord {
+        LogicalRecord::new(cells)
+    }
+
+    fn sample(kind: LogicalType) -> LogicalValue {
+        match kind {
+            LogicalType::Boolean => LogicalValue::Boolean(true),
+            LogicalType::Signed64 => LogicalValue::Signed64(37),
+            LogicalType::Float64 => LogicalValue::Float64(Float64Bits::from_float(-0.0)),
+            LogicalType::Text => LogicalValue::Text("owned 🦀 text".to_owned()),
+            LogicalType::Timestamp | LogicalType::Json => LogicalValue::Null,
+        }
+    }
+
+    #[test]
+    fn admits_exact_selected_matching_and_null_rows_without_reencoding() {
+        let mut source_text = "A|B".to_owned();
+        let schema = LogicalSchema::new(vec![
+            LogicalColumn::new("flag", LogicalType::Boolean),
+            LogicalColumn::new("number", LogicalType::Signed64),
+            LogicalColumn::new("ratio", LogicalType::Float64),
+            LogicalColumn::new("text", LogicalType::Text),
+        ]);
+        let batch = LogicalBatch::try_new(
+            schema,
+            vec![
+                row(vec![
+                    LogicalValue::Boolean(true),
+                    LogicalValue::Signed64(37),
+                    LogicalValue::Float64(Float64Bits::from_float(-0.0)),
+                    LogicalValue::Text(source_text.clone()),
+                ]),
+                row(vec![
+                    LogicalValue::Null,
+                    LogicalValue::Null,
+                    LogicalValue::Null,
+                    LogicalValue::Null,
+                ]),
+            ],
+        )
+        .expect("selected schema/value rows admit");
+        source_text.clear();
+
+        let columns: Vec<_> = batch.schema().columns().collect();
+        assert_eq!(
+            columns
+                .iter()
+                .map(|column| (column.name(), column.logical_type()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("flag", LogicalType::Boolean),
+                ("number", LogicalType::Signed64),
+                ("ratio", LogicalType::Float64),
+                ("text", LogicalType::Text),
+            ]
+        );
+        let rows: Vec<_> = batch.rows().collect();
+        assert_eq!(
+            rows.iter()
+                .map(|row| row.cells().cloned().collect::<Vec<_>>())
+                .collect::<Vec<_>>(),
+            vec![
+                vec![
+                    LogicalValue::Boolean(true),
+                    LogicalValue::Signed64(37),
+                    LogicalValue::Float64(Float64Bits::from_float(-0.0)),
+                    LogicalValue::Text("A|B".to_owned()),
+                ],
+                vec![
+                    LogicalValue::Null,
+                    LogicalValue::Null,
+                    LogicalValue::Null,
+                    LogicalValue::Null,
+                ],
+            ]
+        );
+        match rows[0].cells().nth(2) {
+            Some(LogicalValue::Float64(value)) => assert_eq!(value.bits(), 0x8000_0000_0000_0000),
+            other => panic!("expected Float64, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn admits_exact_selected_duplicate_name_positions() {
+        let batch = LogicalBatch::try_new(
+            LogicalSchema::new(vec![
+                LogicalColumn::new("shared", LogicalType::Signed64),
+                LogicalColumn::new("shared", LogicalType::Text),
+            ]),
+            vec![row(vec![
+                LogicalValue::Signed64(37),
+                LogicalValue::Text("right".to_owned()),
+            ])],
+        )
+        .expect("duplicate names remain positional");
+        assert_eq!(
+            batch
+                .schema()
+                .columns()
+                .map(|column| (column.name(), column.logical_type()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("shared", LogicalType::Signed64),
+                ("shared", LogicalType::Text),
+            ]
+        );
+        assert_eq!(
+            batch
+                .rows()
+                .next()
+                .expect("one row")
+                .cells()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                LogicalValue::Signed64(37),
+                LogicalValue::Text("right".to_owned())
+            ]
+        );
+        assert_eq!(batch.rows().len(), 1);
+    }
+
+    #[test]
+    fn admits_empty_schema_with_zero_or_one_empty_row() {
+        assert!(LogicalBatch::try_new(schema(&[]), vec![]).is_ok());
+        let batch =
+            LogicalBatch::try_new(schema(&[]), vec![row(vec![])]).expect("empty row admits");
+        assert_eq!(batch.rows().len(), 1);
+        assert_eq!(batch.rows().next().expect("row").cells().len(), 0);
+    }
+
+    #[test]
+    fn rejects_timestamp_and_json_before_width_or_values_even_when_null() {
+        for (types, expected_index, expected_type) in [
+            (
+                [LogicalType::Timestamp, LogicalType::Json],
+                0,
+                LogicalType::Timestamp,
+            ),
+            (
+                [LogicalType::Boolean, LogicalType::Json],
+                1,
+                LogicalType::Json,
+            ),
+        ] {
+            assert_eq!(
+                LogicalBatch::try_new(
+                    schema(&types),
+                    vec![row(vec![LogicalValue::Null; types.len()])]
+                ),
+                Err(LogicalBatchError::UnsupportedSchemaType {
+                    column_index: expected_index,
+                    actual: expected_type,
+                })
+            );
+        }
+        assert_eq!(
+            LogicalBatch::try_new(schema(&[LogicalType::Timestamp]), vec![]),
+            Err(LogicalBatchError::UnsupportedSchemaType {
+                column_index: 0,
+                actual: LogicalType::Timestamp,
+            })
+        );
+        assert_eq!(
+            LogicalBatch::try_new(schema(&[LogicalType::Timestamp]), vec![row(vec![])]),
+            Err(LogicalBatchError::UnsupportedSchemaType {
+                column_index: 0,
+                actual: LogicalType::Timestamp,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_widths_before_any_value_type_check() {
+        let expected = 2;
+        assert_eq!(
+            LogicalBatch::try_new(
+                schema(&[LogicalType::Boolean, LogicalType::Text]),
+                vec![
+                    row(vec![]),
+                    row(vec![
+                        LogicalValue::Signed64(9),
+                        LogicalValue::Text("ok".into())
+                    ])
+                ],
+            ),
+            Err(LogicalBatchError::RowWidth {
+                row_index: 0,
+                expected,
+                actual: 0
+            })
+        );
+        assert_eq!(
+            LogicalBatch::try_new(
+                schema(&[LogicalType::Boolean, LogicalType::Text]),
+                vec![
+                    row(vec![
+                        LogicalValue::Signed64(9),
+                        LogicalValue::Text("wrong first".into())
+                    ]),
+                    row(vec![LogicalValue::Boolean(true)]),
+                ],
+            ),
+            Err(LogicalBatchError::RowWidth {
+                row_index: 1,
+                expected,
+                actual: 1,
+            })
+        );
+        assert_eq!(
+            LogicalBatch::try_new(
+                schema(&[LogicalType::Boolean, LogicalType::Text]),
+                vec![
+                    row(vec![LogicalValue::Boolean(true)]),
+                    row(vec![
+                        LogicalValue::Boolean(true),
+                        LogicalValue::Text("ok".into()),
+                        LogicalValue::Null
+                    ])
+                ],
+            ),
+            Err(LogicalBatchError::RowWidth {
+                row_index: 0,
+                expected,
+                actual: 1
+            })
+        );
+        assert_eq!(
+            LogicalBatch::try_new(
+                schema(&[LogicalType::Boolean]),
+                vec![
+                    row(vec![LogicalValue::Boolean(true)]),
+                    row(vec![LogicalValue::Boolean(false), LogicalValue::Null])
+                ],
+            ),
+            Err(LogicalBatchError::RowWidth {
+                row_index: 1,
+                expected: 1,
+                actual: 2
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_all_twelve_cross_type_pairings() {
+        let categories = [
+            LogicalType::Boolean,
+            LogicalType::Signed64,
+            LogicalType::Float64,
+            LogicalType::Text,
+        ];
+        for expected in categories {
+            for actual_type in categories {
+                if expected == actual_type {
+                    continue;
+                }
+                let actual = sample(actual_type);
+                assert_eq!(
+                    LogicalBatch::try_new(schema(&[expected]), vec![row(vec![actual])]),
+                    Err(LogicalBatchError::CellType {
+                        row_index: 0,
+                        column_index: 0,
+                        expected,
+                        actual: match actual_type {
+                            LogicalType::Boolean => LogicalValueCategory::Boolean,
+                            LogicalType::Signed64 => LogicalValueCategory::Signed64,
+                            LogicalType::Float64 => LogicalValueCategory::Float64,
+                            LogicalType::Text => LogicalValueCategory::Text,
+                            LogicalType::Timestamp | LogicalType::Json => unreachable!(),
+                        },
+                    })
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reports_the_first_row_major_value_error_after_all_widths_pass() {
+        assert_eq!(
+            LogicalBatch::try_new(
+                schema(&[LogicalType::Boolean, LogicalType::Signed64]),
+                vec![
+                    row(vec![
+                        LogicalValue::Boolean(true),
+                        LogicalValue::Text("row zero column one".into())
+                    ]),
+                    row(vec![
+                        LogicalValue::Text("later".into()),
+                        LogicalValue::Boolean(false)
+                    ]),
+                ],
+            ),
+            Err(LogicalBatchError::CellType {
+                row_index: 0,
+                column_index: 1,
+                expected: LogicalType::Signed64,
+                actual: LogicalValueCategory::Text,
+            })
+        );
+        assert_eq!(
+            LogicalBatch::try_new(
+                schema(&[LogicalType::Boolean]),
+                vec![
+                    row(vec![LogicalValue::Boolean(true)]),
+                    row(vec![LogicalValue::Signed64(1)]),
+                    row(vec![LogicalValue::Text("later".into())]),
+                ],
+            ),
+            Err(LogicalBatchError::CellType {
+                row_index: 1,
+                column_index: 0,
+                expected: LogicalType::Boolean,
+                actual: LogicalValueCategory::Signed64,
+            })
+        );
+    }
+}

--- a/crates/emburk-core/src/logical_schema.rs
+++ b/crates/emburk-core/src/logical_schema.rs
@@ -1,7 +1,7 @@
 //! Private, ordered logical schema storage with no physical encoding policy.
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum LogicalType {
+pub(super) enum LogicalType {
     Boolean,
     Signed64,
     Float64,
@@ -11,31 +11,39 @@ enum LogicalType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct LogicalColumn {
+pub(super) struct LogicalColumn {
     name: String,
     logical_type: LogicalType,
 }
 
 impl LogicalColumn {
-    fn new(name: impl Into<String>, logical_type: LogicalType) -> Self {
+    pub(super) fn new(name: impl Into<String>, logical_type: LogicalType) -> Self {
         Self {
             name: name.into(),
             logical_type,
         }
     }
+
+    pub(super) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(super) fn logical_type(&self) -> LogicalType {
+        self.logical_type
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct LogicalSchema {
+pub(super) struct LogicalSchema {
     columns: Vec<LogicalColumn>,
 }
 
 impl LogicalSchema {
-    fn new(columns: Vec<LogicalColumn>) -> Self {
+    pub(super) fn new(columns: Vec<LogicalColumn>) -> Self {
         Self { columns }
     }
 
-    fn columns(&self) -> impl ExactSizeIterator<Item = &LogicalColumn> {
+    pub(super) fn columns(&self) -> impl ExactSizeIterator<Item = &LogicalColumn> {
         self.columns.iter()
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -162,6 +162,11 @@ The bounded observation slice is Done; parent contracts remain open.
 These diagnostic observations do not select native defaults or validation.
 A separate reviewed decision must precede schema-bound record implementation.
 
+T-0023/S01 is In Progress under accepted ADR-0014. It permits one private owned
+logical batch with positional admission over selected Boolean, Signed64,
+Float64 and Text categories. No Arrow/Page, lifecycle, public API or transfer
+boundary exists.
+
 
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -162,10 +162,10 @@ The bounded observation slice is Done; parent contracts remain open.
 These diagnostic observations do not select native defaults or validation.
 A separate reviewed decision must precede schema-bound record implementation.
 
-T-0023/S01 is In Progress under accepted ADR-0014. It permits one private owned
-logical batch with positional admission over selected Boolean, Signed64,
-Float64 and Text categories. No Arrow/Page, lifecycle, public API or transfer
-boundary exists.
+T-0023/S01 is Review in PR #101 at frozen source `9f842509`. It implements one
+private owned logical batch with positional admission over selected Boolean,
+Signed64, Float64 and Text categories; final acceptance remains pending. No
+Arrow/Page, lifecycle, public API or transfer boundary exists.
 
 
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -216,9 +216,9 @@ The bounded observation slice is Done; parent contracts remain open.
 These diagnostic observations do not select native defaults or validation.
 A separate reviewed decision must precede schema-bound record implementation.
 
-T-0023/S01 is In Progress under accepted ADR-0014. Its intended evidence is
-Unit/Contract for an internal positional batch invariant only; it adds no
-native Differential or supported Embulk schema/value claim.
+T-0023/S01 is Review in PR #101 at frozen source `9f842509`. Seven local tests
+are pending final acceptance as Unit/Contract evidence for an internal positional
+batch invariant only; it adds no native Differential or supported schema/value claim.
 
 
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -216,6 +216,10 @@ The bounded observation slice is Done; parent contracts remain open.
 These diagnostic observations do not select native defaults or validation.
 A separate reviewed decision must precede schema-bound record implementation.
 
+T-0023/S01 is In Progress under accepted ADR-0014. Its intended evidence is
+Unit/Contract for an internal positional batch invariant only; it adds no
+native Differential or supported Embulk schema/value claim.
+
 
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -187,6 +187,11 @@ The bounded observation slice is Done; parent contracts remain open.
 These diagnostic observations do not select native defaults or validation.
 A separate reviewed decision must precede schema-bound record implementation.
 
+T-0023/S01 is In Progress under accepted ADR-0014 as the next bounded bridge: a
+private positional logical batch for selected schema/value categories.
+Timestamp/JSON values, nullability, external validation, physical encoding and
+all File-to-File claims remain outside the slice.
+
 
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -187,10 +187,10 @@ The bounded observation slice is Done; parent contracts remain open.
 These diagnostic observations do not select native defaults or validation.
 A separate reviewed decision must precede schema-bound record implementation.
 
-T-0023/S01 is In Progress under accepted ADR-0014 as the next bounded bridge: a
-private positional logical batch for selected schema/value categories.
-Timestamp/JSON values, nullability, external validation, physical encoding and
-all File-to-File claims remain outside the slice.
+T-0023/S01 is Review in PR #101 at frozen source `9f842509`: seven local tests
+exercise a private positional logical batch for selected schema/value categories.
+Final-head and independent acceptance remain pending. Timestamp/JSON values,
+nullability, external validation, physical encoding and all File-to-File claims remain outside.
 
 
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -372,11 +372,11 @@ The bounded observation slice is Done; parent contracts remain open.
 These diagnostic observations do not select native defaults or validation.
 A separate reviewed decision must precede schema-bound record implementation.
 
-T-0023/S01 is In Progress under accepted ADR-0014. It permits a private owned logical
-batch admission boundary before any physical representation: validate supported
-schema categories, all row widths, then row-major non-null value categories. A
-later batch consumer must separately decide ownership, resources, lifecycle and
-physical encoding; handoff is unchanged.
+T-0023/S01 is Review in PR #101 at frozen source `9f842509`. It implements a
+private owned logical batch admission boundary before any physical representation:
+validate supported schema categories, all row widths, then row-major non-null
+value categories. A later batch consumer must separately decide ownership,
+resources, lifecycle and physical encoding; handoff is unchanged.
 
 
 

--- a/docs/RUST_RUNTIME_DESIGN.md
+++ b/docs/RUST_RUNTIME_DESIGN.md
@@ -372,6 +372,12 @@ The bounded observation slice is Done; parent contracts remain open.
 These diagnostic observations do not select native defaults or validation.
 A separate reviewed decision must precede schema-bound record implementation.
 
+T-0023/S01 is In Progress under accepted ADR-0014. It permits a private owned logical
+batch admission boundary before any physical representation: validate supported
+schema categories, all row widths, then row-major non-null value categories. A
+later batch consumer must separately decide ownership, resources, lifecycle and
+physical encoding; handoff is unchanged.
+
 
 
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -17,9 +17,10 @@ Development state: `bootstrap`
   executable in a live differential test. No full configuration, plugin,
   data-transfer, or performance claim has passed its evidence gate.
 - A private ordered logical schema preserves owned names, type tags, order and
-  duplicates. Its live comparison matches three selected schema outcomes;
-  schema coupling to values, nullability, lookup and physical encoding remain
-  unimplemented.
+  duplicates. Frozen T-0023/S01 source adds limited private positional batch
+  admission for selected Boolean, Signed64, Float64 and Text values; final
+  acceptance remains pending. Timestamp/JSON, nullability, lookup and physical
+  encoding remain unimplemented.
 - Private owned Null/Boolean/Signed64/Text records preserve row/cell order and
   distinguish null from false, zero and empty text. Primary acceptance matches
   two selected reference getter-result projections, reproduced by an independent
@@ -47,8 +48,8 @@ The slice integrated through PR #91 as `34757c8`. S10's private double-storage
 decision passed readiness review and integrated through PR #92. S10 is now
 Done through PR #93. T-0021/S06 is Done through PR #96 after primary,
 independent and final-head acceptance. T-0012/S11 is Done through PR #99 after final-head acceptance.
-T-0023/S01 is In Progress under accepted ADR-0014; it has no implementation evidence.
-Combined active WIP is one of two. T-0012, T-0013 and
+T-0023/S01 is Review in PR #101 at frozen source `9f842509`; seven local tests
+pass but final-head and independent acceptance are pending. Combined active WIP is one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
@@ -58,7 +59,7 @@ T-0021 parent contracts remain open.
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012/S11 | Done | Automated strict observation validation; PR #99 integrated |
-| T-0023/S01 | In Progress | Private positional logical batch admission; implementation pending |
+| T-0023/S01 | Review | Frozen private positional batch admission; final acceptance pending |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -46,8 +46,9 @@ reproduction and complete raw review authorize Stage B strict validation.
 The slice integrated through PR #91 as `34757c8`. S10's private double-storage
 decision passed readiness review and integrated through PR #92. S10 is now
 Done through PR #93. T-0021/S06 is Done through PR #96 after primary,
-independent and final-head acceptance. T-0012/S11 is Done through PR #99 after final-head acceptance;
-combined active WIP is zero of two. T-0012, T-0013 and
+independent and final-head acceptance. T-0012/S11 is Done through PR #99 after final-head acceptance.
+T-0023/S01 is In Progress under accepted ADR-0014; it has no implementation evidence.
+Combined active WIP is one of two. T-0012, T-0013 and
 T-0021 parent contracts remain open.
 
 | Item | State | Purpose |
@@ -57,6 +58,7 @@ T-0021 parent contracts remain open.
 | T-0003 | Done | Enforce Project discovery, packet checks, and WIP auditing |
 | T-0004 | Done | Established Project delivery operations and burndown inputs |
 | T-0012/S11 | Done | Automated strict observation validation; PR #99 integrated |
+| T-0023/S01 | In Progress | Private positional logical batch admission; implementation pending |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 

--- a/docs/decisions/ADR-0014-private-positional-logical-batch.md
+++ b/docs/decisions/ADR-0014-private-positional-logical-batch.md
@@ -2,7 +2,8 @@
 
 - Status: Accepted; owner approved the bounded internal design after reviewing differences
 - Date: 2026-09-06
-- Proposed implementation: T-0023/S01; no implementation has been accepted.
+- Implementation: T-0023/S01 source is frozen under Review in PR #101 at
+  `9f842509`; no implementation has been accepted or integrated.
 
 ## Context
 
@@ -56,3 +57,7 @@ A later private batch consumer or physical representation needs its own packet
 and decision. No external code, artifact, dependency, or source observation is
 adopted; existing provenance and unreviewed license, redistribution, patent,
 standards, and FTO boundaries remain unchanged.
+
+The frozen S01 source implements only this private decision and has seven local
+tests. Final-head Demo, independent Tester reproduction and integration remain
+open; no compatibility or completion evidence follows from source freeze.

--- a/docs/decisions/ADR-0014-private-positional-logical-batch.md
+++ b/docs/decisions/ADR-0014-private-positional-logical-batch.md
@@ -1,0 +1,58 @@
+# ADR-0014: Private Positional Logical Batch Admission Before Physical Encoding
+
+- Status: Accepted; owner approved the bounded internal design after reviewing differences
+- Date: 2026-09-06
+- Proposed implementation: T-0023/S01; no implementation has been accepted.
+
+## Context
+
+ADR-0007/S06 supplies a private ordered schema that preserves names, types,
+order, and duplicate names. ADR-0011/S08 and ADR-0012/S10 supply private
+owned logical values, including bit-preserving Float64 storage. They remain
+separate representations. T-0012/S11 observes selected positional matching,
+explicit-null, and duplicate-name value outcomes, while its unset and
+wrong-setter cases are diagnostics only. T-0021/S06 supplies a separate
+record-by-record ownership experiment, not a schema-aware consumer.
+
+## Decision
+
+Permit one original, private, dependency-free `LogicalBatch` containing one
+owned `LogicalSchema` and zero or more owned `LogicalRecord` rows. Its only
+constructor consumes the schema and rows and returns either a batch or a
+private admission error; rejected inputs are not recoverable through this
+constructor. This is deliberately not a retry, allocation, or resource policy.
+
+Admission is positional. First scan schema columns from left to right and
+reject Timestamp or Json categories, including rows whose corresponding cell
+is Null. Then validate every row width from first row to last. Only after all
+widths pass, validate non-null cells in row-major order: Boolean, Signed64,
+Float64, and Text values must match the category at that exact position. Null
+is admitted only for those four selected supported categories. This precedence
+is a local testable invariant, not an Embulk error-timing or diagnostic claim.
+
+The batch preserves column order, duplicate names, row order, cell order,
+owned text, and Float64 storage bits. It exposes only private read-only
+iteration. `record_handoff` remains unchanged.
+
+## Consequences and limits
+
+Owner approval follows the explicit Embulk comparison: internal representation
+differences are permitted, not permanent compatibility exceptions. Timestamp,
+JSON, unset values, and externally observable failure behavior remain pending
+reimplementation and differential verification before public exposure. No
+language constraint or prohibitive implementation cost has been established.
+Internal width rejection must not dictate parser behavior: any supported
+source-level missing/extra-column policy belongs in the parser/adapter before
+batch admission. This decision does not approve a parser policy.
+
+This permits original private composition of the already accepted selected
+schema/value evidence. It does not select Embulk nullability, defaults,
+misuse behavior, coercion, lookup, metadata, timestamp/JSON values, external
+error text, public APIs, Arrow/Page encoding, batching/resource bounds,
+lifecycle, plugin behavior, transfer, or compatibility completion. T-0012/S11
+unset-text and wrong-setter outcomes must not be translated into native rules.
+
+A later private batch consumer or physical representation needs its own packet
+and decision. No external code, artifact, dependency, or source observation is
+adopted; existing provenance and unreviewed license, redistribution, patent,
+standards, and FTO boundaries remain unchanged.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,3 +17,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0011](ADR-0011-private-logical-record-values.md) | Private values-only records before schema coupling | Accepted |
 | [ADR-0012](ADR-0012-private-double-bit-storage.md) | Private double bit storage without numeric equality policy | Accepted |
 | [ADR-0013](ADR-0013-private-owned-record-handoff.md) | Private owned-record handoff before plugin APIs | Accepted |
+| [ADR-0014](ADR-0014-private-positional-logical-batch.md) | Private positional logical batch admission before physical encoding | Accepted |

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -313,3 +313,11 @@ Final-head exact Demo at `da7e50f` passed; PR #99 integrated as `413f837`.
 The 5-SP slice is Done; known S03–S11 total 35 SP, parent Current 55 / Initial 5
 unchanged. Parent #15 remains open/Backlog. Default full and validate-only modes
 are automated; no scheduler, native schema policy or parent completion is claimed.
+
+The owner approved ADR-0014 after reviewing the bounded internal representation
+against Embulk differences. T-0023/S01 is Ready on a clean branch from
+`642fe3f`; its 5-SP private positional logical batch slice uses accepted selected
+schema/value evidence. Local precedence is unsupported schema category, then
+all row widths, then row-major non-null type checks; rejected constructor inputs
+do not recover. Timestamp/JSON, nullability, misuse/default behavior, physical
+encoding, consumers, lifecycle and File-to-File claims remain pending.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -321,3 +321,10 @@ schema/value evidence. Local precedence is unsupported schema category, then
 all row widths, then row-major non-null type checks; rejected constructor inputs
 do not recover. Timestamp/JSON, nullability, misuse/default behavior, physical
 encoding, consumers, lifecycle and File-to-File claims remain pending.
+
+T-0023/S01 source froze at `9f842509` and moved to Review in PR #101. Its
+three allowed source paths add a private positional LogicalBatch and seven
+focused local tests; implementer format, focused-test, strict-Clippy and diff
+checks passed. Final-head exact Demo, separate Tester reproduction and
+integration remain required. This adds no native Differential, public interface,
+physical batch, lifecycle, plugin or File-to-File claim.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -30,3 +30,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S10 private double values](T-0012-private-double-values.md) | Done (bounded private slice; PR #93, `742274f`) |
 | [T-0012/S11 schema/value coupling](T-0012-schema-value-coupling-probe.md) | Done; PR #99 integrated after full final-head acceptance |
 | [T-0021/S06 owned-record handoff](T-0021-owned-record-handoff.md) | Done (bounded private slice; PR #96, `56ef9e9`) |
+| [T-0023/S01 positional logical batch](T-0023-positional-logical-batch.md) | Ready (owner-approved planning packet; Unit/Contract target) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -30,4 +30,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S10 private double values](T-0012-private-double-values.md) | Done (bounded private slice; PR #93, `742274f`) |
 | [T-0012/S11 schema/value coupling](T-0012-schema-value-coupling-probe.md) | Done; PR #99 integrated after full final-head acceptance |
 | [T-0021/S06 owned-record handoff](T-0021-owned-record-handoff.md) | Done (bounded private slice; PR #96, `56ef9e9`) |
-| [T-0023/S01 positional logical batch](T-0023-positional-logical-batch.md) | Ready (owner-approved planning packet; Unit/Contract target) |
+| [T-0023/S01 positional logical batch](T-0023-positional-logical-batch.md) | Review (frozen PR #101 source; Unit/Contract acceptance pending) |

--- a/docs/provenance/T-0023-positional-logical-batch.md
+++ b/docs/provenance/T-0023-positional-logical-batch.md
@@ -1,0 +1,105 @@
+# T-0023/S01 private positional logical batch admission
+
+- Issue: [T-0023, #20](https://github.com/bhind/emburk/issues/20)
+- State: In Progress; owner-approved ADR-0014, implementation acceptance pending
+- Branch: `feat/t-0023-s01-schema-bound-record`
+- Owner: Rust Core Implementer; Project Manager owns decision, records, and integration
+- Priority: P1; estimate 5 SP within unchanged parent Current/Initial 8 SP
+  (implementation 2, uncertainty 1, verification 1, environment 1; raw 5)
+- Evidence target: Unit/Contract
+
+## Authority
+
+The owner approved the bounded internal design after reviewing the differences
+from Embulk. ADR-0014 is accepted. Internal representation differences are
+permitted; timestamp/JSON, unset and externally observable error behavior remain
+pending verification before public exposure, not permanent compatibility
+exceptions. This packet authorizes only the bounded private implementation.
+
+## Dependencies
+
+Accepted dependencies are ADR-0007/S06 ordered schema, ADR-0011/S08 values,
+ADR-0012/S10 Float64 bits, T-0012/S11's strict selected schema/value
+observation validator, and parent T-0021/S06's completed private handoff
+boundary. This slice does not modify or consume that handoff.
+
+S11 permits only selected positional matching, explicit-null, and
+duplicate-name evidence. Its unset-text and wrong-setter observations are
+diagnostic-only and do not authorize native defaults, misuse validation, or
+external diagnostics.
+
+## Branch and allowlist
+
+Branch reservation: `feat/t-0023-s01-schema-bound-record`.
+
+One Rust Core Implementer would own exactly:
+
+- `crates/emburk-core/src/logical_schema.rs` for sibling-private type/accessor support only;
+- `crates/emburk-core/src/logical_batch.rs` for original batch admission and local tests;
+- `crates/emburk-core/src/lib.rs` for private module registration only.
+
+Do not modify `logical_record.rs`, `record_handoff.rs`, Cargo manifests,
+dependencies, CLI, public exports, reference probes, S11 automation, or
+canonical records. The Project Manager owns ADR-0014, this packet/index, and
+all status, roadmap, compatibility, architecture, runtime-design and log
+records. Testers/reviewers are read-only.
+
+## Artifacts
+
+No new external source, reference artifact, dependency, runtime fixture, or
+generated repository artifact is admitted. Reuse the accepted S11 validator
+only as an unchanged regression and evidence-integrity gate. Generated build
+and test output remains outside the repository.
+
+## Proposed private boundary
+
+Add an original `LogicalBatch` which owns one private ordered schema and zero
+or more owned logical-record rows. `try_new` consumes its inputs. It rejects,
+in exact local precedence: (1) the first Timestamp or Json schema column;
+(2) after the entire schema is supported, the first row with unequal width;
+and (3) after all widths pass, the first row-major non-null cell whose logical
+value category differs from its positional schema column. Null is accepted
+only in Boolean, Signed64, Float64, and Text columns. Rejected inputs are not
+recoverable through this constructor.
+
+This is a private invariant, not an Embulk validation, nullability, coercion,
+or error-timing contract. Preserve positional order, duplicate names, owned
+text and actual Float64 bits. Provide only private read-only access;
+`record_handoff` remains unchanged.
+
+## Acceptance criteria
+
+Local tests must construct matching, explicit-null, and duplicate-name cases
+using actual private schema and value objects; assert exact schema/row/cell
+order, owned text, and raw negative-zero Float64 bits. They must reject
+Timestamp/Json before values even when null, a width-zero row for a non-empty
+schema, short/long rows, and each cross-type pairing. Empty-schema/zero-row
+and empty-schema/one-empty-row batches must admit. Tests must prove the stated
+global precedence: all schema support checks, then all row widths, then
+row-major value checks.
+
+Primary and independent final-head reproductions, source/diff checks and
+canonical-record reconciliation are required before integration.
+
+## Demo Command
+
+Run:
+
+`cargo test --workspace && cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && bash tests/t0012_schema_value_coupling_probe_test.sh && bash tests/t0012_double_value_differential_test.sh && bash tests/t0012_page_value_differential_test.sh && bash tests/t0012_schema_differential_test.sh`
+
+## Evidence class
+
+Unit/Contract. The existing S11 runner verifies its provenance evidence but
+grants no new native Differential result.
+
+## Stop rule
+
+Stop and return to the Project Manager before allowlist expansion, a new
+artifact or source observation, an external dependency, a physical encoding,
+a consumer rewrite, or material IP/security uncertainty.
+
+## Non-claims
+
+Do not add timestamp/JSON values, schema metadata or nullability, name lookup,
+defaults, coercion, external diagnostics, public APIs, Arrow/Page encoding,
+resource bounds, lifecycle, plugins, transfer, or a compatibility claim.

--- a/docs/provenance/T-0023-positional-logical-batch.md
+++ b/docs/provenance/T-0023-positional-logical-batch.md
@@ -1,7 +1,7 @@
 # T-0023/S01 private positional logical batch admission
 
 - Issue: [T-0023, #20](https://github.com/bhind/emburk/issues/20)
-- State: In Progress; owner-approved ADR-0014, implementation acceptance pending
+- State: Review; frozen implementation acceptance pending in PR #101
 - Branch: `feat/t-0023-s01-schema-bound-record`
 - Owner: Rust Core Implementer; Project Manager owns decision, records, and integration
 - Priority: P1; estimate 5 SP within unchanged parent Current/Initial 8 SP
@@ -30,9 +30,9 @@ external diagnostics.
 
 ## Branch and allowlist
 
-Branch reservation: `feat/t-0023-s01-schema-bound-record`.
+Branch: `feat/t-0023-s01-schema-bound-record`.
 
-One Rust Core Implementer would own exactly:
+One Rust Core Implementer owns exactly:
 
 - `crates/emburk-core/src/logical_schema.rs` for sibling-private type/accessor support only;
 - `crates/emburk-core/src/logical_batch.rs` for original batch admission and local tests;
@@ -43,6 +43,14 @@ dependencies, CLI, public exports, reference probes, S11 automation, or
 canonical records. The Project Manager owns ADR-0014, this packet/index, and
 all status, roadmap, compatibility, architecture, runtime-design and log
 records. Testers/reviewers are read-only.
+
+Frozen source is `9f842509761677b9f56291a8682e56f5bca15a05`:
+
+| Source | SHA-256 |
+| --- | --- |
+| `crates/emburk-core/src/lib.rs` | `61dd14e8f8f65a3669ce3152f15353ec85891b96fd3a7f7038bb7e4940c7c9f1` |
+| `crates/emburk-core/src/logical_schema.rs` | `cde5913afeafb75998c98222b8fafe22e4e9ca9985992e1b76ad46c488229cc0` |
+| `crates/emburk-core/src/logical_batch.rs` | `178171f559dc122712cc493387710e6bb69530b15bbe29c3760e7c3550ceba7a` |
 
 ## Artifacts
 
@@ -66,6 +74,17 @@ This is a private invariant, not an Embulk validation, nullability, coercion,
 or error-timing contract. Preserve positional order, duplicate names, owned
 text and actual Float64 bits. Provide only private read-only access;
 `record_handoff` remains unchanged.
+
+## Frozen implementation under review
+
+The frozen source adds the private batch module and narrowly scoped
+sibling-private schema access. Seven focused local tests cover accepted
+matching, explicit-null and duplicate-name composition; empty-schema cases;
+unsupported Timestamp/Json precedence; widths; and row-major type mismatch
+precedence. Implementer checks report format, focused tests, strict Clippy and
+diff checks passing. This is source-review evidence only: the exact Demo at the
+final PR #101 head, a separate Tester reproduction, record reconciliation and
+integration remain required.
 
 ## Acceptance criteria
 


### PR DESCRIPTION
Refs #20. T-0023/S01 implements owner-approved ADR-0014: private owned schema/record composition, schema-support then global-width then row-major type validation. Seven focused tests pass; format and strict Clippy pass. Primary review corrected full-cell and error-priority assertions. Final-head full Demo and separate reproduction are pending and will be recorded before merge. Unit/Contract only, no new native Differential, public API, Arrow, lifecycle, transfer, or permanent compatibility exception. See docs/provenance/T-0023-positional-logical-batch.md.