### PR TITLE
feat(t-0025): no-clobber single-output publication

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,8 +33,15 @@ independent acceptance at 964b4b5: six experiment and 71 workspace passes,
 eight existing ignores and actual-binary checks. Parent Initial 8 is unchanged.
 T-0014/S01 is Done through PR #115 (c3304fc), accepting 5 SP after primary and
 independent Demo at a031fb8. Eleven harness tests and 71 workspace tests passed;
-eight single-task reference projections matched. T-0032/S01 is In Progress
-(forecast 8 SP) for the configured native CSV consumer under ADR-0017.
+eight single-task reference projections matched. T-0032/S01 is Done through
+PR #116 (66c6125), accepting 8 SP after primary and independent exact Demo at
+59a7cca: 81 passes, eight existing ignores and eight selected comparisons.
+Parent #25 remains open in Backlog, Initial/Current 8 unchanged; broader CSV
+scope is not accepted. T-0025/S01 is In Progress (forecast 5 SP) for safe
+single-output publication under ADR-0018; parent Initial/Current 8 unchanged.
+T-0014/S02 is In Progress in the second independent lane (forecast 3 SP) for
+five bundled format/filter observations. Its packet is on the dedicated
+research/t-0014-formats-oracle branch; parent Initial/Current 8 unchanged.
 
 T-0031/S01 is Done through PR #110 (`c5fb13f`), accepting 5 SP, for a native UTF-8 line-record
 File-to-File command under ADR-0015. It consumes T-0021/S06 without claiming
@@ -70,7 +77,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S13 Done; remaining contracts queued) | Backlog | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
-| T-0014 | Scaffold the differential harness (S01 Done) | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0014 | Scaffold the differential harness (S01 Done, S02 active) | In Progress | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
 
@@ -81,7 +88,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0022 | Implement configuration loading and the MVP CLI (S01 Done) | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 21 | T-0012, T-0021 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
-| T-0025 | Implement atomic transaction and resume state | Backlog | P1 | 8 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
+| T-0025 | Implement atomic transaction and resume state (publication S01 active) | In Progress | P1 | 8 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
 | T-0026 | Implement structured errors and observability | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |
 
 ## T-0030 — Native File-to-File ETL
@@ -90,7 +97,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 |---|---|---|---|---:|---|---|---|
 | T-0030 | Epic: Native File-to-File ETL | Backlog | P1 | — | T-0020 | Project Manager | Planning |
 | T-0031 | Implement file/config inputs and file/stdout/null outputs (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 8 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
-| T-0032 | Implement the CSV parser and formatter (configured S01 active) | In Progress | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
+| T-0032 | Implement the CSV parser and formatter (configured S01 integrated) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
 | T-0033 | Implement the JSON parser | Backlog | P1 | 5 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |
 | T-0035 | Implement rename and remove-columns filters | Backlog | P1 | 3 | T-0023 | Plugin Implementer | Differential (Embulk) |

--- a/crates/emburk-cli/tests/configured_csv.rs
+++ b/crates/emburk-cli/tests/configured_csv.rs
@@ -72,7 +72,7 @@ fn invalid_configurations_do_not_open_output() {
     assert!(!d.join("output/result000.00.csv").exists());
 }
 #[test]
-fn prefix_and_bad_csv_fail_before_or_with_explicit_partial_output() {
+fn prefix_and_bad_csv_fail_without_publishing_or_leaving_temporary_output() {
     let d = dir("prefix");
     write(&d, &config(""));
     fs::write(d.join("input.csv-a"), b"id,name\n1,a\n").unwrap();
@@ -88,7 +88,8 @@ fn prefix_and_bad_csv_fail_before_or_with_explicit_partial_output() {
         write(&d, &config(""));
         fs::write(d.join("input.csv"), bytes).unwrap();
         assert!(!run(&d).status.success());
-        assert!(d.join("output/result000.00.csv").exists());
+        assert!(!d.join("output/result000.00.csv").exists());
+        assert_eq!(fs::read_dir(d.join("output")).unwrap().count(), 0);
     }
 }
 #[cfg(unix)]
@@ -107,4 +108,64 @@ fn generated_file_is_owner_only() {
             & 0o777,
         0o600
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn killed_transfer_never_exposes_partial_final_output() {
+    use std::{
+        io::Write,
+        thread,
+        time::{Duration, Instant},
+    };
+    let d = dir("interrupted");
+    write(&d, &config(""));
+    let mut input = fs::File::create(d.join("input.csv")).unwrap();
+    input.write_all(b"id,name\n").unwrap();
+    let block = b"1,abcdefghijklmnopqrstuvwxyz\n".repeat(4096);
+    for _ in 0..256 {
+        input.write_all(&block).unwrap();
+    }
+    drop(input);
+    let mut child = Command::new(env!("CARGO_BIN_EXE_emburk"))
+        .args(["run", "config.yml"])
+        .current_dir(&d)
+        .spawn()
+        .unwrap();
+    let start = Instant::now();
+    let mut saw_temporary = false;
+    while start.elapsed() < Duration::from_secs(5) {
+        if fs::read_dir(d.join("output")).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".emburk-output-")
+        }) {
+            saw_temporary = true;
+            break;
+        }
+        if child.try_wait().unwrap().is_some() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    // Always reap the child, including a failed synchronization attempt.
+    let _ = child.kill();
+    let status = child.wait().unwrap();
+    assert!(
+        saw_temporary,
+        "did not observe the staged output before timeout/exit"
+    );
+    assert!(!status.success());
+    assert!(!d.join("output/result000.00.csv").exists());
+    // SIGKILL cannot run cleanup. Only a private temporary can remain; recovery
+    // of that residue is deliberately not claimed by this publication slice.
+    assert!(fs::read_dir(d.join("output")).unwrap().all(|entry| {
+        entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".emburk-output-")
+    }));
 }

