### PR TITLE
feat(t-0031): deliver experimental text File-to-File transfer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,7 @@ T-0022/S01 is reserved for an isolated parser-candidate experiment (forecast
 defines decision gates; artifact admission and an execution packet are required
 before Ready. T-0022 remains Backlog; parent Initial 8 is unchanged.
 
-T-0031/S01 is In Progress (5 SP) for an experimental native UTF-8 line-record
+T-0031/S01 is in Review in PR #110 (5 SP) for an experimental native UTF-8 line-record
 File-to-File command under ADR-0015. It consumes T-0021/S06 without claiming
 the parent's YAML, schema-aware plugin, transaction or full MVP contracts.
 
@@ -81,7 +81,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0030 | Epic: Native File-to-File ETL | Backlog | P1 | — | T-0020 | Project Manager | Planning |
-| T-0031 | Implement file/config inputs and file/stdout/null outputs (S01 experimental transfer In Progress) | In Progress | P1 | 5 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
+| T-0031 | Implement file/config inputs and file/stdout/null outputs (S01 experimental transfer in Review) | Review | P1 | 5 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0032 | Implement the CSV parser and formatter | Backlog | P1 | 8 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0033 | Implement the JSON parser | Backlog | P1 | 5 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,10 @@ T-0022/S01 is reserved for an isolated parser-candidate experiment (forecast
 defines decision gates; artifact admission and an execution packet are required
 before Ready. T-0022 remains Backlog; parent Initial 8 is unchanged.
 
+T-0031/S01 is In Progress (5 SP) for an experimental native UTF-8 line-record
+File-to-File command under ADR-0015. It consumes T-0021/S06 without claiming
+the parent's YAML, schema-aware plugin, transaction or full MVP contracts.
+
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
 T-0030–T-0037 and T-0060–T-0067 are `Native Plugins`; T-0040–T-0045 are
@@ -77,7 +81,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0030 | Epic: Native File-to-File ETL | Backlog | P1 | — | T-0020 | Project Manager | Planning |
-| T-0031 | Implement file/config inputs and file/stdout/null outputs | Backlog | P1 | 5 | T-0022, T-0023 | Plugin Implementer | Unit/Contract |
+| T-0031 | Implement file/config inputs and file/stdout/null outputs (S01 experimental transfer In Progress) | In Progress | P1 | 5 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0032 | Implement the CSV parser and formatter | Backlog | P1 | 8 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0033 | Implement the JSON parser | Backlog | P1 | 5 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |

--- a/crates/emburk-cli/src/main.rs
+++ b/crates/emburk-cli/src/main.rs
@@ -40,9 +40,14 @@ fn transfer(input: &Path, output: &Path) -> Result<(), String> {
         return Err("input must be a regular file".into());
     }
     let input_file = File::open(input).map_err(|error| format!("cannot open input: {error}"))?;
-    let output_file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let output_file = options
         .open(output)
         .map_err(|error| format!("cannot create output exclusively: {error}"))?;
     match emburk_core::transfer_lines(BufReader::new(input_file), output_file) {

--- a/crates/emburk-cli/src/main.rs
+++ b/crates/emburk-cli/src/main.rs
@@ -1,5 +1,58 @@
 #![forbid(unsafe_code)]
 
+use std::{
+    env,
+    fs::{self, File, OpenOptions},
+    io::BufReader,
+    path::Path,
+};
+
 fn main() {
-    println!("{}", emburk_core::DEVELOPMENT_STATUS);
+    let arguments: Vec<_> = env::args_os().collect();
+    if arguments.len() == 1 {
+        println!("{}", emburk_core::DEVELOPMENT_STATUS);
+        return;
+    }
+    if arguments.len() == 2
+        && matches!(
+            arguments.get(1).and_then(|value| value.to_str()),
+            Some("--help" | "-h")
+        )
+    {
+        println!("Usage: emburk transfer-lines INPUT OUTPUT");
+        return;
+    }
+    if arguments.len() != 4 || arguments[1] != "transfer-lines" {
+        eprintln!("Usage: emburk transfer-lines INPUT OUTPUT");
+        std::process::exit(2);
+    }
+    let input = Path::new(&arguments[2]);
+    let output = Path::new(&arguments[3]);
+    if let Err(error) = transfer(input, output) {
+        eprintln!("emburk: transfer-lines failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn transfer(input: &Path, output: &Path) -> Result<(), String> {
+    let metadata = fs::metadata(input).map_err(|error| format!("cannot inspect input: {error}"))?;
+    if !metadata.is_file() {
+        return Err("input must be a regular file".into());
+    }
+    let input_file = File::open(input).map_err(|error| format!("cannot open input: {error}"))?;
+    let output_file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(output)
+        .map_err(|error| format!("cannot create output exclusively: {error}"))?;
+    match emburk_core::transfer_lines(BufReader::new(input_file), output_file) {
+        Ok(count) => {
+            println!("emburk: transfer-lines completed: {count} records");
+            Ok(())
+        }
+        Err(error) => Err(format!(
+            "{error}; output may be partially written at {}",
+            output.display()
+        )),
+    }
 }

--- a/crates/emburk-cli/tests/file_transfer.rs
+++ b/crates/emburk-cli/tests/file_transfer.rs
@@ -8,6 +8,29 @@ use std::{
 
 static NEXT_DIRECTORY: AtomicUsize = AtomicUsize::new(0);
 
+#[cfg(unix)]
+#[test]
+fn output_is_owner_only_even_with_permissive_umask() {
+    use std::os::unix::fs::PermissionsExt;
+    let directory = directory("permissions");
+    let input = directory.join("input.txt");
+    let output = directory.join("output.txt");
+    fs::write(&input, b"private\n").unwrap();
+    let result = Command::new("/bin/sh")
+        .args(["-c", "umask 000; exec \"$@\"", "transfer-test"])
+        .arg(env!("CARGO_BIN_EXE_emburk"))
+        .arg("transfer-lines")
+        .arg(&input)
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(result.status.success());
+    assert_eq!(
+        fs::metadata(&output).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+}
+
 fn directory(name: &str) -> PathBuf {
     let unique = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
     let path = std::env::temp_dir().join(format!(

--- a/crates/emburk-cli/tests/file_transfer.rs
+++ b/crates/emburk-cli/tests/file_transfer.rs
@@ -1,0 +1,208 @@
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+static NEXT_DIRECTORY: AtomicUsize = AtomicUsize::new(0);
+
+fn directory(name: &str) -> PathBuf {
+    let unique = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "emburk-file-transfer-{}-{}-{unique}",
+        std::process::id(),
+        name
+    ));
+    fs::create_dir(&path).unwrap();
+    path
+}
+
+fn run(directory: &Path, arguments: &[&OsStr]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_emburk"))
+        .args(arguments)
+        .current_dir(directory)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn retains_development_status_and_exposes_help_and_argument_errors() {
+    let directory = directory("arguments");
+    let status = run(&directory, &[]);
+    assert!(status.status.success());
+    assert!(
+        String::from_utf8_lossy(&status.stdout).contains("experimental text transfer available")
+    );
+    let help = run(&directory, &[OsStr::new("--help")]);
+    assert!(help.status.success());
+    assert!(String::from_utf8_lossy(&help.stdout).contains("transfer-lines INPUT OUTPUT"));
+    let invalid = run(&directory, &[OsStr::new("transfer-lines")]);
+    assert_eq!(invalid.status.code(), Some(2));
+    let extra_help = run(&directory, &[OsStr::new("--help"), OsStr::new("extra")]);
+    assert_eq!(extra_help.status.code(), Some(2));
+}
+
+#[test]
+fn transfers_real_utf8_crlf_blank_and_unterminated_lines() {
+    let directory = directory("normal");
+    let input = directory.join("input.txt");
+    let output = directory.join("output.txt");
+    fs::write(&input, "hello\r\n🦀\n\nfinal").unwrap();
+    let result = run(
+        &directory,
+        &[
+            OsStr::new("transfer-lines"),
+            input.as_os_str(),
+            output.as_os_str(),
+        ],
+    );
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert_eq!(
+        fs::read(&output).unwrap(),
+        "hello\n🦀\n\nfinal\n".as_bytes()
+    );
+    assert!(String::from_utf8_lossy(&result.stdout).contains("4 records"));
+}
+
+#[test]
+fn empty_input_produces_empty_output() {
+    let directory = directory("empty");
+    let input = directory.join("input.txt");
+    let output = directory.join("output.txt");
+    fs::write(&input, []).unwrap();
+    let result = run(
+        &directory,
+        &[
+            OsStr::new("transfer-lines"),
+            input.as_os_str(),
+            output.as_os_str(),
+        ],
+    );
+    assert!(result.status.success());
+    assert_eq!(fs::read(&output).unwrap(), b"");
+    assert!(String::from_utf8_lossy(&result.stdout).contains("0 records"));
+}
+
+#[test]
+fn rejects_missing_existing_and_same_targets_without_overwriting() {
+    let directory = directory("targets");
+    let missing = directory.join("missing.txt");
+    let output = directory.join("output.txt");
+    assert_eq!(
+        run(
+            &directory,
+            &[
+                OsStr::new("transfer-lines"),
+                missing.as_os_str(),
+                output.as_os_str()
+            ]
+        )
+        .status
+        .code(),
+        Some(1)
+    );
+    assert!(!output.exists());
+    let input = directory.join("input.txt");
+    fs::write(&input, b"input\n").unwrap();
+    fs::write(&output, b"original").unwrap();
+    let existing = run(
+        &directory,
+        &[
+            OsStr::new("transfer-lines"),
+            input.as_os_str(),
+            output.as_os_str(),
+        ],
+    );
+    assert_eq!(existing.status.code(), Some(1));
+    assert_eq!(fs::read(&output).unwrap(), b"original");
+    let same = run(
+        &directory,
+        &[
+            OsStr::new("transfer-lines"),
+            input.as_os_str(),
+            input.as_os_str(),
+        ],
+    );
+    assert_eq!(same.status.code(), Some(1));
+    assert_eq!(fs::read(&input).unwrap(), b"input\n");
+    let directory_input = directory.join("directory-input");
+    fs::create_dir(&directory_input).unwrap();
+    let directory_output = directory.join("directory-output.txt");
+    assert_eq!(
+        run(
+            &directory,
+            &[
+                OsStr::new("transfer-lines"),
+                directory_input.as_os_str(),
+                directory_output.as_os_str(),
+            ],
+        )
+        .status
+        .code(),
+        Some(1)
+    );
+    assert!(!directory_output.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_an_existing_symlink_target() {
+    use std::os::unix::fs::symlink;
+    let directory = directory("symlink");
+    let input = directory.join("input.txt");
+    let target = directory.join("target.txt");
+    let output = directory.join("output-link.txt");
+    fs::write(&input, b"input\n").unwrap();
+    fs::write(&target, b"original").unwrap();
+    symlink(&target, &output).unwrap();
+    let result = run(
+        &directory,
+        &[
+            OsStr::new("transfer-lines"),
+            input.as_os_str(),
+            output.as_os_str(),
+        ],
+    );
+    assert_eq!(result.status.code(), Some(1));
+    assert_eq!(fs::read(&target).unwrap(), b"original");
+}
+
+#[test]
+fn rejects_invalid_utf8_and_oversized_input() {
+    let directory = directory("invalid");
+    let invalid = directory.join("invalid.txt");
+    let invalid_output = directory.join("invalid-output.txt");
+    fs::write(&invalid, [0xff, b'\n']).unwrap();
+    let result = run(
+        &directory,
+        &[
+            OsStr::new("transfer-lines"),
+            invalid.as_os_str(),
+            invalid_output.as_os_str(),
+        ],
+    );
+    assert_eq!(result.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&result.stderr).contains("partially written"));
+    let oversized = directory.join("oversized.txt");
+    let oversized_output = directory.join("oversized-output.txt");
+    fs::write(&oversized, vec![b'x'; 1024 * 1024 + 1]).unwrap();
+    assert_eq!(
+        run(
+            &directory,
+            &[
+                OsStr::new("transfer-lines"),
+                oversized.as_os_str(),
+                oversized_output.as_os_str()
+            ]
+        )
+        .status
+        .code(),
+        Some(1)
+    );
+}

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -36,6 +36,13 @@ mod logical_batch;
 )]
 mod record_handoff;
 
+// This is an unstable std-I/O bridge for the experimental CLI command, not a
+// plugin API or a general record-transfer interface.
+mod text_transfer;
+
+#[doc(hidden)]
+pub use text_transfer::transfer_lines;
+
 // This is deliberately private: it is a bounded fake-fixture coordinator, not
 // a public plugin API or a production lifecycle contract.
 #[allow(
@@ -45,14 +52,15 @@ mod record_handoff;
 mod empty_lifecycle;
 
 pub const DEVELOPMENT_STATUS: &str =
-    "emburk: development environment ready (data transfer not implemented yet)";
+    "emburk: experimental text transfer available (full ETL not implemented)";
 
 #[cfg(test)]
 mod tests {
     use super::DEVELOPMENT_STATUS;
 
     #[test]
-    fn development_status_does_not_claim_a_working_loader() {
-        assert!(DEVELOPMENT_STATUS.contains("data transfer not implemented yet"));
+    fn development_status_describes_the_available_experimental_transfer() {
+        assert!(DEVELOPMENT_STATUS.contains("experimental text transfer available"));
+        assert!(DEVELOPMENT_STATUS.contains("full ETL not implemented"));
     }
 }

--- a/crates/emburk-core/src/record_handoff.rs
+++ b/crates/emburk-core/src/record_handoff.rs
@@ -3,26 +3,29 @@
 use crate::logical_record::LogicalRecord;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct SourceError(String);
+pub(crate) struct SourceError(pub(crate) String);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct SinkError(String);
+pub(crate) struct SinkError(pub(crate) String);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum HandoffError {
+pub(crate) enum HandoffError {
     Source(SourceError),
     Sink(SinkError),
 }
 
-trait RecordSource {
+pub(crate) trait RecordSource {
     fn next_record(&mut self) -> Result<Option<LogicalRecord>, SourceError>;
 }
 
-trait RecordSink {
+pub(crate) trait RecordSink {
     fn accept(&mut self, record: LogicalRecord) -> Result<(), SinkError>;
 }
 
-fn handoff_owned_records<S, K>(source: &mut S, sink: &mut K) -> Result<usize, HandoffError>
+pub(crate) fn handoff_owned_records<S, K>(
+    source: &mut S,
+    sink: &mut K,
+) -> Result<usize, HandoffError>
 where
     S: RecordSource,
     K: RecordSink,

--- a/crates/emburk-core/src/text_transfer.rs
+++ b/crates/emburk-core/src/text_transfer.rs
@@ -1,0 +1,189 @@
+//! Bounded UTF-8 line transfer through the private owned-record handoff.
+
+use crate::{
+    logical_record::{LogicalRecord, LogicalValue},
+    record_handoff::{
+        HandoffError, RecordSink, RecordSource, SinkError, SourceError, handoff_owned_records,
+    },
+};
+use std::io::{self, BufRead, Read, Write};
+
+const MAX_PHYSICAL_LINE_BYTES: usize = 1024 * 1024;
+
+/// Transfers UTF-8 physical lines as one private Text cell per logical record.
+#[doc(hidden)]
+pub fn transfer_lines<R: BufRead, W: Write>(input: R, output: W) -> io::Result<usize> {
+    let mut source = TextSource { input };
+    let mut sink = TextSink { output };
+    let count = handoff_owned_records(&mut source, &mut sink).map_err(handoff_io_error)?;
+    sink.output.flush()?;
+    Ok(count)
+}
+
+fn handoff_io_error(error: HandoffError) -> io::Error {
+    match error {
+        HandoffError::Source(SourceError(message)) | HandoffError::Sink(SinkError(message)) => {
+            io::Error::other(message)
+        }
+    }
+}
+
+struct TextSource<R> {
+    input: R,
+}
+
+impl<R: BufRead> RecordSource for TextSource<R> {
+    fn next_record(&mut self) -> Result<Option<LogicalRecord>, SourceError> {
+        let mut bytes = Vec::with_capacity(MAX_PHYSICAL_LINE_BYTES.min(8192));
+        let read = (&mut self.input)
+            .take((MAX_PHYSICAL_LINE_BYTES + 1) as u64)
+            .read_until(b'\n', &mut bytes)
+            .map_err(|error| SourceError(format!("input read failed: {error}")))?;
+        if read == 0 {
+            return Ok(None);
+        }
+        if bytes.len() > MAX_PHYSICAL_LINE_BYTES {
+            return Err(SourceError(format!(
+                "input line exceeds {MAX_PHYSICAL_LINE_BYTES} bytes"
+            )));
+        }
+        let had_lf = bytes.last() == Some(&b'\n');
+        if had_lf {
+            bytes.pop();
+            if bytes.last() == Some(&b'\r') {
+                bytes.pop();
+            }
+        }
+        let text = String::from_utf8(bytes)
+            .map_err(|error| SourceError(format!("input is not valid UTF-8: {error}")))?;
+        Ok(Some(LogicalRecord::new(vec![LogicalValue::Text(text)])))
+    }
+}
+
+struct TextSink<W> {
+    output: W,
+}
+
+impl<W: Write> RecordSink for TextSink<W> {
+    fn accept(&mut self, record: LogicalRecord) -> Result<(), SinkError> {
+        let mut cells = record.cells();
+        let Some(LogicalValue::Text(text)) = cells.next() else {
+            return Err(SinkError(
+                "internal transfer record is not one Text cell".into(),
+            ));
+        };
+        if cells.next().is_some() {
+            return Err(SinkError("internal transfer record is malformed".into()));
+        }
+        self.output
+            .write_all(text.as_bytes())
+            .and_then(|()| self.output.write_all(b"\n"))
+            .map_err(|error| SinkError(format!("output write failed: {error}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, ErrorKind};
+
+    #[test]
+    fn normalizes_crlf_and_final_records_through_the_handoff() {
+        let mut output = Vec::new();
+        assert_eq!(
+            transfer_lines(Cursor::new(b"a\r\nb\n\nfinal"), &mut output).unwrap(),
+            4
+        );
+        assert_eq!(output, b"a\nb\n\nfinal\n");
+        assert_eq!(transfer_lines(Cursor::new(b""), Vec::new()).unwrap(), 0);
+    }
+
+    #[test]
+    fn rejects_invalid_utf8_and_oversized_physical_lines() {
+        let invalid = transfer_lines(Cursor::new(vec![0xff, b'\n']), Vec::new()).unwrap_err();
+        assert_eq!(invalid.kind(), ErrorKind::Other);
+        let oversized = transfer_lines(
+            Cursor::new(vec![b'x'; MAX_PHYSICAL_LINE_BYTES + 1]),
+            Vec::new(),
+        )
+        .unwrap_err();
+        assert_eq!(oversized.kind(), ErrorKind::Other);
+    }
+
+    #[test]
+    fn accepts_boundary_lines_preserves_lone_cr_and_stops_after_invalid_prefix() {
+        let mut output = Vec::new();
+        let cap_minus_lf = [vec![b'a'; MAX_PHYSICAL_LINE_BYTES - 1], vec![b'\n']].concat();
+        assert_eq!(
+            transfer_lines(Cursor::new(cap_minus_lf), &mut output).unwrap(),
+            1
+        );
+        assert_eq!(output.len(), MAX_PHYSICAL_LINE_BYTES);
+        output.clear();
+        assert_eq!(
+            transfer_lines(
+                Cursor::new(vec![b'b'; MAX_PHYSICAL_LINE_BYTES]),
+                &mut output
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(output.len(), MAX_PHYSICAL_LINE_BYTES + 1);
+        output.clear();
+        assert_eq!(
+            transfer_lines(Cursor::new(b"lone\r"), &mut output).unwrap(),
+            1
+        );
+        assert_eq!(output, b"lone\r\n");
+        let mut prefix = Vec::new();
+        let error = transfer_lines(Cursor::new(b"ok\n\xff\nlater\n"), &mut prefix).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(prefix, b"ok\n");
+    }
+
+    struct FailingReader;
+    impl Read for FailingReader {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("read injection"))
+        }
+    }
+    impl BufRead for FailingReader {
+        fn fill_buf(&mut self) -> io::Result<&[u8]> {
+            Err(io::Error::other("read injection"))
+        }
+        fn consume(&mut self, _: usize) {}
+    }
+
+    struct FailingWriter {
+        fail_flush: bool,
+    }
+    impl Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("write injection"))
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            if self.fail_flush {
+                Err(io::Error::other("flush injection"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn propagates_injected_read_write_and_flush_errors() {
+        assert!(transfer_lines(FailingReader, Vec::new()).is_err());
+        assert!(transfer_lines(Cursor::new(b"x\n"), FailingWriter { fail_flush: false }).is_err());
+        struct FlushWriter(Vec<u8>);
+        impl Write for FlushWriter {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                self.0.extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Err(io::Error::other("flush injection"))
+            }
+        }
+        assert!(transfer_lines(Cursor::new(b"x\n"), FlushWriter(Vec::new())).is_err());
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,13 @@
 # Architecture
 
 Status: target architecture unless explicitly identified as implemented below.
-The current runtime remains the two-crate bootstrap, not a working loader.
+The runtime uses two crates. T-0031/S01 adds an experimental text File-to-File
+consumer, not an Embulk-compatible configuration/plugin loader.
+
+ADR-0015 permits CLI-owned regular-file opening and exclusive output creation,
+with a doc-hidden unstable std-I/O core function adapting line payloads to
+private Text records through the existing synchronous handoff. No record or
+plugin types become public, and the empty lifecycle coordinator stays separate.
 
 ## Principles
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -238,6 +238,11 @@ no-callback failures. Primary and independent final-head acceptance passed at
 The [parser candidate assessment](provenance/T-0022-parser-candidates.md) is
 Planning only; no native YAML parser or coercion policy has been admitted.
 
+T-0031/S01 adds an experimental native text transfer, pending final acceptance.
+It is not an Embulk compatibility entry: strict UTF-8, LF normalization, a 1 MiB
+physical-line limit, exclusive output and possible partial files are native
+experimental policies. See [usage and limitations](FILE_TRANSFER.md).
+
 ## Adding an Entry
 
 T-0012/S13 is Done through PR #107 (`441040f`) for six syntax observations. No YAML, duplicate-key, alias,

--- a/docs/FILE_TRANSFER.md
+++ b/docs/FILE_TRANSFER.md
@@ -18,7 +18,9 @@ bounds line-buffer growth, not total process memory. Processing is sequential.
 There is no file-wide record queue, schema inference, transformation expression,
 plugin loading, YAML configuration or Embulk compatibility claim.
 
-An existing output is never overwritten. After output creation, a read,
+An existing output is never overwritten. On Unix, new output is created with
+mode 0600 (or stricter under umask). On non-Unix systems directory/OS ACLs
+apply; no portable owner-only guarantee is made. After output creation, a read,
 encoding, size, write or flush failure may leave a **partial output**. The
 command reports failure; inspect the new file before removing it or choosing a
 different output name. There is no automatic deletion, rollback, crash-durability,

--- a/docs/FILE_TRANSFER.md
+++ b/docs/FILE_TRANSFER.md
@@ -1,0 +1,29 @@
+# Experimental File-to-File transfer
+
+`transfer-lines` is an experimental native text-record path, not Embulk's `run`
+command. It does not load YAML or parse CSV/JSON.
+
+```sh
+cargo run -p emburk-cli -- transfer-lines input.txt output.txt
+```
+
+Input must be an existing regular UTF-8 file. Output must not exist. Paths with
+spaces must be quoted. Each physical input line becomes a single Text-cell
+record, passes through the core's synchronous owned-record handoff, and is
+written with LF. CRLF becomes LF and an unterminated final line gains LF.
+Blank lines remain records; an empty file creates an empty output.
+
+Each physical record is limited to 1 MiB including its input terminator. This
+bounds line-buffer growth, not total process memory. Processing is sequential.
+There is no file-wide record queue, schema inference, transformation expression,
+plugin loading, YAML configuration or Embulk compatibility claim.
+
+An existing output is never overwritten. After output creation, a read,
+encoding, size, write or flush failure may leave a **partial output**. The
+command reports failure; inspect the new file before removing it or choosing a
+different output name. There is no automatic deletion, rollback, crash-durability,
+atomic publication, transaction or resume guarantee. Input must not be modified
+concurrently; hostile filesystem races are outside this experimental contract.
+
+Success reports a record count and exits 0. Invalid command arguments exit 2;
+transfer failures exit 1. The full File-to-File MVP roadmap gate remains open.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,6 +210,10 @@ independent final-head acceptance at `9df0d5c`.
 
 ## Phase 1: Native File-to-File MVP
 
+T-0031/S01 provides the first experimental native text-record transfer path,
+pending final acceptance. This does not satisfy this phase's CSV/JSON, configuration,
+parallelism, recovery or Embulk differential exit gate.
+
 T-0022's [parser assessment](provenance/T-0022-parser-candidates.md) separates
 candidate experiments, dependency admission and actual CLI/runtime consumption.
 None of these gates is satisfied by documentation or YAML conformance alone.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -10,8 +10,10 @@ Development state: `bootstrap`
   verifying the development environment. T-0021/S01 establishes a virtual
   workspace with an inward-only `emburk-cli -> emburk-core` dependency while
   retaining the explicit not-yet-a-loader smoke test.
-- The binary does not load Embulk configuration, transfer records, execute
-  plugins, or implement transaction and resume behavior.
+- T-0031/S01 implements an experimental `transfer-lines INPUT OUTPUT` path:
+  real files, private Text records and the existing synchronous owned handoff.
+  Final acceptance and integration are pending. It does not load Embulk
+  configuration, execute plugins, or implement transactions and resume.
 - No native, Java-hosted, or JRuby-hosted plugin is implemented or verified.
 - Thirteen selected private raw-scalar outcomes match the pinned Embulk
   executable in a live differential test. No full configuration, plugin,
@@ -62,7 +64,8 @@ passed seven cases/36 events, strict controls and unchanged S01/S02 regressions.
 No native configuration behavior is added. T-0012, T-0013 and T-0021 parent
 contracts remain open. S13 is Done through PR #107 (`441040f`) after primary
 and independent final-head Demo at `65a2fb3`: six syntax cases/60 events,
-strict controls and unchanged S12 regression. No WIP lane remains occupied.
+strict controls and unchanged S12 regression. T-0031/S01 occupies one WIP lane
+for the explicitly requested experimental native File-to-File path.
 
 | Item | State | Purpose |
 |---|---|---|

--- a/docs/decisions/ADR-0015-experimental-text-file-transfer.md
+++ b/docs/decisions/ADR-0015-experimental-text-file-transfer.md
@@ -1,0 +1,22 @@
+# ADR-0015: Experimental text File-to-File consumer
+
+Status: Accepted for T-0031/S01 under the owner's explicit implementation request.
+Date: 2026-09-06.
+
+The owner requests a real minimal transfer, not another disconnected probe.
+Permit the CLI to open files and call a doc-hidden, unstable std-I/O core function
+which adapts UTF-8 lines to private Text records and uses ADR-0013's owned handoff.
+Only sibling visibility expands for that handoff; record/plugin types stay private.
+The empty lifecycle coordinator and schema/batch representation remain unchanged.
+
+The separate `transfer-lines` command is explicitly experimental. It normalizes
+LF/CRLF lines to LF, bounds physical records to 1 MiB including terminators,
+creates output exclusively and reports possible partial output on error. It does
+not accept YAML or claim Embulk run, transaction, encoding or plugin semantics.
+This extends ADR-0013's no-consumer/no-public-function restriction only enough
+for this real consumer; it does not supersede the remaining compatibility gates.
+
+File opening stays in the CLI composition boundary; core sees only std I/O.
+No provider dependency, new crate or external source is introduced. A raw file
+copy would not exercise the record handoff; a complete YAML/CSV pipeline is
+deferred rather than simulated. The full File-to-File roadmap gate stays open.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,3 +18,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0012](ADR-0012-private-double-bit-storage.md) | Private double bit storage without numeric equality policy | Accepted |
 | [ADR-0013](ADR-0013-private-owned-record-handoff.md) | Private owned-record handoff before plugin APIs | Accepted |
 | [ADR-0014](ADR-0014-private-positional-logical-batch.md) | Private positional logical batch admission before physical encoding | Accepted |
+| [ADR-0015](ADR-0015-experimental-text-file-transfer.md) | Experimental text File-to-File consumer | Accepted for T-0031/S01 only |

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -423,3 +423,10 @@ metadata with read-only Librarian support. T-0022/S01 is reserved for a 5 SP
 candidate experiment, not activated. Production dependencies and CLI remain
 unchanged; the assessment states concrete preservation, encoding, scalar,
 resource and adoption gates. No points or compatibility claims are awarded.
+
+The owner explicitly requested actual minimal File-to-File execution. PM chose
+T-0031/S01's experimental transfer-lines command under ADR-0015; source work is
+delegated to the low-cost Rust implementer. Read-only PM review confirmed a
+narrow std-I/O entry point is necessary for CLI consumption, with private record
+and handoff types. No YAML/dependency adoption or full MVP claim follows.
+Final primary/independent acceptance and integration remain pending.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -35,3 +35,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S12 config-envelope observation](T-0012-config-envelope-probe.md) | Done (PR #105, `67f0786`; reference evidence only) |
 | [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | Done (PR #107; final-head acceptance passed) |
 | [T-0022 parser candidate assessment](T-0022-parser-candidates.md) | Proposed refinement; no dependency admission |
+| [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | In Progress; native-only record consumer |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -35,4 +35,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S12 config-envelope observation](T-0012-config-envelope-probe.md) | Done (PR #105, `67f0786`; reference evidence only) |
 | [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | Done (PR #107; final-head acceptance passed) |
 | [T-0022 parser candidate assessment](T-0022-parser-candidates.md) | Proposed refinement; no dependency admission |
-| [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | In Progress; native-only record consumer |
+| [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | Review, PR #110; native-only record consumer |

--- a/docs/provenance/T-0031-file-to-file.md
+++ b/docs/provenance/T-0031-file-to-file.md
@@ -1,0 +1,67 @@
+# T-0031/S01 experimental line-record File-to-File
+
+Issue: [#24](https://github.com/bhind/emburk/issues/24). State: In Progress.
+Branch: `feat/t-0031-file-to-file`. Slice: 5 SP; parent remains incomplete.
+
+## Authority
+
+The owner explicitly requested a working minimal File-to-File path. PM selects
+a clearly named experimental native command, not an Embulk-compatible run mode.
+ADR-0015 defines this narrow extension of ADR-0013.
+
+## Dependencies
+
+Accepted T-0021/S06 owned handoff and T-0012/S08 Text records. No YAML/parser,
+new dependency or external source admission. Parent T-0022/T-0023 dependencies
+remain for full configuration and schema-aware plugins, not this fixed Text path.
+
+## Mutation owner and allowlist
+
+Rust implementer owns crates/emburk-core/src/{lib,record_handoff,text_transfer}.rs,
+crates/emburk-cli/src/main.rs and crates/emburk-cli/tests/file_transfer.rs.
+PM owns this packet, ADR-0015 and its index, STATUS, TODO, ROADMAP, ARCHITECTURE,
+COMPATIBILITY, provenance index, docs/FILE_TRANSFER.md and daily log.
+No parallel overlapping mutation; reviewers are read-only.
+
+## Artifacts
+
+Only original Rust/std-library code. Test fixtures are generated in unique
+external temporary directories. No downloads, third-party code or credentials.
+
+## Acceptance criteria
+
+`emburk transfer-lines INPUT OUTPUT` streams UTF-8 lines as single Text-cell
+records through the existing owned handoff. LF/CRLF input is normalized to LF;
+an unterminated final record receives LF. Empty input produces empty output.
+Limit each physical input record to 1 MiB including its terminator; fail without
+unbounded line allocation. Output uses create_new: existing targets, including
+same path and symlinks, are never overwritten. Input must be a regular file.
+Read/UTF-8/size/write/flush failures exit nonzero. A new partial output may
+remain on failure and must be reported explicitly; no rollback or atomicity claim.
+Invalid arguments exit 2, transfer failures exit 1, success exits 0 and reports
+the record count. Preserve no-argument development status and provide help.
+Tests cover actual files, Unicode, CRLF, empty/final lines, existing/same target,
+missing input, malformed UTF-8, oversize records, and injected write/flush errors.
+
+## Demo Command
+
+`cargo test --workspace && cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings`
+
+CLI integration tests execute the actual built binary and compare real files.
+Primary and independent reviewed-head execution required before merge.
+
+## Evidence class
+
+Unit/Contract and local file Integration, not Differential (Embulk).
+
+## Stop rule
+
+Stop before YAML, CSV, external dependencies, public plugin interfaces, lifecycle
+integration, overwrite, deletion, transaction/recovery or compatibility exceptions.
+Bounded implementation failures may be fixed with evidence retained.
+
+## Non-claims
+
+No Embulk CLI/config/encoding parity, generic plugin, schema/batch path,
+parallelism, crash durability, atomic publication, resume or full MVP completion.
+License/patent/FTO gaps remain unreviewed; no external source was adopted.

--- a/docs/provenance/T-0031-file-to-file.md
+++ b/docs/provenance/T-0031-file-to-file.md
@@ -1,6 +1,6 @@
 # T-0031/S01 experimental line-record File-to-File
 
-Issue: [#24](https://github.com/bhind/emburk/issues/24). State: In Progress.
+Issue: [#24](https://github.com/bhind/emburk/issues/24). State: Review, PR #110.
 Branch: `feat/t-0031-file-to-file`. Slice: 5 SP; parent remains incomplete.
 
 ## Authority
@@ -39,7 +39,8 @@ same path and symlinks, are never overwritten. Input must be a regular file.
 Read/UTF-8/size/write/flush failures exit nonzero. A new partial output may
 remain on failure and must be reported explicitly; no rollback or atomicity claim.
 Invalid arguments exit 2, transfer failures exit 1, success exits 0 and reports
-the record count. Preserve no-argument development status and provide help.
+the record count. No-argument status describes experimental availability; help
+describes the command.
 Tests cover actual files, Unicode, CRLF, empty/final lines, existing/same target,
 missing input, malformed UTF-8, oversize records, and injected write/flush errors.
 


### PR DESCRIPTION
Tracks #24, T-0031/S01. Implements transfer-lines INPUT OUTPUT via private Text records and existing owned handoff. No YAML/CSV/Embulk parity; no overwrite, 1MiB physical line cap, explicit partial-output errors. ADR0015 limits the std-I/O consumer boundary. Primary tests67 passed/8 intentional existing ignores; fmt and strict clippy pass. Final-head independent Demo/security review pending. Packet: docs/provenance/T-0031-file-to-file.md. Full task remains open.