### PR TITLE
test(t-0014): capture bundled file CSV reference behavior

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,11 +28,11 @@ T-0012/S13 is Done through PR #107 (`441040f`) after primary and independent
 final-head Demo at `65a2fb3`, accepting 5 SP. Known S03–S13 acceptance totals
 45 SP. Parent #15 remains open in Backlog, Current 55 / Initial 5 unchanged.
 
-T-0022/S01 is In Progress for an isolated parser-candidate experiment (forecast
-5 SP, not accepted). Exact archives were reviewed and the owner explicitly
-approved dependency build execution. The [packet](docs/provenance/T-0022-parser-experiment.md)
-fixes its Demo and non-claims. Parent Initial 8 is unchanged; production
-adoption and configured transfer follow experiment review.
+T-0022/S01 is Done through PR #114 (8b48051), accepting 5 SP after primary and
+independent acceptance at 964b4b5: six experiment and 71 workspace passes,
+eight existing ignores and actual-binary checks. Parent Initial 8 is unchanged.
+T-0014/S01 now observes bundled File/CSV behavior (forecast 5 SP) before
+configured CSV semantics; production parser adoption remains pending.
 
 T-0031/S01 is Done through PR #110 (`c5fb13f`), accepting 5 SP, for a native UTF-8 line-record
 File-to-File command under ADR-0015. It consumes T-0021/S06 without claiming
@@ -68,7 +68,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S13 Done; remaining contracts queued) | Backlog | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
-| T-0014 | Scaffold the differential harness | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0014 | Scaffold the differential harness (S01 File/CSV observation active) | In Progress | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
 
@@ -76,7 +76,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0020 | Epic: Compact Rust execution core | Backlog | P1 | — | T-0010 | Project Manager | Planning |
 | T-0021 | Define workspace boundaries and core traits (S01–S06 integrated; remaining contracts queued) | Backlog | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
-| T-0022 | Implement configuration loading and the MVP CLI | In Progress | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
+| T-0022 | Implement configuration loading and the MVP CLI (S01 Done) | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 21 | T-0012, T-0021 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0025 | Implement atomic transaction and resume state | Backlog | P1 | 8 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -5,6 +5,9 @@ Compatibility is an evidence record, not a general promise.
 T-0022/S01's isolated parser experiment is not production adoption or YAML
 compatibility. Ordered syntax observations are evaluated before configuration
 policy is selected; the production workspace remains unaffected.
+PR #114 accepted that experiment. T-0014/S01 admits the four version-pinned
+bundled File/CSV modules only for local observation; no Native/Verified plugin
+claim or redistribution approval follows.
 
 The implementation objective is strict reproduction of observable behavior for
 the pinned core and admitted plugins. Technical constraints, disproportionate

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,8 +3,10 @@
 The roadmap is ordered by evidence gates. Dates are intentionally omitted until observed throughput and cycle time support forecasting.
 
 The owner-authorized [seven-stage execution sequence](IMPLEMENTATION_SEQUENCE.md)
-connects these gates to actual transfer work. T-0022/S01 currently experiments
-with an isolated parser; it does not pass the configuration or pipeline gates.
+connects these gates to actual transfer work. T-0022/S01's isolated parser
+experiment integrated through PR #114. T-0014/S01 now captures the bundled
+File/CSV reference before configured native semantics; configuration and pipeline
+gates remain open. This early reference work is a dependency of stages 2–4.
 
 ## Phase 0: Governance and Compatibility Contract
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -41,10 +41,10 @@ Development state: `bootstrap`
   review.
 
 Parser-selection research now has a [candidate assessment](provenance/T-0022-parser-candidates.md).
-T-0022/S01 is now In Progress as an isolated parser experiment after exact
-archive review and explicit owner approval of dependency build execution.
+T-0022/S01 is Done through PR #114 after primary and independent acceptance
+of six experiment tests, 71 workspace tests and actual-binary checks.
 The production workspace and CLI remain unchanged. The active packet is
-[T-0022/S01](provenance/T-0022-parser-experiment.md); the owner-authorized
+[T-0014/S01](provenance/T-0014-file-csv-oracle.md); the owner-authorized
 [seven-stage sequence](IMPLEMENTATION_SEQUENCE.md) remains uncompleted work.
 
 ## Delivery queue
@@ -72,7 +72,7 @@ strict controls and unchanged S12 regression. T-0031/S01 is Done through PR #110
 (`c5fb13f`) for the explicitly requested experimental native File-to-File path.
 T-0031/S02 is Done through PR #112 (`2ec236e`) for experimental stdout/null
 consumers: 71 tests passed, eight existing intentional ignores, primary and