--- a/crates/emburk-core/src/configured_csv.rs
+++ b/crates/emburk-core/src/configured_csv.rs
@@ -3,12 +3,13 @@ use crate::{
     csv_stream,
     logical_record::{LogicalRecord, LogicalValue},
     logical_schema::{LogicalColumn, LogicalSchema, LogicalType},
+    publication,
     record_handoff::{RecordSink, RecordSource, SinkError, SourceError, handoff_owned_records},
     yaml_profile::{self, Node},
 };
 use std::{
-    fs::{self, File, OpenOptions},
-    io::{BufReader, BufWriter, Write},
+    fs::{self, File},
+    io::{BufReader, BufWriter},
     path::{Path, PathBuf},
 };
 
@@ -213,51 +214,26 @@ fn execute(profile: Profile) -> Result<usize, String> {
         return Ok(0);
     };
     let file = File::open(&input_path).map_err(|e| format!("cannot open input: {e}"))?;
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    let output = options
-        .open(&profile.output)
-        .map_err(|e| format!("cannot create output exclusively: {e}"))?;
     let mut source = Source {
         input: BufReader::new(file),
         profile: &profile,
         skipped: 0,
     };
-    let mut sink = Sink {
-        output: BufWriter::new(output),
-    };
-    csv_stream::write_row(
-        &mut sink.output,
-        &profile
-            .schema
-            .columns()
-            .map(|column| Some(column.name().to_owned()))
-            .collect::<Vec<_>>(),
-    )
-    .map_err(|error| {
-        format!(
-            "output header failed: {error}; output may be partially written at {}",
-            profile.output.display()
+    publication::write_atomic(&profile.output, |output| {
+        csv_stream::write_row(
+            output,
+            &profile
+                .schema
+                .columns()
+                .map(|column| Some(column.name().to_owned()))
+                .collect::<Vec<_>>(),
         )
-    })?;
-    let n = handoff_owned_records(&mut source, &mut sink).map_err(|e| {
-        format!(
-            "CSV transfer failed: {e:?}; output may be partially written at {}",
-            profile.output.display()
-        )
-    })?;
-    sink.output.flush().map_err(|e| {
-        format!(
-            "output flush failed: {e}; output may be partially written at {}",
-            profile.output.display()
-        )
-    })?;
-    Ok(n)
+        .map_err(|error| format!("CSV header failed: {error}"))?;
+        let mut sink = Sink { output };
+        handoff_owned_records(&mut source, &mut sink)
+            .map_err(|error| format!("CSV transfer failed: {error:?}"))
+    })
+    .map_err(|error| error.to_string())
 }
 struct Source<'a> {
     input: BufReader<File>,
@@ -302,10 +278,10 @@ impl RecordSource for Source<'_> {
         }
     }
 }
-struct Sink {
-    output: BufWriter<File>,
+struct Sink<'a> {
+    output: &'a mut BufWriter<File>,
 }
