### PR TITLE
research(t-0012): validate selected configuration syntax observations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,8 @@ through PR #105 (`67f0786`) after primary and independent final-head Demo at
 remains open, Current 55 / Initial 5 unchanged. S13 now occupies one of two WIP lanes.
 
 T-0012/S13 is In Progress for six selected syntax observations, 5 SP. Stage A raw
-review precedes Stage B validation. Parent Current 55 / Initial 5 is unchanged.
+review passed at `3c70500`; Stage B is authorized. Parent Current 55 / Initial 5
+is unchanged; no points are awarded yet.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,9 @@ through PR #105 (`67f0786`) after primary and independent final-head Demo at
 `9df0d5c`, accepting 5 SP. Known S03–S12 acceptance totals 40 SP. Parent #15
 remains open in Backlog, Current 55 / Initial 5 unchanged; WIP is zero of two.
 
+T-0012/S13 is Ready for six selected syntax observations, 5 SP. Stage A raw
+review precedes Stage B validation. Parent Current 55 / Initial 5 is unchanged.
+
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
 T-0030–T-0037 and T-0060–T-0067 are `Native Plugins`; T-0040–T-0045 are
@@ -47,7 +50,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S12 observations integrated) | Backlog | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
+| T-0012 | Specify configuration, schema, and value semantics (S13 syntax observations Ready) | Ready | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,8 +24,8 @@ through PR #105 (`67f0786`) after primary and independent final-head Demo at
 `9df0d5c`, accepting 5 SP. Known S03–S12 acceptance totals 40 SP. Parent #15
 remains open, Current 55 / Initial 5 unchanged. S13 now occupies one of two WIP lanes.
 
-T-0012/S13 is In Progress for six selected syntax observations, 5 SP. Stage A raw
-review passed at `3c70500`; Stage B is authorized. Parent Current 55 / Initial 5
+T-0012/S13 is in Review in PR #107 for six selected syntax observations, 5 SP.
+Strict controls passed at `d95f2a9`; final-head Demo is pending. Parent Current 55 / Initial 5
 is unchanged; no points are awarded yet.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -51,7 +51,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S13 syntax observations In Progress) | In Progress | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
+| T-0012 | Specify configuration, schema, and value semantics (S13 syntax observations in Review) | Review | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@ through PR #105 (`67f0786`) after primary and independent final-head Demo at
 `9df0d5c`, accepting 5 SP. Known S03–S12 acceptance totals 40 SP. Parent #15
 remains open in Backlog, Current 55 / Initial 5 unchanged; WIP is zero of two.
 
-T-0012/S13 is Ready for six selected syntax observations, 5 SP. Stage A raw
+T-0012/S13 is In Progress for six selected syntax observations, 5 SP. Stage A raw
 review precedes Stage B validation. Parent Current 55 / Initial 5 is unchanged.
 
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
@@ -50,7 +50,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0010 | Epic: Embulk compatibility contract | Backlog | P0 | — | None | Project Manager | Planning |
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
-| T-0012 | Specify configuration, schema, and value semantics (S13 syntax observations Ready) | Ready | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
+| T-0012 | Specify configuration, schema, and value semantics (S13 syntax observations In Progress) | In Progress | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@ timestamp and JSON uncertainty that does not fit 8 SP. It is a forecast, not
 completion evidence. Parent #20 remains open in Backlog. T-0012/S12 is Done
 through PR #105 (`67f0786`) after primary and independent final-head Demo at
 `9df0d5c`, accepting 5 SP. Known S03–S12 acceptance totals 40 SP. Parent #15
-remains open in Backlog, Current 55 / Initial 5 unchanged; WIP is zero of two.
+remains open, Current 55 / Initial 5 unchanged. S13 now occupies one of two WIP lanes.
 
 T-0012/S13 is In Progress for six selected syntax observations, 5 SP. Stage A raw
 review precedes Stage B validation. Parent Current 55 / Initial 5 is unchanged.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -237,9 +237,9 @@ no-callback failures. Primary and independent final-head acceptance passed at
 
 ## Adding an Entry
 
-T-0012/S13 is In Progress for six syntax observations. No YAML, duplicate-key, alias,
+T-0012/S13 is in Review in PR #107 for six syntax observations. No YAML, duplicate-key, alias,
 encoding, or native configuration behavior is accepted. Primary and independent
-Stage A agree on 60 events and six outcomes; strict Stage B is authorized,
+Stage A agree on 60 events and six outcomes; strict Stage B controls pass at `d95f2a9`,
 but final acceptance remains pending.
 
 Each entry must identify the Embulk version, exact plugin artifact, configuration fixture, expected evidence, source/provenance record, and known deviations. Claims enter this document only after review evidence exists.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -237,4 +237,7 @@ no-callback failures. Primary and independent final-head acceptance passed at
 
 ## Adding an Entry
 
+T-0012/S13 is Ready for six syntax observations. No YAML, duplicate-key, alias,
+encoding, or native configuration behavior is added or accepted yet.
+
 Each entry must identify the Embulk version, exact plugin artifact, configuration fixture, expected evidence, source/provenance record, and known deviations. Claims enter this document only after review evidence exists.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -237,7 +237,7 @@ no-callback failures. Primary and independent final-head acceptance passed at
 
 ## Adding an Entry
 
-T-0012/S13 is Ready for six syntax observations. No YAML, duplicate-key, alias,
+T-0012/S13 is In Progress for six syntax observations. No YAML, duplicate-key, alias,
 encoding, or native configuration behavior is added or accepted yet.
 
 Each entry must identify the Embulk version, exact plugin artifact, configuration fixture, expected evidence, source/provenance record, and known deviations. Claims enter this document only after review evidence exists.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -238,6 +238,8 @@ no-callback failures. Primary and independent final-head acceptance passed at
 ## Adding an Entry
 
 T-0012/S13 is In Progress for six syntax observations. No YAML, duplicate-key, alias,
-encoding, or native configuration behavior is added or accepted yet.
+encoding, or native configuration behavior is accepted. Primary and independent
+Stage A agree on 60 events and six outcomes; strict Stage B is authorized,
+but final acceptance remains pending.
 
 Each entry must identify the Embulk version, exact plugin artifact, configuration fixture, expected evidence, source/provenance record, and known deviations. Claims enter this document only after review evidence exists.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,7 +210,7 @@ independent final-head acceptance at `9df0d5c`.
 
 ## Phase 1: Native File-to-File MVP
 
-T-0012/S13 is Ready for six syntax observations to inform configuration-loader
+T-0012/S13 is In Progress for six syntax observations to inform configuration-loader
 constraints. It does not adopt a parser or native policy or complete this gate.
 
 - Build the compact execution core and MVP CLI.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,7 +210,7 @@ independent final-head acceptance at `9df0d5c`.
 
 ## Phase 1: Native File-to-File MVP
 
-T-0012/S13 is In Progress for six syntax observations to inform configuration-loader
+T-0012/S13 is in Review in PR #107 for six syntax observations to inform configuration-loader
 constraints. It does not adopt a parser or native policy or complete this gate.
 
 - Build the compact execution core and MVP CLI.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,6 +210,9 @@ independent final-head acceptance at `9df0d5c`.
 
 ## Phase 1: Native File-to-File MVP
 
+T-0012/S13 is Ready for six syntax observations to inform configuration-loader
+constraints. It does not adopt a parser or native policy or complete this gate.
+
 - Build the compact execution core and MVP CLI.
 - Implement Arrow-compatible batches, bounded scheduling, backpressure, cancellation, transactions, and resume state.
 - Implement file/config inputs; file/stdout/null outputs; CSV/JSON; gzip/bzip2; rename/remove-columns; and format guessing.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -68,7 +68,7 @@ contracts remain open; S13 occupies one of two WIP lanes.
 | T-0023/S01 | Done | Private positional batch admission; PR #101 integrated |
 | T-0023/S02 | Done | Selected three-case LogicalBatch differential bridge; PR #103 integrated |
 | T-0012/S12 | Done | Seven-case reference observation and validator; PR #105 integrated |
-| T-0012/S13 | In Progress | Six syntax fixtures; no new observations or native behavior yet |
+| T-0012/S13 | In Progress | Six raw outcomes reviewed at `3c70500`; Stage B authorized |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -68,6 +68,7 @@ contracts remain open; WIP is zero of two.
 | T-0023/S01 | Done | Private positional batch admission; PR #101 integrated |
 | T-0023/S02 | Done | Selected three-case LogicalBatch differential bridge; PR #103 integrated |
 | T-0012/S12 | Done | Seven-case reference observation and validator; PR #105 integrated |
+| T-0012/S13 | Ready | Six syntax fixtures; no new observations or native behavior yet |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -68,7 +68,7 @@ contracts remain open; S13 occupies one of two WIP lanes.
 | T-0023/S01 | Done | Private positional batch admission; PR #101 integrated |
 | T-0023/S02 | Done | Selected three-case LogicalBatch differential bridge; PR #103 integrated |
 | T-0012/S12 | Done | Seven-case reference observation and validator; PR #105 integrated |
-| T-0012/S13 | In Progress | Six raw outcomes reviewed at `3c70500`; Stage B authorized |
+| T-0012/S13 | Review | PR #107; strict controls pass at `d95f2a9`; final-head Demo pending |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -56,7 +56,7 @@ unchanged regressions. It adds no runtime behavior. T-0012/S12 is Done through
 PR #105 (`67f0786`): primary and independent final-head Demo at `9df0d5c`
 passed seven cases/36 events, strict controls and unchanged S01/S02 regressions.
 No native configuration behavior is added. T-0012, T-0013 and T-0021 parent
