### PR TITLE
feat(t-0031): add stdout and null text targets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,10 @@ T-0031/S01 is Done through PR #110 (`c5fb13f`), accepting 5 SP, for a native UTF
 File-to-File command under ADR-0015. It consumes T-0021/S06 without claiming
 the parent's YAML, schema-aware plugin, transaction or full MVP contracts.
 
+T-0031/S02 is In Progress for experimental stdout/null targets, forecast 3 SP.
+Parent Current 8 / Initial 5 covers accepted S01 and S02; remaining broader
+plugin/configuration scope is not accepted by this forecast.
+
 Project Workstreams map as follows: T-0001–T-0006 are `Governance`;
 T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`;
 T-0030–T-0037 and T-0060–T-0067 are `Native Plugins`; T-0040–T-0045 are
@@ -81,7 +85,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0030 | Epic: Native File-to-File ETL | Backlog | P1 | — | T-0020 | Project Manager | Planning |
-| T-0031 | Implement file/config inputs and file/stdout/null outputs (S01 Done; remaining contracts queued) | Backlog | P1 | 5 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
+| T-0031 | Implement file/config inputs and file/stdout/null outputs (S02 stdout/null In Progress) | In Progress | P1 | 8 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0032 | Implement the CSV parser and formatter | Backlog | P1 | 8 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0033 | Implement the JSON parser | Backlog | P1 | 5 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |

--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@ T-0031/S01 is Done through PR #110 (`c5fb13f`), accepting 5 SP, for a native UTF
 File-to-File command under ADR-0015. It consumes T-0021/S06 without claiming
 the parent's YAML, schema-aware plugin, transaction or full MVP contracts.
 
-T-0031/S02 is In Progress for experimental stdout/null targets, forecast 3 SP.
+T-0031/S02 is in Review in PR #112 for experimental stdout/null targets, forecast 3 SP.
 Parent Current 8 / Initial 5 covers accepted S01 and S02; remaining broader
 plugin/configuration scope is not accepted by this forecast.
 
@@ -85,7 +85,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | ID | Outcome | Status | Priority | SP | Depends on | Owner Role | Evidence |
 |---|---|---|---|---:|---|---|---|
 | T-0030 | Epic: Native File-to-File ETL | Backlog | P1 | — | T-0020 | Project Manager | Planning |
-| T-0031 | Implement file/config inputs and file/stdout/null outputs (S02 stdout/null In Progress) | In Progress | P1 | 8 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
+| T-0031 | Implement file/config inputs and file/stdout/null outputs (S02 stdout/null in Review) | Review | P1 | 8 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0032 | Implement the CSV parser and formatter | Backlog | P1 | 8 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0033 | Implement the JSON parser | Backlog | P1 | 5 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |

--- a/crates/emburk-cli/src/main.rs
+++ b/crates/emburk-cli/src/main.rs
@@ -3,7 +3,7 @@
 use std::{
     env,
     fs::{self, File, OpenOptions},
-    io::BufReader,
+    io::{self, BufReader},
     path::Path,
 };
 
@@ -19,27 +19,43 @@ fn main() {
             Some("--help" | "-h")
         )
     {
-        println!("Usage: emburk transfer-lines INPUT OUTPUT");
+        println!(
+            "Usage: emburk transfer-lines INPUT OUTPUT\n       emburk transfer-lines-stdout INPUT\n       emburk transfer-lines-null INPUT"
+        );
         return;
     }
-    if arguments.len() != 4 || arguments[1] != "transfer-lines" {
-        eprintln!("Usage: emburk transfer-lines INPUT OUTPUT");
-        std::process::exit(2);
-    }
-    let input = Path::new(&arguments[2]);
-    let output = Path::new(&arguments[3]);
-    if let Err(error) = transfer(input, output) {
-        eprintln!("emburk: transfer-lines failed: {error}");
+    let (command, result) = match arguments.as_slice() {
+        [_, command, input, output] if command == "transfer-lines" => (
+            "transfer-lines",
+            transfer(Path::new(input), Path::new(output)),
+        ),
+        [_, command, input] if command == "transfer-lines-stdout" => {
+            ("transfer-lines-stdout", transfer_stdout(Path::new(input)))
+        }
+        [_, command, input] if command == "transfer-lines-null" => {
+            ("transfer-lines-null", transfer_null(Path::new(input)))
+        }
+        _ => {
+            eprintln!("Usage: emburk transfer-lines INPUT OUTPUT");
+            std::process::exit(2);
+        }
+    };
+    if let Err(error) = result {
+        eprintln!("emburk: {command} failed: {error}");
         std::process::exit(1);
     }
 }
 
-fn transfer(input: &Path, output: &Path) -> Result<(), String> {
+fn open_input(input: &Path) -> Result<File, String> {
     let metadata = fs::metadata(input).map_err(|error| format!("cannot inspect input: {error}"))?;
     if !metadata.is_file() {
         return Err("input must be a regular file".into());
     }
-    let input_file = File::open(input).map_err(|error| format!("cannot open input: {error}"))?;
+    File::open(input).map_err(|error| format!("cannot open input: {error}"))
+}
+
+fn transfer(input: &Path, output: &Path) -> Result<(), String> {
+    let input_file = open_input(input)?;
     let mut options = OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
@@ -60,4 +76,21 @@ fn transfer(input: &Path, output: &Path) -> Result<(), String> {
             output.display()
         )),
     }
+}
+
+fn transfer_stdout(input: &Path) -> Result<(), String> {
+    let input_file = open_input(input)?;
+    let stdout = io::stdout();
+    let count = emburk_core::transfer_lines(BufReader::new(input_file), stdout.lock())
+        .map_err(|error| format!("{error}"))?;
+    eprintln!("emburk: transfer-lines-stdout completed: {count} records");
+    Ok(())
+}
+
+fn transfer_null(input: &Path) -> Result<(), String> {
+    let input_file = open_input(input)?;
+    let count = emburk_core::transfer_lines(BufReader::new(input_file), io::sink())
+        .map_err(|error| format!("{error}"))?;
+    eprintln!("emburk: transfer-lines-null completed: {count} records");
+    Ok(())
 }

--- a/crates/emburk-cli/tests/file_transfer.rs
+++ b/crates/emburk-cli/tests/file_transfer.rs
@@ -2,7 +2,7 @@ use std::{
     ffi::OsStr,
     fs,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     sync::atomic::{AtomicUsize, Ordering},
 };
 
@@ -65,6 +65,112 @@ fn retains_development_status_and_exposes_help_and_argument_errors() {
     assert_eq!(invalid.status.code(), Some(2));
     let extra_help = run(&directory, &[OsStr::new("--help"), OsStr::new("extra")]);
     assert_eq!(extra_help.status.code(), Some(2));
+    let missing_stdout_input = run(&directory, &[OsStr::new("transfer-lines-stdout")]);
+    assert_eq!(missing_stdout_input.status.code(), Some(2));
+    let extra_null = run(
+        &directory,
+        &[
+            OsStr::new("transfer-lines-null"),
+            OsStr::new("input"),
+            OsStr::new("extra"),
+        ],
+    );
+    assert_eq!(extra_null.status.code(), Some(2));
+}
+
+#[test]
+fn stdout_and_null_targets_stream_or_validate_without_creating_files() {
+    let directory = directory("stream-targets");
+    let input = directory.join("input.txt");
+    fs::write(&input, "hello\r\n🦀\n\nfinal").unwrap();
+    let stdout = run(
+        &directory,
+        &[OsStr::new("transfer-lines-stdout"), input.as_os_str()],
+    );
+    assert!(stdout.status.success());
+    assert_eq!(stdout.stdout, "hello\n🦀\n\nfinal\n".as_bytes());
+    assert!(String::from_utf8_lossy(&stdout.stderr).contains("4 records"));
+    let null = run(
+        &directory,
+        &[OsStr::new("transfer-lines-null"), input.as_os_str()],
+    );
+    assert!(null.status.success());
+    assert!(null.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&null.stderr).contains("4 records"));
+    let empty = directory.join("empty.txt");
+    fs::write(&empty, []).unwrap();
+    for command in ["transfer-lines-stdout", "transfer-lines-null"] {
+        let result = run(&directory, &[OsStr::new(command), empty.as_os_str()]);
+        assert!(result.status.success());
+        assert!(result.stdout.is_empty());
+        assert!(String::from_utf8_lossy(&result.stderr).contains("0 records"));
+    }
+    assert_eq!(fs::read_dir(&directory).unwrap().count(), 2);
+}
+
+#[test]
+fn stream_targets_reject_bad_inputs_without_success_summaries() {
+    let directory = directory("stream-errors");
+    let missing = directory.join("missing.txt");
+    for command in ["transfer-lines-stdout", "transfer-lines-null"] {
+        let result = run(&directory, &[OsStr::new(command), missing.as_os_str()]);
+        assert_eq!(result.status.code(), Some(1));
+        assert!(!String::from_utf8_lossy(&result.stderr).contains("completed"));
+    }
+    let invalid = directory.join("invalid.txt");
+    fs::write(&invalid, [0xff, b'\n']).unwrap();
+    for command in ["transfer-lines-stdout", "transfer-lines-null"] {
+        let invalid_result = run(&directory, &[OsStr::new(command), invalid.as_os_str()]);
+        assert_eq!(invalid_result.status.code(), Some(1));
+        assert!(invalid_result.stdout.is_empty());
+        assert!(!String::from_utf8_lossy(&invalid_result.stderr).contains("completed"));
+    }
+    let oversized = directory.join("oversized.txt");
+    fs::write(&oversized, vec![b'x'; 1024 * 1024 + 1]).unwrap();
+    for command in ["transfer-lines-stdout", "transfer-lines-null"] {
+        assert_eq!(
+            run(&directory, &[OsStr::new(command), oversized.as_os_str()])
+                .status
+                .code(),
+            Some(1)
+        );
+    }
+    let input_directory = directory.join("input-directory");
+    fs::create_dir(&input_directory).unwrap();
+    for command in ["transfer-lines-stdout", "transfer-lines-null"] {
+        assert_eq!(
+            run(
+                &directory,
+                &[OsStr::new(command), input_directory.as_os_str()]
+            )
+            .status
+            .code(),
+            Some(1)
+        );
+    }
+    assert_eq!(fs::read_dir(&directory).unwrap().count(), 3);
+}
+
+#[cfg(unix)]
+#[test]
+fn closed_stdout_pipe_exits_one_without_a_success_summary() {
+    use std::{os::fd::OwnedFd, os::unix::net::UnixStream};
+    let directory = directory("broken-pipe");
+    let input = directory.join("input.txt");
+    fs::write(&input, b"line\n").unwrap();
+    let (writer, reader) = UnixStream::pair().unwrap();
+    drop(reader);
+    let stdout: OwnedFd = writer.into();
+    let output = Command::new(env!("CARGO_BIN_EXE_emburk"))
+        .arg("transfer-lines-stdout")
+        .arg(input)
+        .current_dir(&directory)
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("completed"));
 }
 
 #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,10 @@ plugin types become public, and the empty lifecycle coordinator stays separate.
 
 ## Principles
 
+ADR-0016 extends only CLI composition with stdout locking and std::io::sink
+adapters. Both use the same core transfer entry point; no new public core or
+plugin API is introduced. Stdout data and stderr summaries remain separate.
+
 Emburk keeps the core compact. The core owns stable orchestration contracts; plugins own integration behavior and dependencies. Installation and dependency resolution are separate from job execution.
 
 The [Rust runtime design proposal](RUST_RUNTIME_DESIGN.md) details candidate

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -243,6 +243,9 @@ It is not an Embulk compatibility entry: strict UTF-8, LF normalization, a 1 MiB
 physical-line limit, exclusive output and possible partial files are native
 experimental policies. See [usage and limitations](FILE_TRANSFER.md).
 
+T-0031/S02's stdout/null targets use the existing native experimental Text rules.
+They do not establish compatibility with any Embulk output plugin.
+
 ## Adding an Entry
 
 T-0012/S13 is Done through PR #107 (`441040f`) for six syntax observations. No YAML, duplicate-key, alias,

--- a/docs/FILE_TRANSFER.md
+++ b/docs/FILE_TRANSFER.md
@@ -29,3 +29,22 @@ concurrently; hostile filesystem races are outside this experimental contract.
 
 Success reports a record count and exits 0. Invalid command arguments exit 2;
 transfer failures exit 1. The full File-to-File MVP roadmap gate remains open.
+
+## Stdout and null targets
+
+T-0031/S02 adds two experimental commands using the same line rules:
+
+```sh
+cargo run -p emburk-cli -- transfer-lines-stdout input.txt
+cargo run -p emburk-cli -- transfer-lines-null input.txt
+```
+
+The stdout command writes only normalized record bytes to stdout; counts and
+diagnostics go to stderr. The null command fully reads and validates input but
+discards records, writes no stdout data, and reports the count on stderr.
+Neither creates an output file. The existing file command retains its stdout
+completion message and exclusive file creation behavior.
+
+A downstream closed pipe is an error (exit 1), not successful completion.
+Already-emitted bytes cannot be recalled. These commands are not Embulk stdout
+or null plugins, schema validation, transaction, resume or performance features.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,6 +210,9 @@ independent final-head acceptance at `9df0d5c`.
 
 ## Phase 1: Native File-to-File MVP
 
+T-0031/S02 extends experimental Text output to stdout and null, pending final
+acceptance. This does not satisfy the generic plugin/configuration gate.
+
 T-0031/S01 provides the first experimental native text-record transfer path,
 accepted through PR #110. This does not satisfy this phase's CSV/JSON, configuration,
 parallelism, recovery or Embulk differential exit gate.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -67,7 +67,8 @@ contracts remain open. S13 is Done through PR #107 (`441040f`) after primary
 and independent final-head Demo at `65a2fb3`: six syntax cases/60 events,
 strict controls and unchanged S12 regression. T-0031/S01 is Done through PR #110
 (`c5fb13f`) for the explicitly requested experimental native File-to-File path.
-No WIP lane remains occupied; the full file/plugin parent stays open.
+T-0031/S02 occupies one WIP lane for experimental stdout/null consumers; the
+full file/plugin parent stays open. Core transfer semantics remain unchanged.
 
 | Item | State | Purpose |
 |---|---|---|

--- a/docs/decisions/ADR-0016-experimental-stream-output-targets.md
+++ b/docs/decisions/ADR-0016-experimental-stream-output-targets.md
@@ -1,0 +1,17 @@
+# ADR-0016: Experimental stdout and null output adapters
+
+Status: Accepted for T-0031/S02 under the owner's Rust continuation request.
+Date: 2026-09-06.
+
+Extend ADR-0015's experimental CLI composition with two additive subcommands:
+transfer-lines-stdout INPUT and transfer-lines-null INPUT. Existing file command
+and path interpretation remain unchanged. Both consume the existing std-I/O
+core function without public plugin types or core changes.
+
+The stdout adapter uses a locked writer, emits only normalized record bytes,
+and routes diagnostics/counts to stderr. Null uses std::io::sink but still
+validates every input record. A broken pipe fails with exit 1, not panic or
+silent success. Output already consumed downstream cannot be rolled back.
+
+These are native experimental policies, not Embulk plugin, validation-timing,
+transaction or resume semantics. No new dependencies or external sources.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -19,3 +19,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0013](ADR-0013-private-owned-record-handoff.md) | Private owned-record handoff before plugin APIs | Accepted |
 | [ADR-0014](ADR-0014-private-positional-logical-batch.md) | Private positional logical batch admission before physical encoding | Accepted |
 | [ADR-0015](ADR-0015-experimental-text-file-transfer.md) | Experimental text File-to-File consumer | Accepted for T-0031/S01 only |
+| [ADR-0016](ADR-0016-experimental-stream-output-targets.md) | Experimental stdout/null adapters | Accepted for T-0031/S02 only |

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -438,3 +438,8 @@ Unix mode 0600 and an actual-binary regression fixed it, confirmed by reviewer.
 Manual four-record Unicode/blank-line transfer matched expected bytes. PR #110
 merged as `c5fb13f`; S01 accepts 5 SP while parent #24 remains open in Backlog.
 DeepSeek connectivity work was deferred by the owner and is not a dependency.
+
+The owner requested committed/merged Rust continuation. T-0031/S02 adds only
+CLI stdout/null adapters under ADR-0016, with output isolation and broken-pipe
+tests. Estimate 3 SP; parent Current 8 / Initial 5 includes accepted S01 and
+this forecast, not full plugin acceptance. Core and dependencies stay unchanged.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -36,4 +36,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | Done (PR #107; final-head acceptance passed) |
 | [T-0022 parser candidate assessment](T-0022-parser-candidates.md) | Proposed refinement; no dependency admission |
 | [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | Done, PR #110; native-only record consumer |
-| [T-0031/S02 experimental stdout/null](T-0031-output-targets.md) | In Progress; unchanged core transfer |
+| [T-0031/S02 experimental stdout/null](T-0031-output-targets.md) | Review, PR #112; unchanged core transfer |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -36,3 +36,4 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | Done (PR #107; final-head acceptance passed) |
 | [T-0022 parser candidate assessment](T-0022-parser-candidates.md) | Proposed refinement; no dependency admission |
 | [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | Done, PR #110; native-only record consumer |
+| [T-0031/S02 experimental stdout/null](T-0031-output-targets.md) | In Progress; unchanged core transfer |

--- a/docs/provenance/T-0031-output-targets.md
+++ b/docs/provenance/T-0031-output-targets.md
@@ -1,6 +1,6 @@
 # T-0031/S02 experimental stdout and null targets
 
-Issue: [#24](https://github.com/bhind/emburk/issues/24). State: In Progress.
+Issue: [#24](https://github.com/bhind/emburk/issues/24). State: Review, PR #112.
 Branch: `feat/t-0031-s02-output-targets`. Owner: Rust Core Implementer.
 Slice estimate: 3 SP (implementation 1, verification 1, uncertainty 1).
 Parent Current forecast 8 / Initial 5; accepted S01 5 SP is not re-awarded.

--- a/docs/provenance/T-0031-output-targets.md
+++ b/docs/provenance/T-0031-output-targets.md
@@ -1,0 +1,64 @@
+# T-0031/S02 experimental stdout and null targets
+
+Issue: [#24](https://github.com/bhind/emburk/issues/24). State: In Progress.
+Branch: `feat/t-0031-s02-output-targets`. Owner: Rust Core Implementer.
+Slice estimate: 3 SP (implementation 1, verification 1, uncertainty 1).
+Parent Current forecast 8 / Initial 5; accepted S01 5 SP is not re-awarded.
+
+## Authority
+
+The owner requested committed, pushed, merged continuation of Rust implementation.
+PM selects stdout/null targets already named by T-0031, limited to experimental
+Text records. New subcommands preserve all existing transfer-lines path meanings.
+
+## Dependencies
+
+S01 integrated in PR #110/#111. Use its std-I/O transfer function unchanged.
+Full YAML/config/schema/plugin parent dependencies remain pending, not waived.
+
+## Branch and allowlist
+
+Implementer: crates/emburk-cli/src/main.rs, crates/emburk-cli/tests/file_transfer.rs.
+PM: this packet, STATUS, TODO, ROADMAP, ARCHITECTURE, COMPATIBILITY,
+docs/FILE_TRANSFER.md, provenance index, daily log, ADR-0016 and decision index.
+Reviewers/testers read-only. No core, Cargo, dependency or prior ADR edits.
+
+## Artifacts
+
+Original Rust std-library adapters only; real binary and unique temp fixtures.
+No download, remote model, external implementation or source reuse.
+
+## Acceptance criteria
+
+Add `transfer-lines-stdout INPUT` and `transfer-lines-null INPUT`. Both require
+regular UTF-8 input, use existing bounded normalized Text handoff, and propagate
+read/encoding/size/write/flush failures. Stdout command emits only record bytes
+on stdout, locks stdout for transfer, reports counts on stderr. Null command uses
+std::io::sink(), emits no data on stdout, reports count on stderr, and still
+fully reads/validates input. Existing file command behavior stays unchanged.
+No files are created by either new command. Success 0, operation error 1,
+argument error 2. Broken pipe is a nonpanic error with exit 1; no successful
+summary follows failure. Partial stdout can already have been consumed.
+Tests run actual binary for Unicode/CRLF/blank/final/empty cases, invalid UTF-8,
+oversize/missing/directory input, arguments, output isolation and a closed stdout
+pipe (Unix). Preserve all S01 file/permissions tests. No global stdout redirection.
+
+## Demo Command
+
+`cargo test --workspace && cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings`
+
+## Evidence class
+
+Unit/Contract plus local process/file Integration. Independent final-head Demo
+and guarded PR integration required before slice Done. No points before acceptance.
+
+## Stop rule
+
+Stop before YAML/CSV, new dependency, generic plugin API, core handoff changes,
+overwrite, deletion, lifecycle, transaction/resume or Embulk compatibility policy.
+
+## Non-claims
+
+No Embulk stdout/null plugin parity, byte-preserving binary copy, atomic output,
+recovery, cross-platform pipe assurance or complete T-0031/MVP acceptance.
+No new third-party material; previous patent/FTO/release gaps remain unreviewed.


### PR DESCRIPTION
Tracks #24 T-0031/S02. Adds additive stdout/null CLI commands using unchanged bounded core handoff. Stdout only data, stderr summaries; null fully validates. Existing file semantics and permissions preserved. 71 tests pass/8 existing intentional ignores; fmt and strict Clippy pass. Final-head independent acceptance pending. No Embulk/YAML/plugin/atomicity claims. Packet docs/provenance/T-0031-output-targets.md.