-independent acceptance at `c5df504`. T-0022/S01 now occupies one WIP lane; the full
+independent acceptance at `c5df504`. T-0014/S01 now occupies one WIP lane; the full
 file/plugin parent stays open. Core transfer semantics remain unchanged.
 
 | Item | State | Purpose |
@@ -89,7 +89,7 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 
-T-0022/S01 is In Progress; other unfinished stable tasks remain `Backlog`. Parent epics are
+T-0014/S01 is In Progress for bundled File/CSV reference observation; other unfinished stable tasks remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
 is the coordination mirror. Its 52 items, lifecycle states, initial estimates,
 roles, dependencies, workstreams, evidence classes, and views were reconciled

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -455,3 +455,9 @@ archive/hash/license triage. Automated safety review required explicit approval
 for dependency build scripts and a procedural macro; the owner supplied it.
 The approved locked dependency build passed, but placeholder compilation is
 not acceptance evidence. Production configuration remains unimplemented.
+
+T-0022/S01 passed primary and independent exact-head acceptance at 964b4b5,
+including six experiment tests, 71 workspace tests and actual observer-binary
+cases. PR #114 integrated as 8b48051; S01 accepts 5 SP. T-0014/S01 now captures
+the official executable's bundled File/CSV behavior before native configuration
+is fixed. This advances the seven-stage sequence without guessing compatibility.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -35,6 +35,7 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0012/S12 config-envelope observation](T-0012-config-envelope-probe.md) | Done (PR #105, `67f0786`; reference evidence only) |
 | [T-0012/S13 config-syntax observation](T-0012-config-syntax-probe.md) | Done (PR #107; final-head acceptance passed) |
 | [T-0022 parser candidate assessment](T-0022-parser-candidates.md) | Proposed refinement; no dependency admission |
-| [T-0022/S01 parser experiment](T-0022-parser-experiment.md) | In Progress; exact artifacts admitted for owner-approved local experiment only |
+| [T-0022/S01 parser experiment](T-0022-parser-experiment.md) | Done, PR #114; isolated experiment only |
+| [T-0014/S01 File/CSV oracle](T-0014-file-csv-oracle.md) | In Progress; bundled reference observation only |
 | [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | Done, PR #110; native-only record consumer |
 | [T-0031/S02 experimental stdout/null](T-0031-output-targets.md) | Done, PR #112; unchanged core transfer |

--- a/docs/provenance/T-0014-file-csv-oracle.md
+++ b/docs/provenance/T-0014-file-csv-oracle.md
@@ -1,0 +1,123 @@
+# T-0014/S01 bundled File/CSV reference observation
+
+Issue: [#17](https://github.com/bhind/emburk/issues/17). State: In Progress.
+Slice forecast: 5 SP. No full differential-harness acceptance is claimed.
+
+## Authority
+
+The owner authorized stages 1–7 and continued local implementation and testing.
+PM admits the already-pinned official executable's bundled File/CSV plugins
+for local reference execution after read-only Librarian artifact review.
+No plugin installation, source copying or redistribution is authorized here.
+
+## Dependencies
+
+T-0011 official executable inventory, S12/S13 syntax observations and T-0022/S01
+parser experiment (PR #114, 8b48051) are integrated. This observation precedes
+native configured CSV semantics, not the entire T-0012/T-0013 parent contracts.
+
+## Branch and allowlist
+
+Branch research/t-0014-file-csv-oracle. Compatibility Host Implementer owns only
+tools/file-csv-oracle/run.py and tests/test_file_csv_oracle.py. PM owns this
+packet, T-0022-parser-experiment.md closeout, STATUS, TODO, ROADMAP,
+COMPATIBILITY, provenance index and daily log. Testers/Librarian are read-only.
+Existing probe scripts and production Rust remain unchanged.
+
+## Artifacts
+
+Official Embulk 0.11.5 executable:
+https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar
+SHA-256 e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47.
+Core commit c5ac2d471edac465b45088669d376a7e2a525f8f. Runtime only, Java 17.
+The runner requires EMBURK_REFERENCE_JAR pointing to a byte-exact local copy;
+it must verify the checksum before execution and never download implicitly.
+
+| Bundled module | SHA-256 | Source commit |
+| --- | --- | --- |
+| input-file 0.11.1 | e18475e5e58efddbf719d91123c83df366fec56c84c8fcc7ee82d6c8285e98bd | b9737ee9f73d73c567f8d862ca67ddabb6e0d736 |
+| parser-csv 0.11.6 | f47c554c4bb8593c8ce5050c22f802c38332759c0ba27d2629a56bd09f52cd32 | 43e9c77fa35c06d7e92677089bce78e0d1e53763 |
+| output-file 0.11.1 | 2364f76b41cb1c12714d10e0126f2ba1cf594404f9b55224e960e1789653b0de | 874f965fff16d08636c4e1cc540dd3cad8a8552d |
+| formatter-csv 0.11.2 | d3f27c5b7905f3380408a27c57c7f4dcf35492d4d4131dcf4d52f4d9896f2062 | f90bb5ef99965b93a17ee320d4ae85303f7cfbd5 |
+
+Sources: https://www.embulk.org/docs/built-in.html and the four official
+embulk/embulk-{input-file,parser-csv,output-file,formatter-csv} repositories at
+the listed commits, accessed 2026-09-06. Only docs/manifests/license metadata
+were consulted. Each module contains Apache-2.0 LICENSE, no module-local NOTICE;
+the outer executable supplies LICENSE and NOTICE. The bundled classpaths use
+util-config 0.5.0, Jackson 2.16.2, validation-api 2.0.1.Final and relevant
+util-file 0.2.0, util-csv 0.3.0, util-text 0.2.0, util-timestamp 0.3.0,
+util-rubytime 0.4.0 and util-json 0.5.0. Complete SBOM, advisory, redistribution
+and patent/FTO reviews remain unreviewed, not cleared. No material blocker
+was identified for this local oracle. All fixture content is original.
+
+## Acceptance criteria
+
+Capture exact original input/config bytes, Java version, executable identity,
+per-invocation stdout/stderr/exit, generated output filenames/bytes/checksums
+and unique run identity. Each case has an isolated temporary directory outside
+the repository and a 60-second process timeout. Never touch user input/output.
+Cases: normal two-column CSV, quoted comma/multiline/Unicode, empty input,
+blank/null cells, malformed numeric record, missing input, duplicate selected
+configuration key and existing output-prefix sentinel. Capture behavior before
+asserting an expected result; failures are retained, not silently normalized.
+Runner validation tests must reject wrong artifact identity and malformed or
+incomplete capture metadata. This slice observes the reference only.
+
+## Demo Command
+
+`python3 -m unittest discover -s tests -p test_file_csv_oracle.py && python3 tools/file-csv-oracle/run.py && cargo test --locked --workspace`
+
+Set EMBURK_REFERENCE_JAR to the verified local artifact and JAVA_HOME to the
+available Java 17 installation before Demo. The runner creates its evidence
+directory with mkdtemp under /private/tmp and prints the retained location.
+
+## Evidence class
+
+Reference Observation / Integration, not native differential acceptance.
+
+## Stop rule
+
+Stop on artifact mismatch, output outside the newly allocated evidence tree,
+unrecognized capture structure or missing raw evidence. Record actual plugin
+failures as observations; do not guess successful semantics. No production
+implementation or reference source translation in this packet.
+
+## Non-claims
+
+No full CSV/configuration compatibility, all encodings/types, transactions,
+resume, performance, redistribution or legal/security clearance. No points
+accepted before primary/independent Demo and integration.
+
+## Preparation findings
+
+Security review found ambient environment forwarding and a mutable reference
+path between hash verification and execution. The runner now allowlists the
+child environment and executes a read-only, exclusively created snapshot of
+the verified bytes. Review cleared these findings within the trusted private
+fixture/same-UID boundary; OS network isolation is not claimed.
+
+Initial absolute-input-path attempts timed out after 60 seconds with exit -9
+after loading the CSV plugin. Evidence is retained, including
+/private/tmp/emburk-t0014-normal-dy_rhswk and
+/private/tmp/emburk-t0014-normal-2txexgcj. A live Java 17 thread dump on 2026-09-06
+showed directory traversal in the input plugin's real-case path lookup, not
+CSV record execution (/private/tmp/t0014-diagnostic-72495-jstack.txt).
+No upstream implementation was inspected or translated. The next fixture
+revision uses input.csv and output/result relative to its private process CWD;
+this is an experiment to avoid the observed absolute-path traversal boundary,
+not a claim that the reference has completed or that absolute paths are unsupported.
+
+The confirmed relative-path run /private/tmp/emburk-t0014-run-9i68hz6n completed
+all eight cases with exit 0. With exec: {}, the host generated eight output
+files for a single input task: one data file and seven header-only files.
+Missing input generated no output; malformed long skipped its row and emitted
+headers, not a failing process. Blank/unquoted versus quoted-empty cells stayed
+distinct in output. The existing prefix sentinel remained beside generated files.
+To remove CPU-count dependence from the selected first native profile, the final
+fixture sets max_threads: 1 and min_output_tasks: 1. These documented executor
+options (https://www.embulk.org/docs/built-in.html, local executor section,
+accessed 2026-09-06) are explicit reference inputs, not output normalization.
+Final primary/independent acceptance will use these single-task fixtures, with
+duplicate skip_header_lines set first to 2 then 1 to observe an actual winner
+in output data, rather than only a warning for an unskipped invalid header.

--- a/docs/provenance/T-0022-parser-experiment.md
+++ b/docs/provenance/T-0022-parser-experiment.md
@@ -1,6 +1,6 @@
 # T-0022/S01 parser experiment packet
 
-Issue: [#19](https://github.com/bhind/emburk/issues/19). State: In Progress.
+Issue: [#19](https://github.com/bhind/emburk/issues/19). State: Done (S01 only).
 Branch: `feat/t-0022-configured-transfer`. Slice forecast: 5 SP.
 
 ## Authority
@@ -99,3 +99,22 @@ observer guard is 64. This is a measured design constraint, not an Embulk limit.
 Implementer Demo passed six experiment tests and 71 workspace tests (eight
 existing intentional ignores); primary/independent reviewed-revision acceptance
 and integration remain required. No points are accepted yet.
+
+## Final acceptance
+
+PR #114 integrated as 8b4805101fd06821ebcaf2cdb23bb89e7c24b824 after primary
+and independent acceptance at 964b4b5ef04472d2ffd175fce0353a7ef1d6e22b.
+Six experiment and 71 workspace tests passed; eight existing intentional
+external-oracle ignores remain. Format and strict Clippy passed. Independent
+actual-binary checks confirmed ordered duplicates, tags, anchor/alias, malformed
+partial stdout with error/exit 1, raw-invalid and oversized input errors, and
+missing-argument exit 2. S01 accepts 5 SP; parent T-0022 remains open.
+
+Retained primary logs: /private/tmp/t0022-s01-primary.6Ic9TH, stdout SHA-256
+4cda785794201ea39cdafb9970ac347860f73b55e1803175e7a1c36d5ef98c30,
+stderr 820730b203dee957ad1368dcbcbf30cb25c544a518a009f70189a6612af2d167.
+Independent logs: /private/tmp/t0022-s01-final-independent.E2t4gJ, stdout
+53596ce64c1e7c36004d152c48e9fefa9dd6645ef18aef6ebf0a03196a0d6fbc,
+stderr 2acaa954ba5b57c8b6064d979f93467395921c364b6347f554adb31c44c09bde.
+Numeric exit 0 was retained and inspected. Independent offline mode used the
+same exact lock. Evidence remains Unit/Contract, not parser production adoption.

--- a/tests/test_file_csv_oracle.py
+++ b/tests/test_file_csv_oracle.py
@@ -1,0 +1,129 @@
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("file_csv_oracle", ROOT / "tools/file-csv-oracle/run.py")
+oracle = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(oracle)
+
+
+class FileCsvOracleTests(unittest.TestCase):
+    def write_valid_manifest(self, directory, input_exists=False):
+        root = Path(directory)
+        (root / "output").mkdir()
+        (root / "config.yml").write_bytes(b"config\n")
+        (root / "java-version.txt").write_bytes(b"java 17\n")
+        (root / "stdout.log").write_bytes(b"stdout\n")
+        (root / "stderr.log").write_bytes(b"")
+        (root / "exit.txt").write_text("0\n", encoding="ascii")
+        (root / "output" / "result.csv").write_bytes(b"id,name\n")
+        if input_exists:
+            (root / "input.csv").write_bytes(b"id,name\n")
+        detail = lambda path: oracle.file_detail(path, root)
+        manifest = {
+            "case": "normal", "run_uuid": "00000000-0000-4000-8000-000000000000",
+            "reference": {"sha256": oracle.EXPECTED_JAR_SHA256}, "java_version": detail(root / "java-version.txt"),
+            "input": {"name": "input.csv", "exists": input_exists, "size": len(b"id,name\n") if input_exists else 0, "sha256": oracle.sha256(b"id,name\n") if input_exists else oracle.sha256(b"")},
+            "config": detail(root / "config.yml"),
+            "process": {"exit": 0, "timed_out": False, "stdout": detail(root / "stdout.log"), "stderr": detail(root / "stderr.log")},
+            "outputs": [{"name": "result.csv", "size": len(b"id,name\n"), "sha256": oracle.sha256(b"id,name\n")}], "preexisting_outputs": [],
+        }
+        path = root / "manifest.json"; path.write_text(json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8")
+        return path, manifest
+
+    def test_wrong_artifact_is_rejected_before_execution(self):
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "wrong.jar"
+            artifact.write_bytes(b"not the pinned artifact")
+            with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+                oracle.reference_jar({"EMBURK_REFERENCE_JAR": str(artifact)})
+
+    def test_incomplete_manifest_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "manifest.json"
+            manifest.write_text(json.dumps({"case": "normal"}) + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "manifest structure"):
+                oracle.validate_case_manifest(manifest)
+
+    def test_malformed_manifest_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "manifest.json"
+            manifest.write_text("{not json}\n", encoding="utf-8")
+            with self.assertRaises(json.JSONDecodeError):
+                oracle.validate_case_manifest(manifest)
+
+    def test_child_environment_does_not_forward_sentinel(self):
+        with tempfile.TemporaryDirectory() as directory:
+            environment = oracle.jvm_environment(Path(directory), "/java-home")
+            self.assertNotIn("T0014_SECRET_SENTINEL", environment)
+            self.assertNotIn("JAVA_TOOL_OPTIONS", environment)
+            self.assertEqual(set(environment), {"PATH", "JAVA_HOME", "EMBULK_HOME", "HOME", "TMPDIR"})
+
+    def test_verified_snapshot_is_unchanged_when_source_is_replaced(self):
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(oracle, "EXPECTED_JAR_SHA256", oracle.sha256(b"trusted")):
+            source, root = Path(directory) / "reference.jar", Path(directory) / "run"
+            source.write_bytes(b"trusted")
+            root.mkdir()
+            data = oracle.reference_bytes({"EMBURK_REFERENCE_JAR": str(source)})
+            copied = oracle.snapshot_reference(data, root)
+            source.write_bytes(b"replacement")
+            self.assertEqual(copied.read_bytes(), b"trusted")
+
+    def test_summary_does_not_overwrite_case_manifest(self):
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(oracle, "EXPECTED_JAR_SHA256", oracle.sha256(b"trusted")):
+            root, case = Path(directory) / "run", Path(directory) / "case"
+            root.mkdir(); case.mkdir()
+            original = b'{"case":"normal"}\n'
+            (case / "manifest.json").write_bytes(original)
+            jar = oracle.snapshot_reference(b"trusted", root)
+            oracle.write_summary(root, "00000000-0000-4000-8000-000000000000", jar, [{"case": "normal", "path": str(case), "manifest_sha256": oracle.sha256(original)}])
+            self.assertEqual((case / "manifest.json").read_bytes(), original)
+
+    def test_config_uses_case_relative_paths(self):
+        config = oracle.config_bytes().decode("utf-8")
+        self.assertIn("path_prefix: input.csv", config)
+        self.assertIn("path_prefix: output/result", config)
+        self.assertNotIn("/private/tmp", config)
+
+    def test_config_explicitly_bounds_execution_and_duplicate_key(self):
+        self.assertIn("exec:\n  max_threads: 1\n  min_output_tasks: 1\n", oracle.config_bytes().decode("utf-8"))
+        self.assertIn("skip_header_lines: 2\n    skip_header_lines: 1", oracle.config_bytes(True).decode("utf-8"))
+
+    def test_manifest_rejects_changed_raw_file_and_missing_output(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest, _ = self.write_valid_manifest(directory)
+            oracle.validate_case_manifest(manifest)
+            (Path(directory) / "config.yml").write_bytes(b"changed\n")
+            with self.assertRaises(ValueError): oracle.validate_case_manifest(manifest)
+        with tempfile.TemporaryDirectory() as directory:
+            manifest, _ = self.write_valid_manifest(directory)
+            (Path(directory) / "output" / "result.csv").unlink()
+            with self.assertRaises(ValueError): oracle.validate_case_manifest(manifest)
+
+    def test_manifest_rejects_omitted_output_and_changed_exit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest, value = self.write_valid_manifest(directory)
+            value["outputs"] = []
+            manifest.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+            with self.assertRaises(ValueError): oracle.validate_case_manifest(manifest)
+        with tempfile.TemporaryDirectory() as directory:
+            manifest, value = self.write_valid_manifest(directory)
+            value["process"]["exit"] = 1
+            manifest.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+            with self.assertRaises(ValueError): oracle.validate_case_manifest(manifest)
+
+    def test_manifest_rejects_escaped_path_and_records_missing_input(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest, value = self.write_valid_manifest(directory)
+            oracle.validate_case_manifest(manifest)
+            value["config"]["name"] = "../outside.yml"
+            manifest.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+            with self.assertRaises(ValueError): oracle.validate_case_manifest(manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/file-csv-oracle/run.py
+++ b/tools/file-csv-oracle/run.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Capture selected bundled File/CSV reference outcomes without inferring policy."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import uuid
+
+EXPECTED_JAR_SHA256 = "e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47"
+JAVA_MAJOR = "17"
+TIMEOUT_SECONDS = 60
+CASE_NAMES = (
+    "normal", "quoted-comma-multiline-unicode", "empty", "blank-null",
+    "malformed-long", "missing-input", "duplicate-config-key", "existing-prefix-sentinel",
+)
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def confined(path: Path, root: Path) -> Path:
+    resolved, boundary = path.resolve(), root.resolve()
+    if resolved == boundary or boundary not in resolved.parents:
+        raise ValueError("path escapes case directory")
+    return resolved
+
+
+def reference_jar(environment: dict[str, str]) -> Path:
+    value = environment.get("EMBURK_REFERENCE_JAR")
+    if not value:
+        raise ValueError("EMBURK_REFERENCE_JAR is required")
+    path = Path(value)
+    if not path.is_file() or path.is_symlink():
+        raise ValueError("reference artifact is not a regular file")
+    if sha256(path.read_bytes()) != EXPECTED_JAR_SHA256:
+        raise ValueError("reference artifact checksum mismatch")
+    return path.resolve()
+
+
+def reference_bytes(environment: dict[str, str]) -> bytes:
+    value = environment.get("EMBURK_REFERENCE_JAR")
+    if not value:
+        raise ValueError("EMBURK_REFERENCE_JAR is required")
+    path = Path(value)
+    if not path.is_file() or path.is_symlink():
+        raise ValueError("reference artifact is not a regular file")
+    data = path.read_bytes()
+    if sha256(data) != EXPECTED_JAR_SHA256:
+        raise ValueError("reference artifact checksum mismatch")
+    return data
+
+
+def snapshot_reference(data: bytes, root: Path) -> Path:
+    path = root / "embulk.jar"
+    with path.open("xb") as stream:
+        stream.write(data)
+    path.chmod(0o400)
+    if sha256(path.read_bytes()) != EXPECTED_JAR_SHA256:
+        raise ValueError("reference snapshot checksum mismatch")
+    return path
+
+
+def java_command(environment: dict[str, str]) -> tuple[Path, bytes]:
+    home = environment.get("JAVA_HOME")
+    if not home:
+        raise ValueError("JAVA_HOME is required")
+    executable = Path(home) / "bin" / "java"
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise ValueError("JAVA_HOME does not provide java")
+    version = subprocess.run([str(executable), "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             env={"PATH": os.defpath, "JAVA_HOME": str(Path(home).resolve())}, timeout=10, check=False)
+    raw = version.stdout + version.stderr
+    if version.returncode != 0 or f'version "{JAVA_MAJOR}.'.encode() not in raw:
+        raise ValueError("Java 17 is required")
+    return executable.resolve(), raw
+
+
+def jvm_environment(case_root: Path, java_home: str) -> dict[str, str]:
+    home, temporary = case_root / "home", case_root / "tmp"
+    home.mkdir()
+    temporary.mkdir()
+    return {"PATH": os.defpath, "JAVA_HOME": java_home, "EMBULK_HOME": str(home), "HOME": str(home), "TMPDIR": str(temporary)}
+
+
+def config_bytes(duplicate: bool = False) -> bytes:
+    skip = b"    skip_header_lines: " + (b"2\n    skip_header_lines: 1\n" if duplicate else b"1\n")
+    return (
+        b"in:\n  type: file\n  path_prefix: input.csv\n  parser:\n"
+        b"    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n"
+        + skip
+        + b"    columns:\n    - {name: id, type: long}\n    - {name: name, type: string}\n"
+        + b"out:\n  type: file\n  path_prefix: output/result"
+        + b"\n  file_ext: csv\n  formatter:\n    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    header_line: true\n    quote_policy: MINIMAL\nexec:\n  max_threads: 1\n  min_output_tasks: 1\n"
+    )
+
+
+def fixture(name: str) -> bytes:
+    fixtures = {
+        "normal": b"id,name\n1,Alice\n-2,Bob\n",
+        "quoted-comma-multiline-unicode": "id,name\n1,\"comma, \"\"quote\"\"\"\n2,\"first\nsecond \u2603\"\n".encode(),
+        "empty": b"",
+        "blank-null": b"id,name\n1,\n2,\"\"\n,empty-long\n3,   \n",
+        "malformed-long": b"id,name\nnot-a-long,value\n",
+        "missing-input": None,
+        "duplicate-config-key": b"id,name\n4,duplicate\n",
+        "existing-prefix-sentinel": b"id,name\n5,sentinel\n",
+    }
+    return fixtures[name]
+
+
+def output_inventory(output_dir: Path) -> list[dict[str, object]]:
+    confined(output_dir, output_dir.parent)
+    result = []
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_file() and not path.is_symlink():
+            confined(path, output_dir)
+            data = path.read_bytes()
+            result.append({"name": str(path.relative_to(output_dir)), "size": len(data), "sha256": sha256(data)})
+    return result
+
+
+def file_detail(path: Path, root: Path) -> dict[str, object]:
+    confined(path, root)
+    data = path.read_bytes()
+    return {"name": str(path.relative_to(root)), "size": len(data), "sha256": sha256(data)}
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def validate_case_manifest(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    required = {"case", "run_uuid", "reference", "java_version", "input", "config", "process", "outputs", "preexisting_outputs"}
+    if not isinstance(value, dict) or set(value) != required or value["case"] not in CASE_NAMES:
+        raise ValueError("manifest structure")
+    if str(uuid.UUID(value["run_uuid"])) != value["run_uuid"]:
+        raise ValueError("manifest UUID")
+    if value["reference"] != {"sha256": EXPECTED_JAR_SHA256}:
+        raise ValueError("manifest artifact")
+    root = path.parent.resolve()
+    for key in ("config",):
+        item = value[key]
+        if not isinstance(item, dict) or set(item) != {"name", "size", "sha256"}:
+            raise ValueError("manifest input")
+        candidate = confined(root / item["name"], root)
+        if not candidate.is_file() or item != file_detail(candidate, root): raise ValueError("manifest input")
+    item = value["input"]
+    if not isinstance(item, dict) or set(item) != {"name", "exists", "size", "sha256"} or not isinstance(item["exists"], bool):
+        raise ValueError("manifest input")
+    candidate = confined(root / item["name"], root)
+    if item["exists"]:
+        if not candidate.is_file() or {"name": item["name"], "exists": True, "size": len(candidate.read_bytes()), "sha256": sha256(candidate.read_bytes())} != item: raise ValueError("manifest input")
+    elif candidate.exists() or item != {"name": item["name"], "exists": False, "size": 0, "sha256": sha256(b"")}:
+        raise ValueError("manifest input")
+    java = value["java_version"]
+    if not isinstance(java, dict) or set(java) != {"name", "size", "sha256"}: raise ValueError("manifest java")
+    java_file = confined(root / java["name"], root)
+    if not java_file.is_file() or java != file_detail(java_file, root): raise ValueError("manifest java")
+    process = value["process"]
+    if not isinstance(process, dict) or set(process) != {"exit", "timed_out", "stdout", "stderr"} or not isinstance(process["exit"], int) or not isinstance(process["timed_out"], bool):
+        raise ValueError("manifest process")
+    for key in ("stdout", "stderr"):
+        item = process[key]
+        if not isinstance(item, dict) or set(item) != {"name", "size", "sha256"}: raise ValueError("manifest process")
+        candidate = confined(root / item["name"], root)
+        if not candidate.is_file() or item != file_detail(candidate, root): raise ValueError("manifest process")
+    exit_file = confined(root / "exit.txt", root)
+    if not exit_file.is_file() or exit_file.read_text(encoding="ascii") != str(process["exit"]) + "\n":
+        raise ValueError("manifest process")
+    if not isinstance(value["outputs"], list) or not isinstance(value["preexisting_outputs"], list):
+        raise ValueError("manifest outputs")
+    names = set()
+    for item in value["outputs"]:
+        if not isinstance(item, dict) or set(item) != {"name", "size", "sha256"} or item["name"] in names: raise ValueError("manifest outputs")
+        names.add(item["name"])
+        candidate = confined(root / "output" / item["name"], root / "output")
+        if not candidate.is_file() or item != {"name": item["name"], "size": len(candidate.read_bytes()), "sha256": sha256(candidate.read_bytes())}: raise ValueError("manifest outputs")
+    previous = set()
+    for item in value["preexisting_outputs"]:
+        if not isinstance(item, dict) or set(item) != {"name", "size", "sha256"} or item["name"] in previous: raise ValueError("manifest outputs")
+        previous.add(item["name"])
+    if value["outputs"] != output_inventory(root / "output"):
+        raise ValueError("manifest outputs")
+    return value
+
+
+def run_case(name: str, jar: Path, java: Path, java_version: bytes, run_uuid: str) -> Path:
+    case_root = Path(tempfile.mkdtemp(prefix=f"emburk-t0014-{name}-", dir="/private/tmp"))
+    input_path, config_path = case_root / "input.csv", case_root / "config.yml"
+    output_dir = case_root / "output"
+    output_dir.mkdir()
+    output_prefix = output_dir / "result"
+    input_data = fixture(name)
+    if input_data is not None:
+        input_path.write_bytes(input_data)
+    if name == "existing-prefix-sentinel":
+        output_prefix.write_bytes(b"original sentinel\n")
+    config_path.write_bytes(config_bytes(name == "duplicate-config-key"))
+    (case_root / "java-version.txt").write_bytes(java_version)
+    preexisting = output_inventory(output_dir)
+    java_detail = file_detail(case_root / "java-version.txt", case_root)
+    input_detail = {"name": input_path.name, "exists": input_data is not None, "size": len(input_data or b""), "sha256": sha256(input_data or b"")}
+    config_detail = file_detail(config_path, case_root)
+    environment = jvm_environment(case_root, str(java.parent.parent))
+    command = [str(java), f"-Duser.home={environment['HOME']}", "-jar", str(jar), f"-Xembulk_home={environment['EMBULK_HOME']}", "run", str(config_path)]
+    stdout_path, stderr_path = case_root / "stdout.log", case_root / "stderr.log"
+    with stdout_path.open("xb") as stdout, stderr_path.open("xb") as stderr:
+        process = subprocess.Popen(command, stdout=stdout, stderr=stderr, env=environment, start_new_session=True, cwd=case_root)
+        timed_out = False
+        try:
+            exit_code = process.wait(timeout=TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            os.killpg(process.pid, signal.SIGKILL)
+            exit_code = process.wait()
+    (case_root / "exit.txt").write_text(f"{exit_code}\n", encoding="ascii")
+    if file_detail(config_path, case_root) != config_detail:
+        raise ValueError("reference process changed captured config")
+    if input_data is not None and file_detail(input_path, case_root) != {"name": input_path.name, "size": input_detail["size"], "sha256": input_detail["sha256"]}:
+        raise ValueError("reference process changed captured input")
+    manifest = {
+        "case": name,
+        "run_uuid": run_uuid,
+        "reference": {"sha256": EXPECTED_JAR_SHA256},
+        "java_version": java_detail,
+        "input": input_detail,
+        "config": config_detail,
+        "process": {"exit": exit_code, "timed_out": timed_out, "stdout": file_detail(stdout_path, case_root), "stderr": file_detail(stderr_path, case_root)},
+        "outputs": output_inventory(output_dir),
+        "preexisting_outputs": preexisting,
+    }
+    write_json(case_root / "manifest.json", manifest)
+    validate_case_manifest(case_root / "manifest.json")
+    print(f"T0014_S01_CASE={name}|exit={exit_code}|timed_out={str(timed_out).lower()}|evidence={case_root}", flush=True)
+    return case_root
+
+
+def write_summary(run_root: Path, run_uuid: str, jar: Path, cases: list[dict[str, object]]) -> Path:
+    summary = run_root / "manifest.json"
+    write_json(summary, {"run_uuid": run_uuid, "reference_sha256": sha256(jar.read_bytes()), "cases": cases})
+    return summary
+
+
+def main() -> int:
+    run_root = Path(tempfile.mkdtemp(prefix="emburk-t0014-run-", dir="/private/tmp"))
+    jar = snapshot_reference(reference_bytes(dict(os.environ)), run_root)
+    java, version = java_command(dict(os.environ))
+    run_uuid = str(uuid.uuid4())
+    cases = []
+    for name in CASE_NAMES:
+        case_root = run_case(name, jar, java, version, run_uuid)
+        cases.append({"case": name, "path": str(case_root), "manifest_sha256": sha256((case_root / "manifest.json").read_bytes())})
+    write_summary(run_root, run_uuid, jar, cases)
+    print(f"T0014_S01_EVIDENCE_DIR={run_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, subprocess.SubprocessError) as failure:
+        print(f"T0014_S01_CAPTURE_ERROR={failure}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
Refs #17 and #19. T-0014/S01 records eight original bundled File/CSV cases through the exact admitted local Embulk 0.11.5 executable. Includes isolated environment, verified artifact snapshot, raw evidence validation, and parser experiment closeout (#114). Relative paths avoid the observed absolute-path traversal timeout; explicit single-task executor removes host CPU-count dependence. Eleven harness tests pass; final-head primary/independent live acceptance at a031fb8e96109e10bbf86202675fdc866faee3db is running. Reference Observation only; no native CSV/configuration adoption or broader compatibility claim.