-contracts remain open; WIP is zero of two.
+contracts remain open; S13 occupies one of two WIP lanes.
 
 | Item | State | Purpose |
 |---|---|---|

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -68,7 +68,7 @@ contracts remain open; WIP is zero of two.
 | T-0023/S01 | Done | Private positional batch admission; PR #101 integrated |
 | T-0023/S02 | Done | Selected three-case LogicalBatch differential bridge; PR #103 integrated |
 | T-0012/S12 | Done | Seven-case reference observation and validator; PR #105 integrated |
-| T-0012/S13 | Ready | Six syntax fixtures; no new observations or native behavior yet |
+| T-0012/S13 | In Progress | Six syntax fixtures; no new observations or native behavior yet |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -405,3 +405,8 @@ Exact input bytes, stderr and all six outcome vectors agree. Five cases have
 field returns the second value, while invalid byte ff is observed as U+FFFD
 without modifying the retained input. PM authorized scoped Stage B validation;
 these observations are not native policy or final acceptance.
+
+S13 Stage B passed at `d95f2a9`: six cases/60 events, 19 raw-copy controls,
+one path and two artifact controls. Initial missing-file control preparation
+failed and was corrected with logs retained. PR #107 enters Review; final-head
+primary and independent exact Demo remain required before integration.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -392,3 +392,9 @@ each with retained/tool-reported exit 0, and integrated through PR #105 as
 the execution gate requested confirmation. S12 is Done for 5 SP; known
 S03–S12 total 40 SP. Parent #15 remains open in Backlog, Current 55 / Initial 5.
 Provenance retains accepted hashes, controls, regressions and non-claims.
+
+The owner explicitly approved S13 start, lifecycle transitions, verified merge
+and completion records. PM prepared a six-case packet after read-only Librarian
+review; no new API, runtime artifact or dependency is admitted. Stage A raw
+review remains required before Stage B. Slice forecast 5 SP; parent Current 55 /
+Initial 5 unchanged. No native parser/policy is adopted.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -398,3 +398,10 @@ and completion records. PM prepared a six-case packet after read-only Librarian
 review; no new API, runtime artifact or dependency is admitted. Stage A raw
 review remains required before Stage B. Slice forecast 5 SP; parent Current 55 /
 Initial 5 unchanged. No native parser/policy is adopted.