-impl RecordSink for Sink {
+impl RecordSink for Sink<'_> {
     fn accept(&mut self, r: LogicalRecord) -> Result<(), SinkError> {
         let row = r
             .cells()

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -42,6 +42,7 @@ mod text_transfer;
 
 mod configured_csv;
 mod csv_stream;
+mod publication;
 mod yaml_profile;
 
 #[doc(hidden)]

--- a/crates/emburk-core/src/publication.rs
+++ b/crates/emburk-core/src/publication.rs
@@ -1,0 +1,370 @@
+//! Private Unix single-output publication. Visibility and cleanup are separate.
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{self, BufWriter, Write},
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+static NEXT: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Phase {
+    Create,
+    Write,
+    Flush,
+    FileSync,
+    Link,
+    TargetDirectorySync,
+    TemporaryRemove,
+    CleanupDirectorySync,
+    AbortRemove,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum State {
+    NotPublished,
+    PublishedDurabilityUnknown,
+    Published,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Cleanup {
+    NoTemporary,
+    Removed,
+    Retained,
+    RemovalDurabilityUnknown,
+}
+#[derive(Debug)]
+pub(crate) struct PublicationError {
+    pub(crate) phase: Phase,
+    pub(crate) state: State,
+    pub(crate) cleanup: Cleanup,
+    pub(crate) target: PathBuf,
+    pub(crate) temporary: Option<PathBuf>,
+    pub(crate) message: String,
+}
+impl std::fmt::Display for PublicationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:?} at {:?}; output {}; cleanup {:?}; {}",
+            self.state,
+            self.phase,
+            self.target.display(),
+            self.cleanup,
+            self.message
+        )?;
+        if let Some(path) = &self.temporary {
+            write!(f, "; temporary {}", path.display())?;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn write_atomic<T>(
+    target: &Path,
+    write: impl FnOnce(&mut BufWriter<File>) -> Result<T, String>,
+) -> Result<T, PublicationError> {
+    write_with(target, write, |_| Ok(()))
+}
+
+// The hook is private and is supplied with faults only by unit tests. It runs
+// immediately before the corresponding real operation, never from environment.
+fn write_with<T>(
+    target: &Path,
+    write: impl FnOnce(&mut BufWriter<File>) -> Result<T, String>,
+    mut before: impl FnMut(Phase) -> io::Result<()>,
+) -> Result<T, PublicationError> {
+    let failure = |phase, state, cleanup, temporary, message| PublicationError {
+        phase,
+        state,
+        cleanup,
+        target: target.to_owned(),
+        temporary,
+        message,
+    };
+    let create_error = |message| {
+        failure(
+            Phase::Create,
+            State::NotPublished,
+            Cleanup::NoTemporary,
+            None,
+            message,
+        )
+    };
+    if !cfg!(unix) {
+        return Err(create_error(
+            "single-file publication is unsupported on this platform".into(),
+        ));
+    }
+    before(Phase::Create).map_err(|e| create_error(e.to_string()))?;
+    if target.file_name().is_none() {
+        return Err(create_error("output has no file name".into()));
+    }
+    let parent = target
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    let mut created = None;
+    for _ in 0..1024 {
+        let temporary = parent.join(format!(
+            ".emburk-output-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&temporary) {
+            Ok(file) => {
+                created = Some((temporary, file));
+                break;
+            }
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(create_error(e.to_string())),
+        }
+    }
+    let (temporary, file) =
+        created.ok_or_else(|| create_error("temporary name attempts exhausted".into()))?;
+    let mut output = BufWriter::new(file);
+    let staged = (|| {
+        before(Phase::Write).map_err(|e| (Phase::Write, e.to_string()))?;
+        let value = write(&mut output).map_err(|e| (Phase::Write, e))?;
+        before(Phase::Flush)
+            .and_then(|()| output.flush())
+            .map_err(|e| (Phase::Flush, e.to_string()))?;
+        before(Phase::FileSync)
+            .and_then(|()| output.get_ref().sync_all())
+            .map_err(|e| (Phase::FileSync, e.to_string()))?;
+        before(Phase::Link)
+            .and_then(|()| fs::hard_link(&temporary, target))
+            .map_err(|e| (Phase::Link, e.to_string()))?;
+        Ok(value)
+    })();
+    // Do not let BufWriter::drop retry a failed write/flush. No buffered bytes
+    // are written after the staged operation has decided its outcome.
+    let (file, _unwritten) = output.into_parts();
+    drop(file);
+    let value = match staged {
+        Ok(value) => value,
+        Err((phase, mut message)) => {
+            let cleanup =
+                match before(Phase::AbortRemove).and_then(|()| fs::remove_file(&temporary)) {
+                    Ok(()) => Cleanup::Removed,
+                    Err(e) => {
+                        message.push_str(&format!("; owned temporary cleanup failed: {e}"));
+                        Cleanup::Retained
+                    }
+                };
+            return Err(failure(
+                phase,
+                State::NotPublished,
+                cleanup,
+                (cleanup == Cleanup::Retained).then_some(temporary),
+                message,
+            ));
+        }
+    };
+    // The final path now exists. Nothing below can remove it, even on failure.
+    let directory = before(Phase::TargetDirectorySync)
+        .and_then(|()| File::open(parent))
+        .and_then(|directory| {
+            directory.sync_all()?;
+            Ok(directory)
+        })
+        .map_err(|e| {
+            failure(
+                Phase::TargetDirectorySync,
+                State::PublishedDurabilityUnknown,
+                Cleanup::Retained,
+                Some(temporary.clone()),
+                e.to_string(),
+            )
+        })?;
+    before(Phase::TemporaryRemove)
+        .and_then(|()| fs::remove_file(&temporary))
+        .map_err(|e| {
+            failure(
+                Phase::TemporaryRemove,
+                State::Published,
+                Cleanup::Retained,
+                Some(temporary.clone()),
+                e.to_string(),
+            )
+        })?;
+    before(Phase::CleanupDirectorySync)
+        .and_then(|()| directory.sync_all())
+        .map_err(|e| {
+            failure(
+                Phase::CleanupDirectorySync,
+                State::Published,
+                Cleanup::RemovalDurabilityUnknown,
+                Some(temporary),
+                e.to_string(),
+            )
+        })?;
+    Ok(value)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    fn target() -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "emburk-publication-test-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&root).unwrap();
+        root.join("result")
+    }
+    fn content(output: &mut BufWriter<File>) -> Result<usize, String> {
+        output.write_all(b"complete\n").map_err(|e| e.to_string())?;
+        Ok(1)
+    }
+    fn fault(phase: Phase, requested: Phase) -> io::Result<()> {
+        if phase == requested {
+            Err(io::Error::other("injected operation failure"))
+        } else {
+            Ok(())
+        }
+    }
+    #[test]
+    fn each_prepublication_failure_leaves_no_output_or_temporary() {
+        for phase in [
+            Phase::Create,
+            Phase::Write,
+            Phase::Flush,
+            Phase::FileSync,
+            Phase::Link,
+        ] {
+            let target = target();
+            let error = write_with(&target, content, |p| fault(p, phase)).unwrap_err();
+            assert_eq!(error.state, State::NotPublished);
+            assert_eq!(error.phase, phase);
+            assert!(!target.exists());
+            assert_eq!(fs::read_dir(target.parent().unwrap()).unwrap().count(), 0);
+            assert_eq!(
+                error.cleanup,
+                if phase == Phase::Create {
+                    Cleanup::NoTemporary
+                } else {
+                    Cleanup::Removed
+                }
+            );
+        }
+    }
+    #[test]
+    fn partial_stream_failure_is_unpublished_and_cleanup_failure_is_explicit() {
+        for fail_cleanup in [false, true] {
+            let target = target();
+            let error = write_with(
+                &target,
+                |out| {
+                    out.write_all(&vec![b'x'; 16384]).unwrap();
+                    Err::<(), _>("injected input failure after partial write".into())
+                },
+                |phase| {
+                    if fail_cleanup {
+                        fault(phase, Phase::AbortRemove)
+                    } else {
+                        Ok(())
+                    }
+                },
+            )
+            .unwrap_err();
+            assert_eq!(error.state, State::NotPublished);
+            assert!(!target.exists());
+            assert_eq!(
+                error.cleanup,
+                if fail_cleanup {
+                    Cleanup::Retained
+                } else {
+                    Cleanup::Removed
+                }
+            );
+            if fail_cleanup {
+                let temporary = error.temporary.as_ref().unwrap();
+                assert_eq!(fs::read(temporary).unwrap().len(), 16384);
+                assert!(error.to_string().contains(&temporary.display().to_string()));
+            }
+        }
+    }
+    #[test]
+    fn every_postlink_failure_preserves_complete_final_output_and_state() {
+        for phase in [
+            Phase::TargetDirectorySync,
+            Phase::TemporaryRemove,
+            Phase::CleanupDirectorySync,
+        ] {
+            let target = target();
+            let error = write_with(&target, content, |p| fault(p, phase)).unwrap_err();
+            assert_eq!(fs::read(&target).unwrap(), b"complete\n");
+            assert_eq!(error.phase, phase);
+            assert_eq!(
+                error.state,
+                if phase == Phase::TargetDirectorySync {
+                    State::PublishedDurabilityUnknown
+                } else {
+                    State::Published
+                }
+            );
+            let retained = phase != Phase::CleanupDirectorySync;
+            assert_eq!(error.temporary.as_ref().unwrap().exists(), retained);
+            assert_eq!(
+                error.cleanup,
+                if retained {
+                    Cleanup::Retained
+                } else {
+                    Cleanup::RemovalDurabilityUnknown
+                }
+            );
+        }
+    }
+    #[test]
+    fn successful_publication_has_one_owner_only_file_and_preserves_value() {
+        use std::os::unix::fs::PermissionsExt;
+        let target = target();
+        assert_eq!(write_atomic(&target, content).unwrap(), 1);
+        assert_eq!(fs::read(&target).unwrap(), b"complete\n");
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(fs::read_dir(target.parent().unwrap()).unwrap().count(), 1);
+    }
+    #[test]
+    fn existing_regular_and_symlink_destinations_are_never_replaced() {
+        use std::os::unix::fs::symlink;
+        for is_link in [false, true] {
+            let target = target();
+            let original = target.with_file_name("original");
+            if is_link {
+                fs::write(&original, b"old").unwrap();
+                symlink(&original, &target).unwrap();
+            } else {
+                fs::write(&target, b"old").unwrap();
+            }
+            let error = write_atomic(&target, content).unwrap_err();
+            assert_eq!(
+                (error.state, error.phase, error.cleanup),
+                (State::NotPublished, Phase::Link, Cleanup::Removed)
+            );
+            assert_eq!(fs::read(&target).unwrap(), b"old");
+            assert_eq!(
+                fs::symlink_metadata(&target)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink(),
+                is_link
+            );
+            assert_eq!(
+                fs::read_dir(target.parent().unwrap()).unwrap().count(),
+                if is_link { 2 } else { 1 }
+            );
+        }
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -252,4 +252,10 @@ must be established per combination before labeling its delivery semantics.
 
 ## Trust Boundaries
 
+ADR-0018 defines a private same-directory publication primitive for configured
+output: owned temporary file, file sync, no-clobber hard link, directory sync,
+owned-temp cleanup and cleanup sync. Visibility, durability and cleanup states
+are separate. T-0025/S01 implementation/acceptance is in progress; no generic
+transaction or resume contract is implied.
+
 The Rust core, native built-ins, external native processes, JVM host, JRuby host, and user plugins are distinct trust boundaries. Protocol input, resume state, plugin output, and artifact metadata must be validated at each boundary.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -4,14 +4,17 @@ Compatibility is an evidence record, not a general promise.
 
 T-0022/S01's isolated parser experiment is not production adoption or YAML
 compatibility. Ordered syntax observations are evaluated before configuration
-policy is selected; the production workspace remains unaffected.
+policy is selected; production adoption was separately admitted by ADR-0017.
 PR #114 accepted that experiment. T-0014/S01 admits the four version-pinned
 bundled File/CSV modules only for local observation; no Native/Verified plugin
 claim or redistribution approval follows.
 T-0014/S01 is now accepted through PR #115 as reference-only evidence.
-ADR-0017 admits a bounded configured CSV implementation (T-0032/S01); its
-Native/Verified claims remain pending acceptance. General CSV and configuration
-behavior outside the selected matrix remains unfinished, not an accepted exception.
+T-0032/S01 integrated through PR #116: eight explicitly configured single-file
+long/string CSV projections match real Embulk outputs and exits in primary and
+independent runs. This is a private native consumer, not a verified generic
+plugin. General CSV and configuration behavior outside that selected matrix
+remains unfinished, not an accepted exception. T-0025/S01 now develops native
+no-clobber publication safety; its failure policy is not observed Embulk parity.
 
 The implementation objective is strict reproduction of observable behavior for
 the pinned core and admitted plugins. Technical constraints, disproportionate

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,9 +5,10 @@ The roadmap is ordered by evidence gates. Dates are intentionally omitted until 
 The owner-authorized [seven-stage execution sequence](IMPLEMENTATION_SEQUENCE.md)
 connects these gates to actual transfer work. T-0022/S01's isolated parser
 experiment integrated through PR #114. T-0014/S01's eight bundled File/CSV
-observations integrated through PR #115. T-0032/S01 now implements the bounded
-configured consumer; configuration and pipeline gates remain open until its
-selected native differential evidence passes. This connects stages 2–4.
+observations integrated through PR #115. T-0032/S01 integrated through PR #116
+after primary and independent eight-case comparison and 81 passing tests.
+This satisfies the bounded stages 2–4 consumer, not full configuration/plugin
+gates. Stage 5 is active as T-0025/S01 under ADR-0018; stages 6–7 remain open.
 
 ## Phase 0: Governance and Compatibility Contract
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -15,7 +15,8 @@ Development state: `bootstrap`
   PR #110 integrated after primary and independent acceptance (68 passing tests,
   eight existing intentional ignores). It does not load Embulk
   configuration, execute plugins, or implement transactions and resume.
-- No native, Java-hosted, or JRuby-hosted plugin is implemented or verified.
+- A bounded private configured File/CSV consumer is integrated through PR #116;
+  no public plugin API or Java/JRuby-hosted plugin is implemented or verified.
 - Thirteen selected private raw-scalar outcomes match the pinned Embulk
   executable in a live differential test. No full configuration, plugin,
   data-transfer, or performance claim has passed its evidence gate.
@@ -45,8 +46,10 @@ T-0022/S01 is Done through PR #114 after primary and independent acceptance
 of six experiment tests, 71 workspace tests and actual-binary checks.
 T-0014/S01 is Done through PR #115 after eleven harness tests, 71 workspace
 tests and matching independent eight-case reference projections. The active
-implementation packet is [T-0032/S01](provenance/T-0032-configured-csv.md);
-its production consumer is not yet accepted. The owner-authorized
+T-0032/S01 consumer is Done through PR #116 (66c6125), after 81 passing tests,
+eight existing ignores and eight independently matching selected real file
+projections at 59a7cca. T-0025/S01 now implements safe single-output publication.
+The owner-authorized
 [seven-stage sequence](IMPLEMENTATION_SEQUENCE.md) remains uncompleted work.
 
 ## Delivery queue
@@ -74,7 +77,7 @@ strict controls and unchanged S12 regression. T-0031/S01 is Done through PR #110
 (`c5fb13f`) for the explicitly requested experimental native File-to-File path.
 T-0031/S02 is Done through PR #112 (`2ec236e`) for experimental stdout/null
 consumers: 71 tests passed, eight existing intentional ignores, primary and
-independent acceptance at `c5df504`. T-0032/S01 now occupies one WIP lane; the full
+independent acceptance at `c5df504`. T-0025/S01 now occupies one WIP lane; the full
 file/plugin parent stays open. Core transfer semantics remain unchanged.
 
 | Item | State | Purpose |
@@ -91,7 +94,10 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 
-T-0032/S01 is In Progress for configured native CSV; other unfinished stable tasks remain `Backlog`. Parent epics are
+T-0025/S01 is In Progress for safe single-output publication. T-0014/S02 uses
+the second independent lane for bundled format/filter reference observations
+on research/t-0014-formats-oracle; its packet and evidence are disjoint.
+Other unfinished stable tasks remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
 is the coordination mirror. Its 52 items, lifecycle states, initial estimates,
 roles, dependencies, workstreams, evidence classes, and views were reconciled

--- a/docs/decisions/ADR-0017-bounded-configured-csv.md
+++ b/docs/decisions/ADR-0017-bounded-configured-csv.md
@@ -1,6 +1,6 @@
 # ADR-0017: Bounded configured CSV consumer
 
-- Status: Accepted for T-0032/S01 implementation; acceptance pending
+- Status: Accepted; T-0032/S01 integrated through PR #116
 - Date: 2026-09-06
 
 ## Context

--- a/docs/decisions/ADR-0018-single-output-publication.md
+++ b/docs/decisions/ADR-0018-single-output-publication.md
@@ -1,0 +1,31 @@
+# ADR-0018: No-clobber single-output publication
+
+- Status: Accepted for T-0025/S01 implementation; acceptance pending
+- Date: 2026-09-06
+
+## Decision
+
+For the bounded configured pipeline, replace direct final-file creation with
+an exclusively owned 0600 sibling temporary file. Flush and sync file contents
+before a same-filesystem hard link creates the final path without replacement.
+Successful linking is the irreversible visibility boundary. Sync the parent
+directory before removing the temporary link, then sync cleanup metadata.
+
+Never remove a published destination to compensate for a later failure.
+Distinguish not published, published with uncertain durability, and published
+with confirmed directory-sync completion. Cleanup disposition is independent:
+an error after durable publication does not mean the transfer can be replayed.
+Report phase and retained paths, including failure to remove an owned temp.
+
+This narrowly supersedes ADR-0017's partial final-file failure behavior for
+configured CSV only. Older experimental line commands are unchanged. A later
+resume design must use these states and validate identities; existence or a
+record count alone cannot establish resumability.
+
+## Constraints
+
+Unix local filesystem, same-directory hard-link and directory-sync support.
+Failure on unsupported operations is explicit. No overwrite fallback, generic
+filesystem durability claim, hostile same-UID protection, multiple-output
+atomic commit or Embulk transaction parity is implied. No new dependency or
+upstream implementation reuse is involved. See T-0025-safe-publication.md.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -467,3 +467,10 @@ the eight relative-path, explicit single-task input/config/output projections
 matched. PR #115 integrated as c3304fc; S01 accepts 5 SP. Absolute-path timeout
 evidence remains recorded. ADR-0017 and T-0032/S01 now authorize a real bounded
 configured CSV consumer. No native acceptance is claimed before its live comparison.
+
+T-0032/S01 integrated through PR #116 (66c6125), accepting 8 SP after exact
+Demo at 59a7cca in primary and independent runs: 81 passes, eight existing
+ignores and eight matching actual Embulk projections. Security review cleared.
+Stages 2–4 now have the bounded configured transfer evidence. T-0025/S01 starts
+stage 5 on its isolated branch with std-only no-clobber publication and an
+explicit pre/post-publication failure matrix. Stages 6–7 remain open.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -37,6 +37,7 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0022 parser candidate assessment](T-0022-parser-candidates.md) | Proposed refinement; no dependency admission |
 | [T-0022/S01 parser experiment](T-0022-parser-experiment.md) | Done, PR #114; isolated experiment only |
 | [T-0014/S01 File/CSV oracle](T-0014-file-csv-oracle.md) | Done, PR #115; eight reference observations |
-| [T-0032/S01 configured CSV](T-0032-configured-csv.md) | In Progress; selected native consumer, acceptance pending |
+| [T-0032/S01 configured CSV](T-0032-configured-csv.md) | Done through PR #116; eight selected comparisons and 81 tests |
+| [T-0025/S01 safe publication](T-0025-safe-publication.md) | In Progress; native single-output publication, acceptance pending |
 | [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | Done, PR #110; native-only record consumer |
 | [T-0031/S02 experimental stdout/null](T-0031-output-targets.md) | Done, PR #112; unchanged core transfer |

--- a/docs/provenance/T-0025-safe-publication.md
+++ b/docs/provenance/T-0025-safe-publication.md
@@ -1,0 +1,86 @@
+# T-0025/S01 safe single-file publication
+
+Issue: [#22](https://github.com/bhind/emburk/issues/22). State: In Progress.
+Forecast: 5 SP. Stage 5 of the authorized execution sequence.
+
+## Authority
+
+The owner authorized stages 1–7, routine commits, pushes and merges absent
+incidents. PM owns this packet and acceptance. No new dependency is admitted.
+
+## Dependencies
+
+T-0032/S01 integrated through PR #116 (66c6125), with 81 passing tests and
+eight selected independent Embulk comparisons at 59a7cca. This slice handles
+one local output only; the complete T-0013/T-0024 contracts are not prerequisites
+for this limited publication primitive and remain open.
+
+## Branch and allowlist
+
+Branch feat/t-0025-safe-publication. Rust Core Implementer owns only
+crates/emburk-core/src/publication.rs, crates/emburk-core/src/lib.rs,
+crates/emburk-core/src/configured_csv.rs and
+crates/emburk-cli/tests/configured_csv.rs. One mutation owner, read-only reviewers.
+PM owns this packet, ADR-0018, STATUS/TODO/ROADMAP/COMPATIBILITY/ARCHITECTURE,
+IMPLEMENTATION_SEQUENCE, provenance index, T-0032 closeout, ADR-0017 status,
+and the daily log. No dependency, old line consumer, or oracle changes.
+
+The initial implementer returned an incomplete scaffold and stopped mutation.
+PM then took serial ownership of the same source allowlist, replacing the
+scaffold with a closure-owned writer, actual typed failure states and operation
+fault tests. The implementer subsequently reviews read-only.
+
+## Artifacts and acceptance
+
+Original std-only Rust, Unix local same-filesystem sibling temporary output.
+Exclusive 0600 temporary creation; stream, flush, file sync, hard-link to the
+final path without replacement, parent sync, remove only the owned temporary
+name, parent sync again. Do not precheck then replace a destination. Existing
+files and symlinks must remain unchanged. Unsupported platforms/filesystems
+return an explicit error; there is no fallback to overwriting rename.
+
+Model NotPublished, PublishedDurabilityUnknown, and Published outcomes with
+phase and temporary cleanup disposition. Before link success, failures cannot
+create the final target and cleanup may remove only the owned temporary file.
+After link success, never delete the target. First directory sync failure
+reports uncertain durability; later unlink or directory sync failure reports
+published output with incomplete cleanup. Errors include retained paths.
+
+Wire configured CSV through this primitive. Transfer/header/read/write/flush
+failures do not publish partial final output. Existing eight successful byte
+projections and older CLI commands remain unchanged. Temporary crash residue is
+not claimed recoverable in this slice. A later slice owns cancellation/resume.
+
+Tests inject create/write/flush/file-sync/link/first-directory-sync/unlink/
+second-directory-sync failures through a private original test seam. Cover
+actual existing regular/symlink targets, successful mode 0600/no residue,
+invalid CSV/read failure unpublished, every post-link error preserving target,
+and cleanup failure retaining an explicit owned path. No environment-driven
+production fault switches. Trusted filesystem and same-UID process boundary;
+hostile directory substitution and power-loss simulation are non-claims.
+
+## Demo Command
+
+The CLI interruption regression observes an actual owned temporary during a
+large transfer, kills and reaps the child, and verifies no partial final output.
+Abrupt termination may leave that private temporary; no resume claim follows.
+
+`cargo fmt --all -- --check && cargo clippy --locked --workspace --all-targets -- -D warnings && cargo test --locked --workspace && bash tests/t0032_configured_csv_differential_test.sh && git diff --check`
+
+Set EMBURK_REFERENCE_JAR and JAVA_HOME as in T-0032/S01. Retain exact-head
+primary/independent logs, exit values and hashes before integration.
+
+## Evidence class
+
+Unit/Contract and local Integration; selected CSV Differential regression only.
+Publication policy is a native safety contract, not measured Embulk parity.
+
+## Stop rule and non-claims
+
+Stop on overwritten/unowned deletion, unexplained differential mismatch, new
+dependencies, source/IP uncertainty or unsafe cleanup. No full distributed
+transaction, replacement semantics, hardware durability, cancellation, resume,
+multi-output atomicity, hostile same-UID defense, or patent/FTO clearance claim.
+
+No external implementation was consulted or copied for this original state
+machine; existing provenance remains applicable to CSV reference behavior.

--- a/docs/provenance/T-0032-configured-csv.md
+++ b/docs/provenance/T-0032-configured-csv.md
@@ -1,6 +1,6 @@
 # T-0032/S01 configured native File/CSV consumer
 
-Issue: [#25](https://github.com/bhind/emburk/issues/25). State: In Progress.
+Issue: [#25](https://github.com/bhind/emburk/issues/25). State: Done through PR #116.
 Forecast: 8 SP. This slice advances stages 2–4, not the complete CSV parent.
 
 ## Authority
@@ -78,7 +78,29 @@ uses the actual built CLI and compares all eight cases. Retain raw results.
 
 ## Evidence class
 
-Selected Differential (Embulk) plus Unit/Contract. Acceptance/integration pending.
+Selected Differential (Embulk) plus Unit/Contract. Accepted 8 SP, integrated
+as 66c6125e5783dd43bb5b3f7ab91c38bd5facc44c. Parent remains open in Backlog.
+
+## Acceptance evidence
+
+Exact Demo passed in primary and independent runs at
+59a7cca60101efc17139bc838fe01e3cd070bb56, Rust/Cargo 1.98.1, macOS arm64,
+Java 17: 81 tests passed, eight pre-existing intentional ignores; all eight
+selected real reference/native exit, output inventory and byte comparisons
+matched. Fmt, strict locked Clippy and diff-check passed. Security review
+cleared after explicit non-optimizable driver guards; forced exit mismatch
+under PYTHONOPTIMIZE returned 1 and retained an incomplete manifest.
+
+Primary logs: /private/tmp/t0032-s01-primary.UdwrJB; stdout SHA256
+9447552b88e3df3c7a91daab93d95713e7be51f2e9622fdb850d1638df81ef97,
+stderr 4f7d9ee97817cb647d748c1f10363d9d710f45482ef7d6c8c9d868e2226f4f7c.
+Independent: /private/tmp/t0032-s01-final-independent.RSbCch; stdout SHA256
+c954bb1564566dc036df5a22baa909adb94b5fcf48df4f422f9db296d5b2809d,
+stderr f44c40b8aaecc876b84078b9fc38249b6efe5d8fc48f51dcd2d3da74359c51fb.
+Both exit 0; exit-file SHA256
+9a271f2a916b0b6ee6cecb2426f0b3206ef074578be55d9bc94f6f3fe3ab86aa.
+Independent manifest /private/tmp/emburk-t0032-differential-ikjarkh4/manifest.json
+SHA256 ffca7589f93691e410c858f6cdda6399b13a8652a80ac03f715bbe393a4f7c14.
 
 ## Stop rule
 


### PR DESCRIPTION
T-0025/S01 for #22 (5 SP slice; parent remains open). Implements stage 5: owned sibling temporary output, explicit write/flush/sync/link/cleanup phases, no-replacement publication and distinct visibility/durability/cleanup states. Configured CSV uses the primitive; old line commands are unchanged.

Exact Demo passed in primary and independent runs at 725dd7e9ff25f2abf0e055dae08cfc789fa00d6c: 87 tests pass, eight existing intentional ignores; all eight CSV comparisons match. Includes real CLI interruption and private operation-failure matrix. Primary stdout SHA256 6cd62b5d1f648c98860e4b90a22ee79ac2f5035915a66c102b38c38ce8d81ecc; independent combined log c5ed2e4f0e6e6d5d3552530b9419f4aebf973b7401180e8b2b1fd73add478bda. Read-only safety review found no concrete defect.

Native local Unix safety contract only: no Embulk transaction parity, general hardware durability, multi-output commit or resume claim. No new dependencies or upstream implementation copying. Packet: docs/provenance/T-0025-safe-publication.md, ADR-0018. Also records integrated #116 acceptance.