+
+S13 Stage A at `3c70500` passed primary and independent capture, each exit 0.
+Exact input bytes, stderr and all six outcome vectors agree. Five cases have
+12 events and exit 0; malformed flow has no callback and exit 1. Duplicate
+field returns the second value, while invalid byte ff is observed as U+FFFD
+without modifying the retained input. PM authorized scoped Stage B validation;
+these observations are not native policy or final acceptance.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -33,4 +33,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0023/S01 positional logical batch](T-0023-positional-logical-batch.md) | Done (PR #101, `d0eebf8`; Unit/Contract only) |
 | [T-0023/S02 logical-batch differential](T-0023-logical-batch-differential.md) | Done (PR #103, `5d72866`; selected Differential only) |
 | [T-0012/S12 config-envelope observation](T-0012-config-envelope-probe.md) | Done (PR #105, `67f0786`; reference evidence only) |
-| [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | In Progress (Stage A capture; no accepted observation) |
+| [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | In Progress (Stage A reviewed; Stage B authorized) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -33,4 +33,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0023/S01 positional logical batch](T-0023-positional-logical-batch.md) | Done (PR #101, `d0eebf8`; Unit/Contract only) |
 | [T-0023/S02 logical-batch differential](T-0023-logical-batch-differential.md) | Done (PR #103, `5d72866`; selected Differential only) |
 | [T-0012/S12 config-envelope observation](T-0012-config-envelope-probe.md) | Done (PR #105, `67f0786`; reference evidence only) |
-| [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | Ready (Stage A capture; no accepted observation) |
+| [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | In Progress (Stage A capture; no accepted observation) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -33,3 +33,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0023/S01 positional logical batch](T-0023-positional-logical-batch.md) | Done (PR #101, `d0eebf8`; Unit/Contract only) |
 | [T-0023/S02 logical-batch differential](T-0023-logical-batch-differential.md) | Done (PR #103, `5d72866`; selected Differential only) |
 | [T-0012/S12 config-envelope observation](T-0012-config-envelope-probe.md) | Done (PR #105, `67f0786`; reference evidence only) |
+| [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | Ready (Stage A capture; no accepted observation) |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -33,4 +33,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0023/S01 positional logical batch](T-0023-positional-logical-batch.md) | Done (PR #101, `d0eebf8`; Unit/Contract only) |
 | [T-0023/S02 logical-batch differential](T-0023-logical-batch-differential.md) | Done (PR #103, `5d72866`; selected Differential only) |
 | [T-0012/S12 config-envelope observation](T-0012-config-envelope-probe.md) | Done (PR #105, `67f0786`; reference evidence only) |
-| [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | In Progress (Stage A reviewed; Stage B authorized) |
+| [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | Review (PR #107; final-head acceptance pending) |

--- a/docs/provenance/T-0012-config-syntax-probe.md
+++ b/docs/provenance/T-0012-config-syntax-probe.md
@@ -1,7 +1,7 @@
 # T-0012/S13 selected configuration-syntax observation
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: In Progress; Stage A reviewed, Stage B validation authorized
+- State: Review; PR #107, final-head acceptance pending
 - Branch: `research/t-0012-s13-config-syntax`
 - Owner: Compatibility Host Implementer; PM owns records and acceptance
 - Priority: P0; slice 5 SP (implementation 2, uncertainty 1, verification 1,
@@ -163,8 +163,6 @@ the integrity control deliberately does not. Add positive validate-only, one
 symlink-path and two exact artifact-failure controls. Final Demo and independent
 reproduction are still required before verified merge and completion.
 
-## Evidence class
-
 ## Stage B implementation evidence
 
 Source freeze `d95f2a9a39f921458c9b7af0b434113908bd1f66` passed the fresh
@@ -184,7 +182,7 @@ was retracted after checking that the mutation receives complete event lines.
 Final-head exact Demo and independent reproduction remain required. No points
 are awarded by this implementation evidence.
 
-## Evidence classification
+## Evidence class
 
 Reference Observation / Integration for the selected runtime fixtures;
 Unit/Contract for validator controls. No native Differential claim follows.

--- a/docs/provenance/T-0012-config-syntax-probe.md
+++ b/docs/provenance/T-0012-config-syntax-probe.md
@@ -165,6 +165,27 @@ reproduction are still required before verified merge and completion.
 
 ## Evidence class
 
+## Stage B implementation evidence
+
+Source freeze `d95f2a9a39f921458c9b7af0b434113908bd1f66` passed the fresh
+S13 wrapper with retained and process exit 0: six cases/60 events, 19 raw-copy
+controls, one symlink-path control and two artifact controls. Java is unchanged.
+Runner SHA-256 `2e5a8ad66820a065b36fc17a06a253843ddef5f5261e98fa1a16a72144123f57`;
+wrapper `d740b9fe4f88bcc47fc800e1c2b66556fc4dcbadfd8d230bc422706d13223aaa`.
+Outer stdout/stderr hashes are
+`7c0bc07b6367e51fd00c2b6716ae564369dc05ea028e3056f49c1ae16fd239f4` /
+`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
+The initial wrapper run at `5ae628f` exited 1 during missing-file control
+preparation, not reference execution. Its logs remain retained; `d95f2a9`
+preserves the missing entry's old digest so the validator tests file inventory.
+Root review restored framing checks lost in the first draft. Independent
+read-only source review found no remaining blocker; an event-value finding
+was retracted after checking that the mutation receives complete event lines.
+Final-head exact Demo and independent reproduction remain required. No points
+are awarded by this implementation evidence.
+
+## Evidence classification
+
 Reference Observation / Integration for the selected runtime fixtures;
 Unit/Contract for validator controls. No native Differential claim follows.
 

--- a/docs/provenance/T-0012-config-syntax-probe.md
+++ b/docs/provenance/T-0012-config-syntax-probe.md
@@ -1,7 +1,7 @@
 # T-0012/S13 selected configuration-syntax observation
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: Ready; Stage A capture authorized
+- State: In Progress; Stage A capture authorized
 - Branch: `research/t-0012-s13-config-syntax`
 - Owner: Compatibility Host Implementer; PM owns records and acceptance
 - Priority: P0; slice 5 SP (implementation 2, uncertainty 1, verification 1,

--- a/docs/provenance/T-0012-config-syntax-probe.md
+++ b/docs/provenance/T-0012-config-syntax-probe.md
@@ -1,7 +1,7 @@
 # T-0012/S13 selected configuration-syntax observation
 
 - Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
-- State: In Progress; Stage A capture authorized
+- State: In Progress; Stage A reviewed, Stage B validation authorized
 - Branch: `research/t-0012-s13-config-syntax`
 - Owner: Compatibility Host Implementer; PM owns records and acceptance
 - Priority: P0; slice 5 SP (implementation 2, uncertainty 1, verification 1,
@@ -98,6 +98,70 @@ This is final Stage B acceptance, not Stage A. S12 remains unchanged and its
 wrapper verifies the preceding envelope gate. No Rust changes or redundant
 workspace suites are required. Primary and independent final-head Demo plus
 record reconciliation and PR integration are required for completion/points.
+
+## Stage A evidence and Stage B decision
+
+Primary and independent `--capture` both exited 0 at
+`3c705007673de22db1a94650471d6cb4ce9a300c`. PM verified the retained independent
+exit and compared exact input bytes, stderr bytes and all projected events.
+Six inputs, 60 events and outcomes agree; no diagnostic normalization is needed.
+Raw timestamps, paths and UUIDs remain retained, not semantic comparisons.
+
+| Case | Exit / events | Observed String or boundary |
+| --- | --- | --- |
+| control | 0 / 12 | `syntax-value` |
+| quoted | 0 / 12 | `syntax-value` |
+| duplicate-field | 0 / 12 | `second-value` |
+| malformed-flow | 1 / 0 | No callback; flow-sequence parsing diagnostic |
+| scalar-alias | 0 / 12 | `syntax-value` |
+| invalid-utf8 | 0 / 12 | `bad-\uFFFD-value`; source still contains byte `ff` |
+
+Each successful case has one unique context and sequence 1–12:
+transaction-entry, config-load-entry, config-value(the value above),
+control-entry, run-entry, finish-entry, finish-return, run-return,
+control-return, transaction-return, cleanup-entry, cleanup-return.
+All successful stderr files are empty. The malformed-flow stderr is 2725 bytes,
+SHA-256 `480dfb5bc6be8e8e567869545710d73db2ce87b80882b372e735021606e3c950`.
+Its selected diagnostic identifies a flow sequence at line 7/column 10 and
+the unexpected colon at line 8/column 4; stack details are pinned observations,
+not native errors or a claim about internal parser implementation.
+
+| Exact input bytes | SHA-256 |
+| --- | --- |
+| control | `b6529ab10a9be386b12e6e26c75344ee4903e85464df1863e4e638398e4bee14` |
+| quoted | `ad50b4ddf3864a4cebc2c88ca562e5fb3a94105f5d30bda41be9ab14c87ba2c5` |
+| duplicate-field | `7a8659ae16b67e5a909c906477f511d6aa319c79d8c9ec0aad9fa661d398f257` |
+| malformed-flow | `6f2b75feeb5f1df992e3f2472b7f1df53752fe4ee6bb3d9781cde2dfa3767cea` |
+| scalar-alias | `f76fb799c7228956d07f25d340bb5325176c060073cc88f726a253e1dba9c4bf` |
+| invalid-utf8 | `6856e72333e988149d1fe972c6c7790bf01893790bccaf86f7b496b0e9d1f056` |
+
+Frozen Java SHA-256 `5f29ac5bef4ffa52dead57f7bf13b6f40dfd444384bbb7d775f40998d39859b3`;
+Stage A runner `0561850fd53275a31231c6913fad55ffe977ffbba8a4600633acddbfd6fc11fe`;
+wrapper `3be9134aadf5f0b87fc9a1605fdf8bfd21d46e484a68c68c687db135f5ee8a88`.
+Primary outer stdout/stderr SHA-256:
+`8061b00cbce50bff60cb466c5982d0933dc27148aa3b39bac0afde6b8ea858af` /
+`677b102eba712e358838a62f226b5c0f64f5790f8ec0885bac39c32117fd4ce4`.
+Independent hashes:
+`e9ff63af1269851cb37eaf6f5ca516c0ad9e6c839ce6fab224ac74c5297cbe3c` /
+`d3ee6883523a248f359167829f86ce7c1e29b78785ec718bdee9e68d84f485f5`.
+Runtime pins matched. Raw evidence stays external/local-only. No full Demo,
+Stage B acceptance, points, or native policy follows from capture.
+
+PM authorizes Stage B only in the runner/wrapper, preserving Java semantics.
+Keep explicit capture-only; add default full plus explicit validate-only with
+no writes/runtime/network/full marker. Bind the exact inputs above, six unique
+invocations, five unique contexts, per-case values, fixed exits/stderr, historical
+three-source identities, before/after hashes, all files and integrity metadata.
+Preserve source `ff` distinctly from result UTF-8 `ef bf bd`. Hashes are integrity
+aids, not malicious-local-process attestation or security isolation.
+
+Adapt S12's 16 raw-copy controls and add three selected controls: duplicate
+result changed to first-value (event-vector), invalid source byte replaced with
+UTF-8 U+FFFD (input-vector), and alias replaced with its plain value
+(input-vector). Repair dependent case/integrity hashes for semantic mutations;
+the integrity control deliberately does not. Add positive validate-only, one
+symlink-path and two exact artifact-failure controls. Final Demo and independent
+reproduction are still required before verified merge and completion.
 
 ## Evidence class
 

--- a/docs/provenance/T-0012-config-syntax-probe.md
+++ b/docs/provenance/T-0012-config-syntax-probe.md
@@ -1,0 +1,141 @@
+# T-0012/S13 selected configuration-syntax observation
+
+- Issue: [T-0012, #15](https://github.com/bhind/emburk/issues/15)
+- State: Ready; Stage A capture authorized
+- Branch: `research/t-0012-s13-config-syntax`
+- Owner: Compatibility Host Implementer; PM owns records and acceptance
+- Priority: P0; slice 5 SP (implementation 2, uncertainty 1, verification 1,
+  environment 1). Parent Current 55 / Initial 5 is unchanged.
+
+## Authority
+
+The owner explicitly approved S13 start, lifecycle transitions, verified merge
+and completion records. This does not waive the acceptance or raw-review gates.
+
+The owner requested continued chained work after S12 closeout. This packet
+permits original reference instrumentation, not native parser adoption, public
+configuration policy or upstream implementation reuse. Stage A captures raw
+outcomes; the PM must review those bytes before Stage B expectations are added.
+
+## Dependencies
+
+S12 and its factual closeout are integrated through PR #105/#106 (`67f0786`,
+`82581e3`). S01/S02 already cover selected presence and scalar conversions;
+S12 covers selected `in`/`out` missing/null envelopes. None establishes YAML
+syntax behavior. ADR-0006's private in-memory resolver remains unchanged.
+
+## Branch and allowlist
+
+One implementer owns exactly three new source/test paths:
+
+- `tools/t0012-config-syntax-probe/src/T0012ConfigSyntaxInputPlugin.java`
+- `tools/t0012-config-syntax-probe/run.sh`
+- `tests/t0012_config_syntax_probe_test.sh`
+
+PM owns this packet, provenance index, STATUS, TODO, ROADMAP, COMPATIBILITY,
+and daily log. Reviewers/testers are read-only. No existing probe, Rust, CLI,
+Cargo/dependency, architecture, ADR, or other task changes are permitted.
+
+## Artifacts
+
+Reuse the admitted unmodified 0.11.5 executable and local Maven test-plugin
+route from S12, plus bundled null output. All runtime/generated artifacts,
+exact input bytes and raw output stay in unique external temporary storage.
+No upstream build, source download, external plugin, or redistribution occurs.
+Original repository S12 instrumentation may be adapted with its origin recorded;
+that is not permission to copy upstream implementation or upstream test vectors.
+
+## Acceptance criteria
+
+Exactly six original configurations share S12's local Maven input structure
+(plugin name `t0012_syntax`) and output `type: "null"`. Each document ends in LF.
+
+| Case | Exact variation |
+| --- | --- |
+| control | `in.field: syntax-value` (plain String token) |
+| quoted | Same field, double-quoted `"syntax-value"` |
+| duplicate-field | Two consecutive `field` lines in `in`: `first-value`, then `second-value` |
+| malformed-flow | Field line `  field: [unterminated` |
+| scalar-alias | Root `seed: &v syntax-value` before `in`; field line `  field: *v` |
+| invalid-utf8 | Field line bytes `b'  field: bad-\xff-value\n'` |
+
+The known-good control is necessary to distinguish global initialization failure
+from a selected observation. Do not preselect success, rejection, winning
+duplicate value, alias behavior, replacement characters, or parser cause for
+the other five cases. The plugin observes one required annotated String only;
+it preserves null/empty exception messages and rethrows original exceptions.
+
+Stage A must retain six exact byte files (never decode/re-encode invalid UTF-8),
+separate stdout/stderr/numeric process exits, per-invocation UUIDs, independent
+plugin-context UUIDs and context-local contiguous events. Preserve zero-event
+files and unexpected context shapes; do not synthesize missing callbacks.
+Use S12's callback vocabulary and safe base64 payloads. Capture source revision
+and all three committed source hashes, runtime/plugin/toolchain identity and
+LICENSE/NOTICE hashes. Validate bounded framing and control success only.
+Expose evidence and numeric capture exit even on setup failures. All path
+ancestors must be canonical, external and nonsymlinked before directory creation.
+
+Stage A accepts only explicit `--capture`; the final Demo must clearly remain
+unavailable until PM raw review. After raw review, Stage B may add full fresh
+capture/strict validation and existing-evidence validate-only (no Java/network,
+no writes, no fresh-success marker). Freeze actual byte/event/exit/diagnostic
+vectors before implementing expectations. Runtime paths, timestamps and UUIDs
+must not be erased by guessed normalization; any required normalization needs
+demonstrated nondeterminism and PM review.
+
+Stage B controls must use fresh copies and repair dependent hashes to exercise
+exact semantic diagnostics: input bytes, fixture set, events/order/value/context,
+invocation, exit, diagnostics, source and integrity. Include positive
+validate-only, external-path/symlink rejection, corrupt-artifact and unavailable-
+artifact controls. Preserve full logs and exact exits for each. A download error
+cannot pass a semantic corruption control. Exact control count follows raw review.
+
+## Demo Command
+
+`bash tests/t0012_config_syntax_probe_test.sh && bash tests/t0012_config_envelope_probe_test.sh`
+
+This is final Stage B acceptance, not Stage A. S12 remains unchanged and its
+wrapper verifies the preceding envelope gate. No Rust changes or redundant
+workspace suites are required. Primary and independent final-head Demo plus
+record reconciliation and PR integration are required for completion/points.
+
+## Evidence class
+
+Reference Observation / Integration for the selected runtime fixtures;
+Unit/Contract for validator controls. No native Differential claim follows.
+
+## Provenance and admission
+
+Local references: S12 original Java/runner/wrapper at `67f0786`, and the S01,
+S02 and S12 provenance records. Use only their already-compiled public Config,
+Task, ConfigSource.loadConfig, InputPlugin, Exec, empty Schema and PageOutput
+signatures. Core pin `c5ac2d471edac465b45088669d376a7e2a525f8f`, public
+configuration locators under `embulk-core/src/main/java/org/embulk/config/`;
+SPI pin `576e98033a14ba8ac994ed581d3c9d8fcdda2749`, under
+`src/main/java/org/embulk/spi/`. No new API or external source is needed.
+
+Artifact: https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
+SHA-256 `e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`.
+Embedded LICENSE `cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30`;
+NOTICE `27f0e45afdf10e406ee8bf478bfce38279e9087338a7981942a4a2762bcd5be8`.
+The Apache-2.0 source classification is not whole-distribution legal clearance.
+Transitive SBOM, redistribution, patents, standards, trademark, jurisdiction
+and freedom to operate remain unreviewed. No legal advice or clearance is given.
+Read-only Librarian reviewed local records and original code on 2026-09-06:
+no new source/API admission is needed; syntax gaps do not duplicate S01/S02/S12.
+PM retains the six fixtures above. The broken `[` fixture is a flow sequence,
+not a mapping. The invalid byte is surrounded by ASCII to expose replacement.
+No mapping-specific, parser-adoption or legal-clearance claim follows.
+
+## Stop rule
+
+Stop for PM raw review before Stage B, and before new fixtures/signatures,
+artifacts, parser/dependency/native policy, upstream implementation inspection,
+redistribution, or material IP/security uncertainty. Ordinary bounded harness
+failures may be corrected while retaining failed evidence.
+
+## Non-claims
+
+No generic YAML conformance, duplicate-key/alias/encoding/error policy, native
+parser, CLI, plugin, file transfer, lifecycle, File-to-File, or parent completion.
+An observed outcome does not automatically authorize a native behavior.

--- a/tests/t0012_config_syntax_probe_test.sh
+++ b/tests/t0012_config_syntax_probe_test.sh
@@ -39,6 +39,9 @@ def repair(directory):
         lines=[]
         for line in path.read_text().splitlines():
             _, recorded = line.split('  ',1); target=directory / Path(recorded).name
+            if not target.exists():
+                lines.append(line)
+                continue
             lines.append(hashlib.sha256(target.read_bytes()).hexdigest() + '  ' + recorded)
         path.write_text('\n'.join(lines)+'\n')
     hashes={p.name:hashlib.sha256(p.read_bytes()).hexdigest() for p in sorted(directory.iterdir()) if p.is_file() and p.name not in {'integrity.json','capture.exit'}}

--- a/tests/t0012_config_syntax_probe_test.sh
+++ b/tests/t0012_config_syntax_probe_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+runner="$root/tools/t0012-config-syntax-probe/run.sh"
+
+if [[ $# != 1 || $1 != --capture ]]; then
+  printf '%s\n' 'Stage A only: usage: --capture' >&2
+  exit 2
+fi
+
+bash -n "$runner"
+"$runner" --capture

--- a/tests/t0012_config_syntax_probe_test.sh
+++ b/tests/t0012_config_syntax_probe_test.sh
@@ -4,10 +4,105 @@ set -euo pipefail
 root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 runner="$root/tools/t0012-config-syntax-probe/run.sh"
 
-if [[ $# != 1 || $1 != --capture ]]; then
-  printf '%s\n' 'Stage A only: usage: --capture' >&2
+if [[ $# == 1 && $1 == --capture ]]; then
+  bash -n "$runner"
+  "$runner" --capture
+  exit $?
+elif [[ $# != 0 ]]; then
+  printf '%s\n' 'usage: [--capture]' >&2
   exit 2
 fi
 
 bash -n "$runner"
-"$runner" --capture
+python3 - "$runner" <<'PY'
+import base64, hashlib, json, os
+from pathlib import Path
+import shutil, subprocess, sys, tempfile, uuid
+
+runner = sys.argv[1]
+outer = Path(tempfile.mkdtemp(prefix='t0012-s13-controls.', dir='/private/tmp'))
+print(f'T0012_S13_TEST_EVIDENCE_DIR={outer}', flush=True)
+def check(value, message):
+    if not value: raise ValueError(message)
+def invoke(label, args, env=None):
+    with (outer / f'{label}.stdout').open('xb') as out, (outer / f'{label}.stderr').open('xb') as err:
+        result = subprocess.run(['bash', runner, *args], stdout=out, stderr=err, env=env, check=False)
+    (outer / f'{label}.exit').write_text(str(result.returncode) + '\n')
+    return result.returncode, (outer / f'{label}.stdout').read_text(), (outer / f'{label}.stderr').read_text()
+def evidence_from(stdout):
+    paths = [line.split('=', 1)[1] for line in stdout.splitlines() if line.startswith('T0012_S13_EVIDENCE_DIR=')]
+    check(len(paths) == 1, 'evidence marker')
+    return Path(paths[0])
+def repair(directory):
+    for path in directory.glob('*.sha256'):
+        if path.name in {'source.sha256','source-before.sha256','source-after.sha256','source-historical.sha256','plugin.sha256','executable.sha256'}: continue
+        lines=[]
+        for line in path.read_text().splitlines():
+            _, recorded = line.split('  ',1); target=directory / Path(recorded).name
+            lines.append(hashlib.sha256(target.read_bytes()).hexdigest() + '  ' + recorded)
+        path.write_text('\n'.join(lines)+'\n')
+    hashes={p.name:hashlib.sha256(p.read_bytes()).hexdigest() for p in sorted(directory.iterdir()) if p.is_file() and p.name not in {'integrity.json','capture.exit'}}
+    (directory/'integrity.json').write_text(json.dumps(hashes,sort_keys=True)+'\n')
+def change_events(directory, transform):
+    path=directory/'control.events.raw'; after=transform(path.read_text().splitlines(keepends=True)); path.write_text(''.join(after))
+    replacement=iter(after); stdout=directory/'control.stdout.log'
+    stdout.write_text(''.join(next(replacement,'') if line.startswith('SYNTAXTRACE|') else line for line in stdout.read_text().splitlines(keepends=True)))
+def mutate(directory, label):
+    if label == 'input': (directory/'control.yml').write_bytes((directory/'control.yml').read_bytes()+b'# changed\n')
+    elif label == 'missing-file': (directory/'quoted.events.raw').rename(outer/'removed-events.backup')
+    elif label == 'extra-file': (directory/'extra.txt').write_text('extra\n')
+    elif label == 'event-remove': change_events(directory, lambda x:x[:-1])
+    elif label == 'event-order':
+        def f(x):
+            first, second = x[0].split('|'), x[1].split('|')
+            first[5], second[5] = second[5], first[5]
+            x[0], x[1] = '|'.join(first), '|'.join(second)
+            return x
+        change_events(directory,f)
+    elif label == 'event-value':
+        def f(x): x[2]=x[2].replace('c3ludGF4LXZhbHVl',base64.b64encode(b'changed').decode()); return x
+        change_events(directory,f)
+    elif label == 'context':
+        def f(x):
+            a=x[-1].split('|'); a[3],a[4]=str(uuid.uuid4()),'1'; x[-1]='|'.join(a); return x
+        change_events(directory,f)
+    elif label == 'invocation': (directory/'control.invocation.txt').write_text(str(uuid.uuid4())+'\n')
+    elif label == 'exit': (directory/'control.exit.txt').write_text('1\n')
+    elif label == 'stderr': (directory/'control.stderr.log').write_text('changed\n')
+    elif label == 'source':
+        for name in ('source.sha256','source-before.sha256','source-after.sha256'):
+            text=(directory/name).read_text(); (directory/name).write_text('0'*64+text[64:])
+    elif label == 'integrity':
+        data=json.loads((directory/'integrity.json').read_text()); data['control.yml']='0'*64; (directory/'integrity.json').write_text(json.dumps(data,sort_keys=True)+'\n')
+    elif label == 'outcomes':
+        data=json.loads((directory/'stage-a-outcomes.json').read_text()); data['control']['exit']=1; (directory/'stage-a-outcomes.json').write_text(json.dumps(data,sort_keys=True)+'\n')
+    elif label == 'capture-exit': (directory/'capture.exit').write_text('1\n')
+    elif label == 'artifact': (directory/'executable.sha256').write_text('0'*64+'\n')
+    elif label == 'file-cap': (directory/'control.stdout.log').write_bytes(b'x'*1048577)
+    elif label == 'duplicate-value':
+        p=directory/'duplicate-field.events.raw'; p.write_text(p.read_text().replace('c2Vjb25kLXZhbHVl','Zmlyc3QtdmFsdWU=')); (directory/'duplicate-field.stdout.log').write_text((directory/'duplicate-field.stdout.log').read_text().replace('c2Vjb25kLXZhbHVl','Zmlyc3QtdmFsdWU='))
+    elif label == 'invalid-utf8': (directory/'invalid-utf8.yml').write_bytes((directory/'invalid-utf8.yml').read_bytes().replace(b'\xff',b'\xef\xbf\xbd'))
+    elif label == 'alias': (directory/'scalar-alias.yml').write_bytes((directory/'scalar-alias.yml').read_bytes().replace(b'seed: &v syntax-value\n',b'').replace(b'*v',b'syntax-value'))
+try:
+    env=dict(os.environ); env.pop('T0012_SYNTAX_NEGATIVE',None); env['T0012_SYNTAX_TEMP_ROOT']='/private/tmp/t0012-syntax'
+    code,stdout,stderr=invoke('full',['--full'],env); check(code==0,f'fresh full capture failed: {code}')
+    evidence=evidence_from(stdout); check(stdout.splitlines()==[f'T0012_S13_FULL_VALIDATED=6|evidence={evidence}',f'T0012_S13_EVIDENCE_DIR={evidence}'],'full marker')
+    code,stdout,stderr=invoke('positive',['--validate',str(evidence)]); check(code==0 and stdout=='T0012_S13_VALIDATE_ONLY=6\n' and stderr=='','positive validate')
+    controls={'input':'input-vector','missing-file':'file-set','extra-file':'file-set','event-remove':'event-vector','event-order':'event-vector','event-value':'event-vector','context':'context-vector','invocation':'event-identity','exit':'exit-vector','stderr':'stderr-vector','source':'source-identity','integrity':'integrity-hash','outcomes':'outcome-vector','capture-exit':'capture-exit','artifact':'artifact-identity','file-cap':'file-cap','duplicate-value':'event-vector','invalid-utf8':'input-vector','alias':'input-vector'}
+    for label, diagnostic in controls.items():
+        copy=outer/f'copy-{label}'; shutil.copytree(evidence,copy); mutate(copy,label)
+        if label!='integrity': repair(copy)
+        code,stdout,stderr=invoke(label,['--validate',str(copy)])
+        check(code==4 and stdout=='' and stderr==f'T0012_S13_VALIDATION_ERROR={diagnostic}\n',f'{label}: {code}/{stderr!r}')
+    alias=outer/'evidence-alias'; alias.symlink_to(evidence,target_is_directory=True)
+    code,stdout,stderr=invoke('symlink',['--validate',str(alias)]); check(code==1 and stdout=='' and stderr=='noncanonical, symlinked or repository evidence path\n','symlink')
+    for label,expected in (('corrupt-hash',3),('unavailable-runtime',56)):
+        code,stdout,stderr=invoke(label,['--full'],dict(env,T0012_SYNTAX_NEGATIVE=label)); negative=evidence_from(stdout)
+        check(code==expected and (negative/'capture.exit').read_text()==str(expected)+'\n','artifact exit')
+        check(not (negative/'control.yml').exists() and not (negative/'java-version.txt').exists(),'artifact early stop')
+        if label=='corrupt-hash': check(stderr=='pinned executable checksum mismatch\n' and (negative/'negative-control.txt').read_text()=='corrupt-copy-injected\n','corrupt boundary')
+        else: check(stderr.startswith('unable to retrieve pinned executable: https://github.com/embulk/embulk/releases/download/v0.11.5/unavailable-s13.jar'),'unavailable boundary')
+    print(f'T0012/S13: six selected syntax observations validated; 19 raw-copy controls, one path control, two artifact controls passed|evidence={outer}')
+except (OSError,ValueError) as failure:
+    print(f'T0012_S13_TEST_ERROR={failure}',file=sys.stderr); sys.exit(1)
+PY

--- a/tools/t0012-config-syntax-probe/run.sh
+++ b/tools/t0012-config-syntax-probe/run.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+root=$(cd -- "$here/../.." && pwd)
+source="$here/src/T0012ConfigSyntaxInputPlugin.java"
+wrapper="$root/tests/t0012_config_syntax_probe_test.sh"
+base=${T0012_SYNTAX_TEMP_ROOT:-/private/tmp/t0012-syntax}
+
+if [[ $# != 1 || $1 != --capture ]]; then
+  printf '%s\n' 'usage: --capture' >&2
+  exit 2
+fi
+
+# Reject repository paths, spelling aliases, and symlinked ancestors before writing.
+python3 - "$base" "$root" <<'PY'
+from pathlib import Path
+import sys
+
+requested, repository = map(Path, sys.argv[1:])
+allowed = (Path('/private/tmp'), Path('/private/var/folders'))
+if not requested.is_absolute() or str(requested) != sys.argv[1] or '..' in requested.parts:
+    raise SystemExit('noncanonical, symlinked or repository evidence path')
+existing = requested
+while not existing.exists() and existing != existing.parent:
+    existing = existing.parent
+if existing.is_symlink() or existing.resolve() != existing:
+    raise SystemExit('noncanonical, symlinked or repository evidence path')
+canonical = existing.joinpath(*requested.relative_to(existing).parts)
+if str(canonical) != str(requested) or not any(requested != item and requested.is_relative_to(item) for item in allowed):
+    raise SystemExit('noncanonical, symlinked or repository evidence path')
+if requested.is_relative_to(repository.resolve()):
+    raise SystemExit('noncanonical, symlinked or repository evidence path')
+PY
+
+mkdir -p "$base"
+run=$(mktemp -d "$base/run.XXXXXX")
+run=$(cd "$run" && pwd -P)
+evidence="$run/evidence"
+mkdir -p "$evidence" "$run/classes"
+
+finish() {
+  code=$?
+  printf '%s\n' "$code" > "$evidence/capture.exit"
+  printf 'T0012_S13_EVIDENCE_DIR=%s\n' "$evidence"
+}
+trap finish EXIT
+
+paths=("$source" "$here/run.sh" "$wrapper")
+git -C "$root" rev-parse HEAD > "$evidence/source-revision.txt"
+shasum -a 256 "${paths[@]}" > "$evidence/source-before.sha256"
+python3 - "$root" "$evidence/source-revision.txt" "$evidence/source-before.sha256" \
+  'tools/t0012-config-syntax-probe/src/T0012ConfigSyntaxInputPlugin.java' \
+  'tools/t0012-config-syntax-probe/run.sh' 'tests/t0012_config_syntax_probe_test.sh' <<'PY'
+import hashlib
+from pathlib import Path
+import subprocess
+import sys
+
+root, revision_file, digest_file, *relative = sys.argv[1:]
+revision = Path(revision_file).read_text().strip()
+lines = Path(digest_file).read_text().splitlines()
+if len(lines) != len(relative):
+    raise SystemExit('source hash framing failed')
+for line, path in zip(lines, relative):
+    digest, _ = line.split('  ', 1)
+    result = subprocess.run(['git', '-C', root, 'show', f'{revision}:{path}'], capture_output=True)
+    if result.returncode or hashlib.sha256(result.stdout).hexdigest() != digest:
+        raise SystemExit('source files must be committed before capture')
+PY
+cp "$evidence/source-before.sha256" "$evidence/source.sha256"
+
+jar="$run/embulk.jar"
+url=https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
+printf '%s\n' "$url" > "$evidence/executable-url.txt"
+download_code=0
+curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error -o "$jar" "$url" > "$evidence/download.stdout" 2> "$evidence/download.stderr" || download_code=$?
+printf '%s\n' "$download_code" > "$evidence/download.exit"
+[[ $download_code == 0 ]] || { printf 'unable to retrieve pinned executable: %s\n' "$url" >&2; exit 56; }
+[[ $(shasum -a 256 "$jar" | awk '{print $1}') == e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47 ]] || { printf '%s\n' 'pinned executable checksum mismatch' >&2; exit 3; }
+shasum -a 256 "$jar" | awk '{print $1}' > "$evidence/executable.sha256"
+unzip -p "$jar" META-INF/LICENSE > "$evidence/LICENSE-executable" || [[ -s "$evidence/LICENSE-executable" ]]
+unzip -p "$jar" META-INF/NOTICE > "$evidence/NOTICE-executable" || [[ -s "$evidence/NOTICE-executable" ]]
+[[ $(shasum -a 256 "$evidence/LICENSE-executable" | awk '{print $1}') == cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30 ]] || exit 3
+[[ $(shasum -a 256 "$evidence/NOTICE-executable" | awk '{print $1}') == 27f0e45afdf10e406ee8bf478bfce38279e9087338a7981942a4a2762bcd5be8 ]] || exit 3
+unzip -p "$jar" META-INF/MANIFEST.MF > "$evidence/executable-manifest.txt" || [[ -s "$evidence/executable-manifest.txt" ]]
+grep -Fq 'Main-Class: org.embulk.cli.Main' "$evidence/executable-manifest.txt"
+java -version > "$evidence/java-version.txt" 2>&1
+javac -version > "$evidence/javac-version.txt" 2>&1
+python3 --version > "$evidence/python-version.txt" 2>&1
+uname -a > "$evidence/os.txt"
+
+javac -cp "$jar" -d "$run/classes" "$source"
+manifest="$run/MANIFEST.MF"
+printf '%s\n' 'Manifest-Version: 1.0' 'Embulk-Plugin-Main-Class: T0012ConfigSyntaxInputPlugin' 'Embulk-Plugin-Category: input' 'Embulk-Plugin-Type: t0012_syntax' 'Embulk-Plugin-Spi-Version: 0' > "$manifest"
+plugin="$run/embulk-input-t0012_syntax-0.0.1.jar"
+jar cfm "$plugin" "$manifest" -C "$run/classes" .
+printf '%s' '<project><modelVersion>4.0.0</modelVersion><groupId>org.embulk.t0012</groupId><artifactId>embulk-input-t0012_syntax</artifactId><version>0.0.1</version></project>' > "${plugin%.jar}.pom"
+shasum -a 256 "$plugin" > "$evidence/plugin.sha256"
+printf '%s\n' 'org.embulk.t0012:embulk-input-t0012_syntax:0.0.1|local-only' > "$evidence/plugin-coordinate.txt"
+
+python3 - "$evidence" <<'PY'
+from pathlib import Path
+import sys
+
+d = Path(sys.argv[1])
+prefix = b'in:\n  type:\n    source: maven\n    group: org.embulk.t0012\n    name: t0012_syntax\n    version: 0.0.1\n'
+suffix = b'out:\n  type: "null"\n'
+fixtures = {
+    'control': prefix + b'  field: syntax-value\n' + suffix,
+    'quoted': prefix + b'  field: "syntax-value"\n' + suffix,
+    'duplicate-field': prefix + b'  field: first-value\n  field: second-value\n' + suffix,
+    'malformed-flow': prefix + b'  field: [unterminated\n' + suffix,
+    'scalar-alias': b'seed: &v syntax-value\n' + prefix + b'  field: *v\n' + suffix,
+    'invalid-utf8': prefix + b'  field: bad-\xff-value\n' + suffix,
+}
+for name, data in fixtures.items():
+    if not data.endswith(b'\n'):
+        raise SystemExit('fixture LF missing')
+    (d / f'{name}.yml').write_bytes(data)
+PY
+
+for name in control quoted duplicate-field malformed-flow scalar-alias invalid-utf8; do
+  case_home="$run/home/$name"
+  destination="$case_home/lib/m2/repository/org/embulk/t0012/embulk-input-t0012_syntax/0.0.1"
+  mkdir -p "$destination"
+  cp "$plugin" "${plugin%.jar}.pom" "$destination/"
+  invocation=$(python3 -c 'import uuid; print(uuid.uuid4())')
+  status=0
+  EMBULK_HOME="$case_home" T0012_SYNTAX_CASE="$name" T0012_SYNTAX_INVOCATION="$invocation" \
+    java -jar "$jar" "-Xembulk_home=$case_home" run "$evidence/$name.yml" > "$evidence/$name.stdout.log" 2> "$evidence/$name.stderr.log" || status=$?
+  printf '%s\n' "$status" > "$evidence/$name.exit.txt"
+  grep '^SYNTAXTRACE|' "$evidence/$name.stdout.log" > "$evidence/$name.events.raw" || :
+  printf '%s\n' "$invocation" > "$evidence/$name.invocation.txt"
+  shasum -a 256 "$evidence/$name.yml" "$evidence/$name.stdout.log" "$evidence/$name.stderr.log" "$evidence/$name.events.raw" > "$evidence/$name.sha256"
+done
+shasum -a 256 "${paths[@]}" > "$evidence/source-after.sha256"
+cmp "$evidence/source-before.sha256" "$evidence/source-after.sha256"
+
+# Stage A intentionally checks framing and the known-good control only; it records no selected outcome vectors.
+python3 - "$evidence" <<'PY'
+import base64
+import hashlib
+import json
+import re
+from pathlib import Path
+import sys
+import uuid
+
+d = Path(sys.argv[1])
+cases = ('control', 'quoted', 'duplicate-field', 'malformed-flow', 'scalar-alias', 'invalid-utf8')
+arity = {'transaction-entry': 0, 'config-load-entry': 0, 'config-value': 1, 'config-exception': 2,
+         'control-entry': 0, 'control-return': 0, 'callback-exception': 2, 'transaction-return': 0,
+         'run-entry': 0, 'finish-entry': 0, 'finish-return': 0, 'run-return': 0, 'cleanup-entry': 0, 'cleanup-return': 0}
+def fail(message): raise ValueError(message)
+def raw(path):
+    if not path.is_file() or path.is_symlink(): fail('file-kind')
+    with path.open('rb') as stream:
+        data = stream.read(1048577)
+    if len(data) > 1048576: fail('file-cap')
+    return data
+seen = set()
+outcomes = {}
+for name in cases:
+    fixture = raw(d / f'{name}.yml')
+    if not fixture.endswith(b'\n'): fail('fixture-lf')
+    invocation = raw(d / f'{name}.invocation.txt').decode('ascii').strip()
+    if str(uuid.UUID(invocation)) != invocation: fail('invocation')
+    if invocation in seen or raw(d / f'{name}.invocation.txt') != (invocation + '\n').encode(): fail('invocation-duplicate')
+    seen.add(invocation)
+    exit_text = raw(d / f'{name}.exit.txt').decode('ascii')
+    if not re.fullmatch(r'-?[0-9]+\n', exit_text): fail('exit')
+    stdout, events = raw(d / f'{name}.stdout.log'), raw(d / f'{name}.events.raw')
+    if events != b''.join(line for line in stdout.splitlines(keepends=True) if line.startswith(b'SYNTAXTRACE|')): fail('event-stdout')
+    counters = {}
+    parsed = []
+    if events and (not events.endswith(b'\n') or b'\r' in events): fail('event-transport')
+    for line in events.decode('utf-8').splitlines():
+        parts = line.split('|')
+        if len(parts) < 6 or parts[0] != 'SYNTAXTRACE' or parts[1] != name or parts[2] != invocation: fail('event-identity')
+        if str(uuid.UUID(parts[3])) != parts[3] or parts[4] != str(counters.get(parts[3], 0) + 1): fail('event-sequence')
+        counters[parts[3]] = int(parts[4])
+        if parts[5] not in arity or len(parts) != 6 + arity[parts[5]]: fail('event-vocabulary')
+        payload = []
+        for value in parts[6:]:
+            if value != '-':
+                decoded = base64.b64decode(value, validate=True)
+                if base64.b64encode(decoded).decode() != value: fail('event-base64')
+                payload.append(decoded.decode('utf-8'))
+            else:
+                payload.append(None)
+        parsed.append([parts[5], payload])
+    outcomes[name] = {'exit': int(exit_text), 'events': parsed}
+    lines = raw(d / f'{name}.sha256').decode('ascii').splitlines()
+    if len(lines) != 4: fail('case-hash-count')
+    for line, suffix in zip(lines, ('yml', 'stdout.log', 'stderr.log', 'events.raw')):
+        digest, path = line.split('  ', 1)
+        if Path(path).name != f'{name}.{suffix}' or digest != hashlib.sha256(raw(d / f'{name}.{suffix}')).hexdigest(): fail('case-hash')
+control = outcomes['control']
+if control['exit'] != 0 or ['config-value', ['syntax-value']] not in control['events'] or ['run-return', []] not in control['events']:
+    fail('control-result')
+with (d / 'stage-a-outcomes.json').open('x') as stream:
+    stream.write(json.dumps(outcomes, sort_keys=True) + '\n')
+hashes = {p.name: hashlib.sha256(raw(p)).hexdigest() for p in sorted(d.iterdir()) if p.is_file()}
+with (d / 'integrity.json').open('x') as stream:
+    stream.write(json.dumps(hashes, sort_keys=True) + '\n')
+PY
+
+printf 'T0012_S13_STAGE_A_CAPTURED=6|evidence=%s\n' "$evidence"

--- a/tools/t0012-config-syntax-probe/run.sh
+++ b/tools/t0012-config-syntax-probe/run.sh
@@ -7,10 +7,12 @@ source="$here/src/T0012ConfigSyntaxInputPlugin.java"
 wrapper="$root/tests/t0012_config_syntax_probe_test.sh"
 base=${T0012_SYNTAX_TEMP_ROOT:-/private/tmp/t0012-syntax}
 
-if [[ $# != 1 || $1 != --capture ]]; then
-  printf '%s\n' 'usage: --capture' >&2
-  exit 2
-fi
+mode=${1:---full}
+case "$mode" in
+  --capture|--full) [[ $# -le 1 ]] || exit 2 ;;
+  --validate) [[ $# == 2 ]] || exit 2; base=$2 ;;
+  *) printf '%s\n' 'usage: [--full|--capture|--validate EVIDENCE]' >&2; exit 2 ;;
+esac
 
 # Reject repository paths, spelling aliases, and symlinked ancestors before writing.
 python3 - "$base" "$root" <<'PY'
@@ -33,6 +35,7 @@ if requested.is_relative_to(repository.resolve()):
     raise SystemExit('noncanonical, symlinked or repository evidence path')
 PY
 
+if [[ $mode != --validate ]]; then
 mkdir -p "$base"
 run=$(mktemp -d "$base/run.XXXXXX")
 run=$(cd "$run" && pwd -P)
@@ -69,14 +72,28 @@ for line, path in zip(lines, relative):
         raise SystemExit('source files must be committed before capture')
 PY
 cp "$evidence/source-before.sha256" "$evidence/source.sha256"
+printf '%s  %s\n' \
+  '5f29ac5bef4ffa52dead57f7bf13b6f40dfd444384bbb7d775f40998d39859b3' "$source" \
+  '0561850fd53275a31231c6913fad55ffe977ffbba8a4600633acddbfd6fc11fe' "$here/run.sh" \
+  '3be9134aadf5f0b87fc9a1605fdf8bfd21d46e484a68c68c687db135f5ee8a88' "$wrapper" > "$evidence/source-historical.sha256"
 
 jar="$run/embulk.jar"
 url=https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
+case ${T0012_SYNTAX_NEGATIVE:-} in
+  '') ;;
+  unavailable-runtime) url=https://github.com/embulk/embulk/releases/download/v0.11.5/unavailable-s13.jar ;;
+  corrupt-hash) ;;
+  *) printf '%s\n' 'unknown artifact control' >&2; exit 2 ;;
+esac
 printf '%s\n' "$url" > "$evidence/executable-url.txt"
 download_code=0
 curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error -o "$jar" "$url" > "$evidence/download.stdout" 2> "$evidence/download.stderr" || download_code=$?
 printf '%s\n' "$download_code" > "$evidence/download.exit"
 [[ $download_code == 0 ]] || { printf 'unable to retrieve pinned executable: %s\n' "$url" >&2; exit 56; }
+if [[ ${T0012_SYNTAX_NEGATIVE:-} == corrupt-hash ]]; then
+  printf '%s' 'corrupt' >> "$jar"
+  printf '%s\n' 'corrupt-copy-injected' > "$evidence/negative-control.txt"
+fi
 [[ $(shasum -a 256 "$jar" | awk '{print $1}') == e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47 ]] || { printf '%s\n' 'pinned executable checksum mismatch' >&2; exit 3; }
 shasum -a 256 "$jar" | awk '{print $1}' > "$evidence/executable.sha256"
 unzip -p "$jar" META-INF/LICENSE > "$evidence/LICENSE-executable" || [[ -s "$evidence/LICENSE-executable" ]]
@@ -137,18 +154,29 @@ done
 shasum -a 256 "${paths[@]}" > "$evidence/source-after.sha256"
 cmp "$evidence/source-before.sha256" "$evidence/source-after.sha256"
 
-# Stage A intentionally checks framing and the known-good control only; it records no selected outcome vectors.
-python3 - "$evidence" <<'PY'
+else
+evidence=$base
+fi
+
+# Capture preserves Stage A's framing-only behavior; full/validate bind the reviewed vectors.
+python3 - "$evidence" "$root" "$mode" <<'PY'
 import base64
 import hashlib
 import json
 import re
 from pathlib import Path
+import subprocess
 import sys
 import uuid
 
-d = Path(sys.argv[1])
+d, root, mode = Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3]
 cases = ('control', 'quoted', 'duplicate-field', 'malformed-flow', 'scalar-alias', 'invalid-utf8')
+input_hashes = dict(zip(cases, ('b6529ab10a9be386b12e6e26c75344ee4903e85464df1863e4e638398e4bee14',
+    'ad50b4ddf3864a4cebc2c88ca562e5fb3a94105f5d30bda41be9ab14c87ba2c5',
+    '7a8659ae16b67e5a909c906477f511d6aa319c79d8c9ec0aad9fa661d398f257',
+    '6f2b75feeb5f1df992e3f2472b7f1df53752fe4ee6bb3d9781cde2dfa3767cea',
+    'f76fb799c7228956d07f25d340bb5325176c060073cc88f726a253e1dba9c4bf',
+    '6856e72333e988149d1fe972c6c7790bf01893790bccaf86f7b496b0e9d1f056')))
 arity = {'transaction-entry': 0, 'config-load-entry': 0, 'config-value': 1, 'config-exception': 2,
          'control-entry': 0, 'control-return': 0, 'callback-exception': 2, 'transaction-return': 0,
          'run-entry': 0, 'finish-entry': 0, 'finish-return': 0, 'run-return': 0, 'cleanup-entry': 0, 'cleanup-return': 0}
@@ -159,51 +187,115 @@ def raw(path):
         data = stream.read(1048577)
     if len(data) > 1048576: fail('file-cap')
     return data
-seen = set()
-outcomes = {}
-for name in cases:
-    fixture = raw(d / f'{name}.yml')
-    if not fixture.endswith(b'\n'): fail('fixture-lf')
-    invocation = raw(d / f'{name}.invocation.txt').decode('ascii').strip()
-    if str(uuid.UUID(invocation)) != invocation: fail('invocation')
-    if invocation in seen or raw(d / f'{name}.invocation.txt') != (invocation + '\n').encode(): fail('invocation-duplicate')
-    seen.add(invocation)
-    exit_text = raw(d / f'{name}.exit.txt').decode('ascii')
-    if not re.fullmatch(r'-?[0-9]+\n', exit_text): fail('exit')
-    stdout, events = raw(d / f'{name}.stdout.log'), raw(d / f'{name}.events.raw')
-    if events != b''.join(line for line in stdout.splitlines(keepends=True) if line.startswith(b'SYNTAXTRACE|')): fail('event-stdout')
-    counters = {}
-    parsed = []
-    if events and (not events.endswith(b'\n') or b'\r' in events): fail('event-transport')
-    for line in events.decode('utf-8').splitlines():
-        parts = line.split('|')
-        if len(parts) < 6 or parts[0] != 'SYNTAXTRACE' or parts[1] != name or parts[2] != invocation: fail('event-identity')
-        if str(uuid.UUID(parts[3])) != parts[3] or parts[4] != str(counters.get(parts[3], 0) + 1): fail('event-sequence')
-        counters[parts[3]] = int(parts[4])
-        if parts[5] not in arity or len(parts) != 6 + arity[parts[5]]: fail('event-vocabulary')
-        payload = []
-        for value in parts[6:]:
-            if value != '-':
-                decoded = base64.b64decode(value, validate=True)
-                if base64.b64encode(decoded).decode() != value: fail('event-base64')
-                payload.append(decoded.decode('utf-8'))
+def pairs(items):
+    value = {}
+    for key, item in items:
+        if key in value: fail('json-duplicate')
+        value[key] = item
+    return value
+def text(path): return raw(path).decode('utf-8')
+def read_json(path):
+    value = json.loads(text(path), object_pairs_hook=pairs)
+    if text(path) != json.dumps(value, sort_keys=True) + '\n': fail('json-transport')
+    return value
+try:
+    metadata = {'LICENSE-executable', 'NOTICE-executable', 'download.exit', 'download.stderr', 'download.stdout',
+        'executable-manifest.txt', 'executable.sha256', 'executable-url.txt', 'java-version.txt', 'javac-version.txt',
+        'os.txt', 'plugin-coordinate.txt', 'plugin.sha256', 'python-version.txt', 'source-after.sha256', 'source-before.sha256',
+        'source-historical.sha256', 'source-revision.txt', 'source.sha256'}
+    expected_files = metadata | {f'{name}.{suffix}' for name in cases for suffix in ('yml', 'exit.txt', 'events.raw', 'stdout.log', 'stderr.log', 'invocation.txt', 'sha256')}
+    if mode == '--validate': expected_files |= {'capture.exit', 'integrity.json', 'stage-a-outcomes.json'}
+    if set(p.name for p in d.iterdir()) != expected_files: fail('file-set')
+    for filename in expected_files: raw(d / filename)
+    if mode == '--validate':
+        if text(d / 'capture.exit') != '0\n': fail('capture-exit')
+        integrity = read_json(d / 'integrity.json')
+        if set(integrity) != expected_files - {'integrity.json', 'capture.exit'} or any(integrity[k] != hashlib.sha256(raw(d / k)).hexdigest() for k in integrity): fail('integrity-hash')
+    revision = text(d / 'source-revision.txt').strip()
+    if not re.fullmatch('[0-9a-f]{40}', revision) or text(d / 'source-revision.txt') != revision + '\n': fail('source-revision')
+    if text(d / 'source-before.sha256') != text(d / 'source-after.sha256') or text(d / 'source-before.sha256') != text(d / 'source.sha256'): fail('source-changed')
+    relative = ('tools/t0012-config-syntax-probe/src/T0012ConfigSyntaxInputPlugin.java', 'tools/t0012-config-syntax-probe/run.sh', 'tests/t0012_config_syntax_probe_test.sh')
+    source_lines = text(d / 'source.sha256').splitlines()
+    if len(source_lines) != 3: fail('source-count')
+    for line, path in zip(source_lines, relative):
+        digest, recorded = line.split('  ', 1)
+        result = subprocess.run(['git', '-C', str(root), 'show', f'{revision}:{path}'], capture_output=True)
+        if not re.fullmatch('[0-9a-f]{64}', digest) or not recorded.endswith('/' + path) or result.returncode or hashlib.sha256(result.stdout).hexdigest() != digest: fail('source-identity')
+    historical_hashes = ('5f29ac5bef4ffa52dead57f7bf13b6f40dfd444384bbb7d775f40998d39859b3', '0561850fd53275a31231c6913fad55ffe977ffbba8a4600633acddbfd6fc11fe', '3be9134aadf5f0b87fc9a1605fdf8bfd21d46e484a68c68c687db135f5ee8a88')
+    historical = text(d / 'source-historical.sha256').splitlines()
+    if len(historical) != 3 or any(
+        len(line.split('  ', 1)) != 2 or line.split('  ', 1)[0] != digest or not line.split('  ', 1)[1].endswith('/' + path)
+        for line, digest, path in zip(historical, historical_hashes, relative)
+    ): fail('source-historical')
+    if text(d / 'executable.sha256') != 'e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47\n' or text(d / 'executable-url.txt') != 'https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar\n': fail('artifact-identity')
+    if hashlib.sha256(raw(d / 'LICENSE-executable')).hexdigest() != 'cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30' or hashlib.sha256(raw(d / 'NOTICE-executable')).hexdigest() != '27f0e45afdf10e406ee8bf478bfce38279e9087338a7981942a4a2762bcd5be8': fail('artifact-notice')
+    expected_names = ['transaction-entry', 'config-load-entry', 'config-value', 'control-entry', 'run-entry', 'finish-entry', 'finish-return', 'run-return', 'control-return', 'transaction-return', 'cleanup-entry', 'cleanup-return']
+    values = {'control': 'syntax-value', 'quoted': 'syntax-value', 'duplicate-field': 'second-value', 'scalar-alias': 'syntax-value', 'invalid-utf8': 'bad-\ufffd-value'}
+    seen, contexts, outcomes = set(), set(), {}
+    for name in cases:
+        fixture = raw(d / f'{name}.yml')
+        if not fixture.endswith(b'\n'): fail('fixture-lf')
+        invocation = text(d / f'{name}.invocation.txt').strip()
+        if str(uuid.UUID(invocation)) != invocation or invocation in seen or text(d / f'{name}.invocation.txt') != invocation + '\n': fail('invocation-duplicate')
+        seen.add(invocation)
+        exit_text = text(d / f'{name}.exit.txt')
+        if not re.fullmatch(r'-?[0-9]+\n', exit_text): fail('exit')
+        stdout, stderr, events = raw(d / f'{name}.stdout.log'), raw(d / f'{name}.stderr.log'), raw(d / f'{name}.events.raw')
+        if events != b''.join(line for line in stdout.splitlines(keepends=True) if line.startswith(b'SYNTAXTRACE|')): fail('event-stdout')
+        if events and (not events.endswith(b'\n') or b'\r' in events): fail('event-transport')
+        parsed, counters = [], {}
+        for line in events.decode('utf-8').splitlines():
+            fields = line.split('|')
+            if len(fields) < 6 or fields[0] != 'SYNTAXTRACE' or fields[1] != name or fields[2] != invocation: fail('event-identity')
+            if str(uuid.UUID(fields[3])) != fields[3] or fields[4] != str(counters.get(fields[3], 0) + 1): fail('event-sequence')
+            counters[fields[3]] = int(fields[4])
+            if fields[5] not in arity or len(fields) != 6 + arity[fields[5]]: fail('event-vocabulary')
+            payload = []
+            for value in fields[6:]:
+                if value == '-':
+                    payload.append(None)
+                else:
+                    decoded = base64.b64decode(value, validate=True)
+                    if base64.b64encode(decoded).decode() != value: fail('event-base64')
+                    payload.append(decoded.decode('utf-8'))
+            parsed.append([fields[5], payload])
+        outcomes[name] = {'exit': int(exit_text), 'events': parsed}
+        lines = text(d / f'{name}.sha256').splitlines()
+        suffixes = ('yml','stdout.log','stderr.log','events.raw')
+        if len(lines) != 4 or any(
+            len(part.split('  ', 1)) != 2 or Path(part.split('  ', 1)[1]).name != f'{name}.{suffix}'
+            or part.split('  ', 1)[0] != hashlib.sha256(raw(d / f'{name}.{suffix}')).hexdigest()
+            for part, suffix in zip(lines, suffixes)
+        ): fail('case-hash')
+        if mode != '--capture':
+            if hashlib.sha256(fixture).hexdigest() != input_hashes[name]: fail('input-vector')
+            if name == 'malformed-flow':
+                if exit_text != '1\n': fail('exit-vector')
+                if parsed: fail('event-vector')
+                if hashlib.sha256(stderr).hexdigest() != '480dfb5bc6be8e8e567869545710d73db2ce87b80882b372e735021606e3c950': fail('stderr-vector')
             else:
-                payload.append(None)
-        parsed.append([parts[5], payload])
-    outcomes[name] = {'exit': int(exit_text), 'events': parsed}
-    lines = raw(d / f'{name}.sha256').decode('ascii').splitlines()
-    if len(lines) != 4: fail('case-hash-count')
-    for line, suffix in zip(lines, ('yml', 'stdout.log', 'stderr.log', 'events.raw')):
-        digest, path = line.split('  ', 1)
-        if Path(path).name != f'{name}.{suffix}' or digest != hashlib.sha256(raw(d / f'{name}.{suffix}')).hexdigest(): fail('case-hash')
-control = outcomes['control']
-if control['exit'] != 0 or ['config-value', ['syntax-value']] not in control['events'] or ['run-return', []] not in control['events']:
-    fail('control-result')
-with (d / 'stage-a-outcomes.json').open('x') as stream:
-    stream.write(json.dumps(outcomes, sort_keys=True) + '\n')
-hashes = {p.name: hashlib.sha256(raw(p)).hexdigest() for p in sorted(d.iterdir()) if p.is_file()}
-with (d / 'integrity.json').open('x') as stream:
-    stream.write(json.dumps(hashes, sort_keys=True) + '\n')
+                if exit_text != '0\n': fail('exit-vector')
+                if stderr: fail('stderr-vector')
+                if len(counters) != 1 or set(counters) & contexts: fail('context-vector')
+                if [event[0] for event in parsed] != expected_names or parsed[2] != ['config-value', [values[name]]]: fail('event-vector')
+                contexts.update(counters)
+    if mode == '--validate':
+        if len(seen) != 6 or len(contexts) != 5 or read_json(d / 'stage-a-outcomes.json') != outcomes: fail('outcome-vector')
+    control = outcomes['control']
+    if control['exit'] != 0 or ['config-value', ['syntax-value']] not in control['events'] or ['run-return', []] not in control['events']:
+        fail('control-result')
+except (OSError, ValueError, UnicodeError, subprocess.SubprocessError) as failure:
+    print(f'T0012_S13_VALIDATION_ERROR={failure}', file=sys.stderr)
+    sys.exit(4)
+if mode != '--validate':
+    # Capture records raw values; only --full emits a reviewed success marker.
+    with (d / 'stage-a-outcomes.json').open('x') as stream: stream.write(json.dumps(outcomes, sort_keys=True) + '\n')
+    hashes = {p.name: hashlib.sha256(raw(p)).hexdigest() for p in sorted(d.iterdir()) if p.is_file()}
+    with (d / 'integrity.json').open('x') as stream: stream.write(json.dumps(hashes, sort_keys=True) + '\n')
 PY
 
-printf 'T0012_S13_STAGE_A_CAPTURED=6|evidence=%s\n' "$evidence"
+case "$mode" in
+  --capture) printf 'T0012_S13_STAGE_A_CAPTURED=6|evidence=%s\n' "$evidence" ;;
+  --full) printf 'T0012_S13_FULL_VALIDATED=6|evidence=%s\n' "$evidence" ;;
+  --validate) printf '%s\n' 'T0012_S13_VALIDATE_ONLY=6' ;;
+esac

--- a/tools/t0012-config-syntax-probe/src/T0012ConfigSyntaxInputPlugin.java
+++ b/tools/t0012-config-syntax-probe/src/T0012ConfigSyntaxInputPlugin.java
@@ -1,0 +1,54 @@
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import org.embulk.config.*;
+import org.embulk.spi.*;
+
+/** Local Stage A observer for selected input bytes; it defines no product policy. */
+public final class T0012ConfigSyntaxInputPlugin implements InputPlugin {
+  public interface ConfigTask extends Task { @Config("field") String getField(); }
+  private static final String CASE = System.getenv("T0012_SYNTAX_CASE");
+  private static final String INVOCATION = System.getenv("T0012_SYNTAX_INVOCATION");
+  private static final String CONTEXT = UUID.randomUUID().toString();
+  private static int sequence;
+
+  private static String encoded(String value) {
+    return value == null ? "-" : Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void event(String name, String... values) {
+    StringBuilder line = new StringBuilder("SYNTAXTRACE|").append(CASE).append('|')
+        .append(INVOCATION).append('|').append(CONTEXT).append('|').append(++sequence).append('|').append(name);
+    for (String value : values) line.append('|').append(encoded(value));
+    System.out.println(line);
+  }
+
+  public ConfigDiff transaction(ConfigSource config, Control control) {
+    event("transaction-entry");
+    event("config-load-entry");
+    try {
+      event("config-value", config.loadConfig(ConfigTask.class).getField());
+    } catch (RuntimeException failure) {
+      event("config-exception", failure.getClass().getName(), failure.getMessage());
+      throw failure;
+    }
+    try {
+      event("control-entry");
+      control.run(Exec.newTaskSource(), Schema.builder().build(), 1);
+      event("control-return");
+    } catch (RuntimeException failure) {
+      event("callback-exception", failure.getClass().getName(), failure.getMessage());
+      throw failure;
+    }
+    event("transaction-return");
+    return Exec.newConfigDiff();
+  }
+
+  public ConfigDiff resume(TaskSource task, Schema schema, int tasks, Control control) { return Exec.newConfigDiff(); }
+  public void cleanup(TaskSource task, Schema schema, int tasks, List<TaskReport> reports) { event("cleanup-entry"); event("cleanup-return"); }
+  public TaskReport run(TaskSource task, Schema schema, int index, PageOutput output) {
+    event("run-entry"); event("finish-entry"); output.finish(); event("finish-return"); event("run-return"); return Exec.newTaskReport();
+  }
+  public ConfigDiff guess(ConfigSource config) { return Exec.newConfigDiff(); }
+}


### PR DESCRIPTION
Tracks #15, T-0012/S13. Implements six original pinned-reference syntax fixtures and strict evidence validation with 19 raw-copy, one path and two artifact controls. Packet: docs/provenance/T-0012-config-syntax-probe.md. Demo: bash tests/t0012_config_syntax_probe_test.sh && bash tests/t0012_config_envelope_probe_test.sh. S13 wrapper passes at d95f2a9; exact final-head primary and independent Demo pending. Reference Observation / Integration and validator Unit/Contract only; no native parser, dependency, public policy, transfer or parent completion.