### PR TITLE
test(t-0014): observe bundled formats and ordered filters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,9 +37,10 @@ eight single-task reference projections matched. T-0032/S01 is Done through
 PR #116 (66c6125), accepting 8 SP after primary and independent exact Demo at
 59a7cca: 81 passes, eight existing ignores and eight selected comparisons.
 Parent #25 remains open in Backlog, Initial/Current 8 unchanged; broader CSV
-scope is not accepted. T-0025/S01 is In Progress (forecast 5 SP) for safe
-single-output publication under ADR-0018; parent Initial/Current 8 unchanged.
-T-0014/S02 is In Progress in the second independent lane (forecast 3 SP) for
+scope is not accepted. T-0025/S01 is Done through PR #117 (aac0003), accepting
+5 SP after primary and independent Demo at 725dd7e: 87 passes, eight existing
+ignores and eight CSV comparisons. Parent #22 remains open in Backlog;
+Initial/Current 8 unchanged. T-0014/S02 is In Progress (forecast 3 SP) for
 five bundled format/filter observations. Its packet is on the dedicated
 research/t-0014-formats-oracle branch; parent Initial/Current 8 unchanged.
 
@@ -88,7 +89,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0022 | Implement configuration loading and the MVP CLI (S01 Done) | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 21 | T-0012, T-0021 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
-| T-0025 | Implement atomic transaction and resume state (publication S01 active) | In Progress | P1 | 8 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
+| T-0025 | Implement atomic transaction and resume state (publication S01 Done) | Backlog | P1 | 8 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
 | T-0026 | Implement structured errors and observability | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |
 
 ## T-0030 — Native File-to-File ETL

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -255,7 +255,7 @@ must be established per combination before labeling its delivery semantics.
 ADR-0018 defines a private same-directory publication primitive for configured
 output: owned temporary file, file sync, no-clobber hard link, directory sync,
 owned-temp cleanup and cleanup sync. Visibility, durability and cleanup states
-are separate. T-0025/S01 implementation/acceptance is in progress; no generic
+are separate. T-0025/S01 integrated through PR #117; no generic
 transaction or resume contract is implied.
 
 The Rust core, native built-ins, external native processes, JVM host, JRuby host, and user plugins are distinct trust boundaries. Protocol input, resume state, plugin output, and artifact metadata must be validated at each boundary.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -13,8 +13,9 @@ T-0032/S01 integrated through PR #116: eight explicitly configured single-file
 long/string CSV projections match real Embulk outputs and exits in primary and
 independent runs. This is a private native consumer, not a verified generic
 plugin. General CSV and configuration behavior outside that selected matrix
-remains unfinished, not an accepted exception. T-0025/S01 now develops native
-no-clobber publication safety; its failure policy is not observed Embulk parity.
+remains unfinished, not an accepted exception. T-0025/S01 integrated native
+no-clobber publication safety through PR #117; its failure policy is not
+observed Embulk parity. T-0014/S02 is reference-only format/filter preparation.
 
 The implementation objective is strict reproduction of observable behavior for
 the pinned core and admitted plugins. Technical constraints, disproportionate

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,9 @@ experiment integrated through PR #114. T-0014/S01's eight bundled File/CSV
 observations integrated through PR #115. T-0032/S01 integrated through PR #116
 after primary and independent eight-case comparison and 81 passing tests.
 This satisfies the bounded stages 2–4 consumer, not full configuration/plugin
-gates. Stage 5 is active as T-0025/S01 under ADR-0018; stages 6–7 remain open.
+gates. Stage 5 integrated as T-0025/S01 through PR #117 after fault/interruption
+acceptance. Stage 6 reference-only preparation is T-0014/S02; native formats
+and stage 7 remain open.
 
 ## Phase 0: Governance and Compatibility Contract
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -45,10 +45,13 @@ Parser-selection research now has a [candidate assessment](provenance/T-0022-par
 T-0022/S01 is Done through PR #114 after primary and independent acceptance
 of six experiment tests, 71 workspace tests and actual-binary checks.
 T-0014/S01 is Done through PR #115 after eleven harness tests, 71 workspace
-tests and matching independent eight-case reference projections. The active
+tests and matching independent eight-case reference projections. The
 T-0032/S01 consumer is Done through PR #116 (66c6125), after 81 passing tests,
 eight existing ignores and eight independently matching selected real file
-projections at 59a7cca. T-0025/S01 now implements safe single-output publication.
+projections at 59a7cca. T-0025/S01 is Done through PR #117 (aac0003): 87 passes,
+eight existing ignores, actual interruption and operation-failure tests, and
+unchanged eight-case CSV comparison. T-0014/S02 now captures selected stage-6
+format/filter observations; native formats and stage 7 remain unfinished.
 The owner-authorized
 [seven-stage sequence](IMPLEMENTATION_SEQUENCE.md) remains uncompleted work.
 
@@ -77,7 +80,7 @@ strict controls and unchanged S12 regression. T-0031/S01 is Done through PR #110
 (`c5fb13f`) for the explicitly requested experimental native File-to-File path.
 T-0031/S02 is Done through PR #112 (`2ec236e`) for experimental stdout/null
 consumers: 71 tests passed, eight existing intentional ignores, primary and
-independent acceptance at `c5df504`. T-0025/S01 now occupies one WIP lane; the full
+independent acceptance at `c5df504`. T-0014/S02 now occupies one WIP lane; the full
 file/plugin parent stays open. Core transfer semantics remain unchanged.
 
 | Item | State | Purpose |
@@ -94,8 +97,8 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 
-T-0025/S01 is In Progress for safe single-output publication. T-0014/S02 uses
-the second independent lane for bundled format/filter reference observations
+T-0025/S01 is Done through PR #117. T-0014/S02 uses
+one lane for bundled format/filter reference observations
 on research/t-0014-formats-oracle; its packet and evidence are disjoint.
 Other unfinished stable tasks remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)

--- a/docs/decisions/ADR-0018-single-output-publication.md
+++ b/docs/decisions/ADR-0018-single-output-publication.md
@@ -1,6 +1,6 @@
 # ADR-0018: No-clobber single-output publication
 
-- Status: Accepted for T-0025/S01 implementation; acceptance pending
+- Status: Accepted; T-0025/S01 integrated through PR #117
 - Date: 2026-09-06
 
 ## Decision

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -474,3 +474,9 @@ ignores and eight matching actual Embulk projections. Security review cleared.
 Stages 2–4 now have the bounded configured transfer evidence. T-0025/S01 starts
 stage 5 on its isolated branch with std-only no-clobber publication and an
 explicit pre/post-publication failure matrix. Stages 6–7 remain open.
+
+T-0025/S01 integrated through PR #117 (aac0003), accepting 5 SP after exact
+primary and independent Demo at 725dd7e: 87 passes, eight existing ignores,
+eight CSV matches and actual interruption coverage. T-0014/S02 independently
+prepares stage-6 reference observations; initial incorrect rename fixtures
+were rejected and corrected before acceptance. Native stages 6–7 remain open.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -38,6 +38,7 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0022/S01 parser experiment](T-0022-parser-experiment.md) | Done, PR #114; isolated experiment only |
 | [T-0014/S01 File/CSV oracle](T-0014-file-csv-oracle.md) | Done, PR #115; eight reference observations |
 | [T-0032/S01 configured CSV](T-0032-configured-csv.md) | Done through PR #116; eight selected comparisons and 81 tests |
-| [T-0025/S01 safe publication](T-0025-safe-publication.md) | In Progress; native single-output publication, acceptance pending |
+| [T-0025/S01 safe publication](T-0025-safe-publication.md) | Done through PR #117; fault/interruption acceptance |
+| [T-0014/S02 format/filter observations](T-0014-formats-oracle.md) | In Progress; reference-only stage-6 preparation |
 | [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | Done, PR #110; native-only record consumer |
 | [T-0031/S02 experimental stdout/null](T-0031-output-targets.md) | Done, PR #112; unchanged core transfer |

--- a/docs/provenance/T-0014-formats-oracle.md
+++ b/docs/provenance/T-0014-formats-oracle.md
@@ -1,0 +1,99 @@
+# T-0014/S02 bundled format and filter observations
+
+Issue: [#17](https://github.com/bhind/emburk/issues/17). State: In Progress.
+Forecast: 3 SP. Reference-only preparation for stage 6.
+
+## Authority and dependencies
+
+Owner authorized stages 1–7 and independent parallel work. PM owns acceptance.
+T-0014/S01 (#115) and T-0032/S01 (#116) are integrated. This slice is independent
+of active T-0025/S01: no shared implementation, tests, evidence or rollback.
+
+## Branch and allowlist
+
+Branch research/t-0014-formats-oracle. Compatibility Host Implementer owns only
+tools/formats-oracle/run.py and tests/test_formats_oracle.py. PM owns this packet.
+Other canonical closeout records reconcile serially after the publication PR.
+No mutations to the prior oracle, Cargo dependencies, runtime or other records.
+
+After PR #117 integrated, PM fast-forwarded this branch and serially owns its
+publication closeout in STATUS/TODO/ROADMAP/COMPATIBILITY/ARCHITECTURE,
+ADR-0018, provenance index/T-0025 packet, implementation sequence and daily log.
+No implementer edits those records. Final source acceptance remains pending.
+
+## Rejected fixture attempts
+
+The initial implementation used an undocumented `rename` key rather than the
+packet's documented `columns` mapping, producing misleading filter outcomes.
+PM rejected those inputs. Raw evidence /private/tmp/emburk-t0014-s02-run-e5e3fbra
+is retained as an invalid fixture attempt, not compatibility evidence. Corrected
+fixtures use identical `columns: {name: renamed}` and `remove: [renamed]` options
+with order alone changed. The preliminary corrected run
+/private/tmp/emburk-t0014-s02-run-cktdrnj4 observes rename-then-remove success
+and the reverse order failing for a missing renamed column. Final validators
+also reject altered exact fixture bytes, unsafe paths, timeout and UUID mixing.
+
+## Artifacts and provenance
+
+Use the same verified outer Embulk 0.11.5 JAR and Java 17 controls as
+T-0014-file-csv-oracle.md. Outer SHA256:
+e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47.
+Official artifact URL:
+https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar.
+Bundled runtime-only module inventory, read 2026-09-06:
+
+| Embedded module | SHA256 |
+| --- | --- |
+| embulk-parser-json-0.11.2.jar | ac8c240f1a49af2cdba7384c7bac2da1c25b9ed903234df1aa0e61eecaca7048 |
+| embulk-decoder-gzip-0.11.1.jar | 438de3a5f3f8b76d087b442633f67b2882f2ae6e847e5a220875f1d2791762c0 |
+| embulk-decoder-bzip2-0.11.1.jar | 77c9ec4926317ea6ada8b486ecc7e3e4348ac84e12c7e44fcac441dc5e3d0df5 |
+| embulk-encoder-gzip-0.11.1.jar | 9461eaa218422f9a7d10f9da437e708b0abbf6732688ae9e62c7c2ea5225c772 |
+| embulk-encoder-bzip2-0.11.1.jar | 075edbc111decd8329da61418b8ad9ac1d244e856fc2fca503da0935b0b26ee5 |
+| embulk-filter-rename-0.11.1.jar | bd964c44ac70071d11aced194a1a865d2b2b99baa64302787bc4494994c6f780 |
+| embulk-filter-remove_columns-0.11.1.jar | e8880fbf6d5e3970aae4a86742796a79a4c5ade2507e8bffd3a0ff86e782d0b2 |
+
+Each inner archive contains Apache-2.0 LICENSE and no inner NOTICE; outer
+LICENSE/NOTICE hashes remain pinned by S01. Runtime observation only, no source
+translation/reuse/redistribution; full transitive SBOM, patent/FTO, security and
+release clearance remain unreviewed. Source commits are not newly inferred.
+
+Official configuration documentation, accessed 2026-09-06:
+https://www.embulk.org/docs/built-in.html, headings JSON parser, gzip/bzip2
+decoder/encoder, Rename and Remove columns. JSON explicit long/string columns
+extract same-name properties. Codec chains appear under decoders/encoders;
+observe gzip level 6 and bzip2 level 9. Rename columns mapping and remove list
+are selected; generic rename rules, keep and unmatched acceptance stay outside
+scope. This paragraph describes documentation, not observed runtime behavior.
+
+## Acceptance
+
+Capture five cases: json-scalars (several objects with long/string/null/empty
+and Unicode values); gzip-csv; bzip2-csv; rename-then-remove; remove-before-rename.
+Use relative input/output paths and explicit max_threads=1/min_output_tasks=1,
+the previously pinned explicit CSV formatter profile, fresh private dirs and
+verified read-only JAR snapshot. No download or external plugin installation.
+Record real exits, timeouts, complete raw output names/bytes/hashes, input and
+config hashes, stdout/stderr, Java version, UUID, reference artifact. Preserve
+failed observations; never convert a timeout into a behavioral result.
+
+For codec cases also retain exact decompressed output and its metadata. Codec
+bitstreams are not assumed equal. Validate manifests against retained files,
+exhaustive output inventories and expected fixture bytes. Include negative
+controls for modified config/input/output/exit/decoded data, missing/extra
+case evidence, timeout, artifact mismatch and path escape. No optimized-away
+Python assert acceptance guards. Use existing S01 helpers read-only when useful.
+Primary and independent runs must match selected semantic projections (exits,
+names, decoded/plain content); raw compressed bytes may differ and stay retained.
+
+## Demo Command
+
+`python3 -I -B -m unittest discover -s tests -p test_formats_oracle.py && python3 -I -B tools/formats-oracle/run.py && git diff --check`
+
+Set EMBURK_REFERENCE_JAR and JAVA_HOME to the pinned local artifact and Java17.
+
+## Evidence class, stop rule and non-claims
+
+Reference-only observation plus Unit/Contract harness controls. Stop on artifact
+mismatch, unsafe filesystem writes, unexplained timeout or source/IP issue.
+No native implementation acceptance, full JSON/codecs/filter parity, compressed
+bitstream identity, external JSON formatter, concurrency or resume claim.

--- a/docs/provenance/T-0025-safe-publication.md
+++ b/docs/provenance/T-0025-safe-publication.md
@@ -1,6 +1,6 @@
 # T-0025/S01 safe single-file publication
 
-Issue: [#22](https://github.com/bhind/emburk/issues/22). State: In Progress.
+Issue: [#22](https://github.com/bhind/emburk/issues/22). State: Done through PR #117.
 Forecast: 5 SP. Stage 5 of the authorized execution sequence.
 
 ## Authority
@@ -74,6 +74,25 @@ primary/independent logs, exit values and hashes before integration.
 
 Unit/Contract and local Integration; selected CSV Differential regression only.
 Publication policy is a native safety contract, not measured Embulk parity.
+
+## Acceptance evidence
+
+Accepted 5 SP; integrated aac00039d9d60c218750125d274400be4b8e135e.
+Exact Demo passed in primary and independent runs at
+725dd7e9ff25f2abf0e055dae08cfc789fa00d6c: 87 tests (72 core, 5 configured CLI,
+10 old CLI) passed, eight existing intentional ignores; eight selected CSV
+comparisons matched. Actual kill regression and five publication fault tests
+passed. Fmt, strict locked Clippy and diff-check passed; no concrete defect
+found by read-only peer review. macOS arm64, Rust/Cargo 1.98.1, Java17.
+
+Primary /private/tmp/t0025-s01-primary.t2cXuE: stdout SHA256
+6cd62b5d1f648c98860e4b90a22ee79ac2f5035915a66c102b38c38ce8d81ecc;
+stderr 52bf09dc42db1ccdf0b71e7e4af82af86354684e493786791b4161461f9931fd.
+Independent /private/tmp/emburk-t0025-acceptance.6RzodA/demo.log SHA256
+c5ed2e4f0e6e6d5d3552530b9419f4aebf973b7401180e8b2b1fd73add478bda.
+Both numeric exit 0, exit-file SHA256
+9a271f2a916b0b6ee6cecb2426f0b3206ef074578be55d9bc94f6f3fe3ab86aa.
+Parent #22 remains open in Backlog for resume and broader transaction scope.
 
 ## Stop rule and non-claims
 

--- a/tests/test_formats_oracle.py
+++ b/tests/test_formats_oracle.py
@@ -1,0 +1,76 @@
+import gzip, importlib.util, json, tempfile, unittest
+from pathlib import Path
+from unittest import mock
+ROOT=Path(__file__).resolve().parents[1]; spec=importlib.util.spec_from_file_location("oracle",ROOT/"tools/formats-oracle/run.py"); oracle=importlib.util.module_from_spec(spec); spec.loader.exec_module(oracle)
+class FormatsOracleTests(unittest.TestCase):
+ def valid(self,d,case="json-scalars"):
+  root=Path(d); (root/"output").mkdir(); data,name=oracle.fixture(case); (root/name).write_bytes(data); (root/"config.yml").write_bytes(oracle.config(case)); (root/"java-version.txt").write_bytes(b"17\n"); (root/"stdout.log").write_bytes(b""); (root/"stderr.log").write_bytes(b""); (root/"exit.txt").write_text("0\n")
+  val={"case":case,"uuid":"00000000-0000-4000-8000-000000000000","artifact":{"sha256":oracle.JAR_SHA},"java":oracle.detail(root/"java-version.txt",root),"input":oracle.detail(root/name,root),"config":oracle.detail(root/"config.yml",root),"process":{"exit":0,"timed_out":False,"stdout":oracle.detail(root/"stdout.log",root),"stderr":oracle.detail(root/"stderr.log",root)},"outputs":[],"decoded":[]}; p=root/"manifest.json"; p.write_text(json.dumps(val,sort_keys=True)+"\n"); return p,val
+ def test_fixture_profiles_are_explicit(self):
+  self.assertEqual(set(oracle.CASES),{"json-scalars","gzip-csv","bzip2-csv","rename-then-remove","remove-before-rename"}); self.assertIn(b"max_threads: 1",oracle.config("gzip-csv")); self.assertIn(b"type: json",oracle.config("json-scalars")); self.assertIn(b"columns: {name: renamed}",oracle.config("rename-then-remove")); self.assertIn(b"remove: [renamed]",oracle.config("remove-before-rename")); self.assertEqual(oracle.fixture("gzip-csv"),oracle.fixture("gzip-csv"))
+ def test_wrong_artifact(self):
+  with tempfile.TemporaryDirectory() as d:
+   p=Path(d)/"bad"; p.write_bytes(b"bad")
+   with self.assertRaises(ValueError): oracle.pinned_bytes({"EMBURK_REFERENCE_JAR":str(p)})
+ def test_manifest_raw_controls(self):
+  with tempfile.TemporaryDirectory() as d:
+   p,v=self.valid(d); oracle.validate(p); (Path(d)/"config.yml").write_bytes(b"changed")
+   with self.assertRaises(ValueError): oracle.validate(p)
+  with tempfile.TemporaryDirectory() as d:
+   p,v=self.valid(d); name=oracle.fixture("json-scalars")[1]; (Path(d)/name).write_bytes(b"changed")
+   with self.assertRaises(ValueError): oracle.validate(p)
+  with tempfile.TemporaryDirectory() as d:
+   p,v=self.valid(d); v["process"]["exit"]=1; p.write_text(json.dumps(v))
+   with self.assertRaises(ValueError): oracle.validate(p)
+ def test_extra_missing_and_path_controls(self):
+  with tempfile.TemporaryDirectory() as d:
+   p,v=self.valid(d); (Path(d)/"output"/"extra.csv").write_bytes(b"x")
+   with self.assertRaises(ValueError): oracle.validate(p)
+  with tempfile.TemporaryDirectory() as d:
+   p,v=self.valid(d); v["config"]["name"]="../escape"; p.write_text(json.dumps(v))
+   with self.assertRaises(ValueError): oracle.validate(p)
+ def test_timeout_is_retained_not_success(self):
+  with tempfile.TemporaryDirectory() as d:
+   p,v=self.valid(d); v["process"]["timed_out"]=True; p.write_text(json.dumps(v)); self.assertTrue(oracle.validate(p)["process"]["timed_out"])
+ def test_codec_decoded_control(self):
+  with tempfile.TemporaryDirectory() as d:
+   root=Path(d); (root/"output").mkdir(); raw=gzip.compress(b"id,name\n"); (root/"output"/"result.csv").write_bytes(raw); (root/"decoded").mkdir(); (root/"decoded"/"result.csv.decoded").write_bytes(b"id,name\n")
+   data,name=oracle.fixture("gzip-csv"); (root/name).write_bytes(data); (root/"config.yml").write_bytes(oracle.config("gzip-csv")); (root/"java-version.txt").write_bytes(b"17"); (root/"stdout.log").write_bytes(b""); (root/"stderr.log").write_bytes(b""); (root/"exit.txt").write_text("0\n")
+   v={"case":"gzip-csv","uuid":"00000000-0000-4000-8000-000000000000","artifact":{"sha256":oracle.JAR_SHA},"java":oracle.detail(root/"java-version.txt",root),"input":oracle.detail(root/name,root),"config":oracle.detail(root/"config.yml",root),"process":{"exit":0,"timed_out":False,"stdout":oracle.detail(root/"stdout.log",root),"stderr":oracle.detail(root/"stderr.log",root)},"outputs":oracle.inventory(root/"output"),"decoded":[oracle.detail(root/"decoded"/"result.csv.decoded",root)]}; p=root/"manifest.json"; p.write_text(json.dumps(v)); oracle.validate(p); (root/"decoded"/"result.csv.decoded").write_bytes(b"changed")
+   with self.assertRaises(ValueError): oracle.validate(p)
+ def test_exact_fixture_byte_controls(self):
+  with tempfile.TemporaryDirectory() as d:
+   p,v=self.valid(d); changed=oracle.config("json-scalars")+b"# changed\n"; (Path(d)/"config.yml").write_bytes(changed); v["config"]["size"]=len(changed); v["config"]["sha256"]=oracle.digest(changed); p.write_text(json.dumps(v))
+   with self.assertRaises(ValueError): oracle.validate(p)
+  with tempfile.TemporaryDirectory() as d:
+   p,v=self.valid(d); name=oracle.fixture("json-scalars")[1]; changed=b"changed"; (Path(d)/name).write_bytes(changed); v["input"]["size"]=len(changed); v["input"]["sha256"]=oracle.digest(changed); p.write_text(json.dumps(v))
+   with self.assertRaises(ValueError): oracle.validate(p)
+ def test_output_symlink_and_decoded_extra_controls(self):
+  with tempfile.TemporaryDirectory() as d:
+   p,v=self.valid(d); (Path(d)/"output"/"link").symlink_to(Path(d)/"output")
+   with self.assertRaises(ValueError): oracle.validate(p)
+  with tempfile.TemporaryDirectory() as d:
+   root=Path(d); (root/"output").mkdir(); raw=gzip.compress(b"id,name\n"); (root/"output"/"result.csv").write_bytes(raw); (root/"decoded").mkdir(); (root/"decoded"/"result.csv.decoded").write_bytes(b"id,name\n")
+   data,name=oracle.fixture("gzip-csv"); (root/name).write_bytes(data); (root/"config.yml").write_bytes(oracle.config("gzip-csv")); (root/"java-version.txt").write_bytes(b"17"); (root/"stdout.log").write_bytes(b""); (root/"stderr.log").write_bytes(b""); (root/"exit.txt").write_text("0\n")
+   v={"case":"gzip-csv","uuid":"00000000-0000-4000-8000-000000000000","artifact":{"sha256":oracle.JAR_SHA},"java":oracle.detail(root/"java-version.txt",root),"input":oracle.detail(root/name,root),"config":oracle.detail(root/"config.yml",root),"process":{"exit":0,"timed_out":False,"stdout":oracle.detail(root/"stdout.log",root),"stderr":oracle.detail(root/"stderr.log",root)},"outputs":oracle.inventory(root/"output"),"decoded":[oracle.detail(root/"decoded"/"result.csv.decoded",root)]}; p=root/"manifest.json"; p.write_text(json.dumps(v)); oracle.validate(p); (root/"decoded"/"extra").write_bytes(b"x")
+   with self.assertRaises(ValueError): oracle.validate(p)
+ def test_summary_missing_extra_duplicate_uuid_and_timeout_controls(self):
+  with tempfile.TemporaryDirectory(dir="/private/tmp") as d:
+   root=Path(d); run_uuid="00000000-0000-4000-8000-000000000000"; entries=[]
+   for case in oracle.CASES:
+    item=root/case; item.mkdir(); manifest=item/"manifest.json"; manifest.write_bytes(case.encode()); entries.append({"case":case,"path":str(item),"manifest_sha256":oracle.digest(manifest.read_bytes())})
+   summary=root/"summary.json"
+   def observed(manifest): return {"case":manifest.parent.name,"uuid":run_uuid,"process":{"timed_out":False}}
+   with mock.patch.object(oracle,"validate",side_effect=observed):
+    summary.write_text(json.dumps({"uuid":run_uuid,"artifact_sha256":oracle.JAR_SHA,"cases":entries})); oracle.validate_summary(summary)
+    for changed in (entries[:-1], entries+[entries[0]]):
+     summary.write_text(json.dumps({"uuid":run_uuid,"artifact_sha256":oracle.JAR_SHA,"cases":changed}))
+     with self.assertRaises(ValueError): oracle.validate_summary(summary)
+    def wrong_uuid(manifest): return {"case":manifest.parent.name,"uuid":"00000000-0000-4000-8000-000000000001","process":{"timed_out":False}}
+    with mock.patch.object(oracle,"validate",side_effect=wrong_uuid):
+     summary.write_text(json.dumps({"uuid":run_uuid,"artifact_sha256":oracle.JAR_SHA,"cases":entries}))
+     with self.assertRaises(ValueError): oracle.validate_summary(summary)
+    def timed(manifest): return {"case":manifest.parent.name,"uuid":run_uuid,"process":{"timed_out":True}}
+    with mock.patch.object(oracle,"validate",side_effect=timed):
+     with self.assertRaises(ValueError): oracle.validate_summary(summary)
+if __name__=="__main__": unittest.main()

--- a/tools/formats-oracle/run.py
+++ b/tools/formats-oracle/run.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Original, retained observations of selected bundled Embulk formats and filters."""
+import bz2, gzip, hashlib, json, os, signal, subprocess, sys, tempfile, uuid
+from pathlib import Path
+
+JAR_SHA = "e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47"
+CASES = ("json-scalars", "gzip-csv", "bzip2-csv", "rename-then-remove", "remove-before-rename")
+TIMEOUT = 60
+
+def digest(data): return hashlib.sha256(data).hexdigest()
+def detail(path, root):
+    path, root = path.resolve(), root.resolve()
+    if root not in path.parents: raise ValueError("path escape")
+    data = path.read_bytes()
+    return {"name": str(path.relative_to(root)), "size": len(data), "sha256": digest(data)}
+def write_json(path, value): path.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+def pinned_bytes(env):
+    value = env.get("EMBURK_REFERENCE_JAR")
+    if not value or Path(value).is_symlink() or not Path(value).is_file(): raise ValueError("reference artifact")
+    data = Path(value).read_bytes()
+    if digest(data) != JAR_SHA: raise ValueError("reference checksum")
+    return data
+def snapshot(data, root):
+    path=root/"embulk.jar"
+    with path.open("xb") as stream: stream.write(data)
+    path.chmod(0o400)
+    if digest(path.read_bytes()) != JAR_SHA: raise ValueError("snapshot checksum")
+    return path
+def java(env):
+    home=env.get("JAVA_HOME"); binary=Path(home or "")/"bin"/"java"
+    if not binary.is_file(): raise ValueError("JAVA_HOME")
+    result=subprocess.run([str(binary),"-version"],stdout=subprocess.PIPE,stderr=subprocess.PIPE,env={"PATH":os.defpath,"JAVA_HOME":str(Path(home).resolve())},timeout=10)
+    raw=result.stdout+result.stderr
+    if result.returncode or b'version "17.' not in raw: raise ValueError("Java 17")
+    return binary.resolve(),raw
+def child_env(root, java_home):
+    home=root/"home"; tmp=root/"tmp"; home.mkdir(); tmp.mkdir()
+    return {"PATH":os.defpath,"JAVA_HOME":java_home,"EMBULK_HOME":str(home),"HOME":str(home),"TMPDIR":str(tmp)}
+def csv_parser(): return b"    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    skip_header_lines: 1\n    columns:\n    - {name: id, type: long}\n    - {name: name, type: string}\n"
+def formatter(): return b"    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    header_line: true\n    quote_policy: MINIMAL\n"
+def fixture(case):
+    plain="id,name\n1,alpha\n2,\"comma, \u2603\"\n".encode("utf-8")
+    if case=="json-scalars": return b'{"id":1,"name":"alpha"}\n{"id":2,"name":null}\n{"id":3,"name":""}\n{"id":4,"name":"\xe2\x98\x83"}\n',"input.json"
+    if case=="gzip-csv": return gzip.compress(plain,compresslevel=6,mtime=0),"input.csv.gz"
+    if case=="bzip2-csv": return bz2.compress(plain,compresslevel=9),"input.csv.bz2"
+    return plain,"input.csv"
+def config(case):
+    input_name=fixture(case)[1]
+    if case=="json-scalars": parser=b"    type: json\n    columns:\n    - {name: id, type: long}\n    - {name: name, type: string}\n"
+    else: parser=csv_parser()
+    decoder=b""
+    encoder=b""
+    if case=="gzip-csv": decoder=b"  decoders:\n  - {type: gzip}\n"; encoder=b"  encoders:\n  - {type: gzip, level: 6}\n"
+    if case=="bzip2-csv": decoder=b"  decoders:\n  - {type: bzip2}\n"; encoder=b"  encoders:\n  - {type: bzip2, level: 9}\n"
+    filters=b""
+    if case=="rename-then-remove": filters=b"filters:\n- type: rename\n  columns: {name: renamed}\n- type: remove_columns\n  remove: [renamed]\n"
+    if case=="remove-before-rename": filters=b"filters:\n- type: remove_columns\n  remove: [renamed]\n- type: rename\n  columns: {name: renamed}\n"
+    return b"in:\n  type: file\n  path_prefix: "+input_name.encode()+b"\n"+decoder+b"  parser:\n"+parser+filters+b"out:\n  type: file\n  path_prefix: output/result\n  file_ext: csv\n"+encoder+b"  formatter:\n"+formatter()+b"exec:\n  max_threads: 1\n  min_output_tasks: 1\n"
+def inventory(directory):
+    result=[]
+    for path in sorted(directory.rglob("*")):
+        if path.is_symlink(): raise ValueError("inventory symlink")
+        if path.is_file(): result.append(detail(path,directory))
+    return result
+def decode_codec(case, outputs, root):
+    decoded=[]
+    if case not in {"gzip-csv","bzip2-csv"}: return decoded
+    destination=root/"decoded"; destination.mkdir()
+    for item in outputs:
+        source=root/"output"/item["name"]
+        raw=source.read_bytes(); data=gzip.decompress(raw) if case=="gzip-csv" else bz2.decompress(raw)
+        target=destination/(Path(item["name"]).name+".decoded"); target.write_bytes(data); decoded.append(detail(target,root))
+    return decoded
+def decoded_inventory(case, outputs, root):
+    result=[]
+    for item in outputs:
+        raw=(root/"output"/item["name"]).read_bytes()
+        data=gzip.decompress(raw) if case=="gzip-csv" else bz2.decompress(raw)
+        result.append({"name":"decoded/"+Path(item["name"]).name+".decoded","size":len(data),"sha256":digest(data)})
+    return result
+def validate(path):
+    value=json.loads(path.read_text()); root=path.parent.resolve()
+    expected={"case","uuid","artifact","java","input","config","process","outputs","decoded"}
+    if set(value)!=expected or value["case"] not in CASES or value["artifact"]!={"sha256":JAR_SHA}: raise ValueError("manifest structure")
+    if str(uuid.UUID(value["uuid"]))!=value["uuid"]: raise ValueError("manifest uuid")
+    for key in ("java","input","config"):
+        item=value[key]; candidate=root/item["name"]
+        if not isinstance(item,dict) or set(item)!={"name","size","sha256"} or not candidate.is_file() or detail(candidate,root)!=item: raise ValueError("manifest raw")
+    expected_input, expected_name=fixture(value["case"])
+    if value["java"]["name"] != "java-version.txt" or value["config"]["name"] != "config.yml" or value["input"]["name"] != expected_name or (root/expected_name).read_bytes() != expected_input: raise ValueError("fixture input")
+    if (root/"config.yml").read_bytes() != config(value["case"]): raise ValueError("fixture config")
+    process=value["process"]
+    if set(process)!={"exit","timed_out","stdout","stderr"} or not isinstance(process["exit"],int) or not isinstance(process["timed_out"],bool): raise ValueError("manifest process")
+    for key in ("stdout","stderr"):
+        if process[key]["name"] != f"{key}.log" or detail(root/process[key]["name"],root)!=process[key]: raise ValueError("manifest process")
+    if (root/"exit.txt").read_text(encoding="ascii") != str(process["exit"])+"\n": raise ValueError("manifest exit")
+    if value["outputs"] != inventory(root/"output"): raise ValueError("manifest output")
+    decoded=value["decoded"]
+    if value["case"] in {"gzip-csv","bzip2-csv"}:
+        if not decoded: raise ValueError("manifest decoded")
+        for item in decoded:
+            if detail(root/item["name"],root)!=item: raise ValueError("manifest decoded")
+        if decoded_inventory(value["case"],value["outputs"],root) != decoded: raise ValueError("manifest decoded")
+        expected={root/item["name"] for item in decoded}; actual={path for path in (root/"decoded").rglob("*") if path.is_file() or path.is_symlink()}
+        if actual != expected or any(path.is_symlink() for path in actual): raise ValueError("manifest decoded")
+    elif decoded or (root/"decoded").exists(): raise ValueError("manifest decoded")
+    return value
+def validate_summary(path):
+    value=json.loads(path.read_text()); root=path.parent.resolve()
+    if set(value)!={"uuid","artifact_sha256","cases"} or str(uuid.UUID(value["uuid"]))!=value["uuid"] or value["artifact_sha256"]!=JAR_SHA or not isinstance(value["cases"],list): raise ValueError("summary structure")
+    seen=set()
+    for item in value["cases"]:
+        if set(item)!={"case","path","manifest_sha256"} or item["case"] not in CASES or item["case"] in seen: raise ValueError("summary cases")
+        case=Path(item["path"])
+        if not case.is_absolute() or case.is_symlink() or not case.is_dir() or not str(case).startswith("/private/tmp/"): raise ValueError("summary path")
+        manifest=case/"manifest.json"
+        if digest(manifest.read_bytes())!=item["manifest_sha256"]: raise ValueError("summary manifest")
+        observed=validate(manifest)
+        if observed["case"]!=item["case"] or observed["uuid"]!=value["uuid"] or observed["process"]["timed_out"]: raise ValueError("summary manifest")
+        seen.add(item["case"])
+    if seen!=set(CASES): raise ValueError("summary cases")
+    return value
+def run_case(case, jar, binary, version, run_uuid):
+    root=Path(tempfile.mkdtemp(prefix="emburk-t0014-s02-",dir="/private/tmp")); (root/"output").mkdir()
+    input_data,input_name=fixture(case); (root/input_name).write_bytes(input_data); (root/"config.yml").write_bytes(config(case)); (root/"java-version.txt").write_bytes(version)
+    env=child_env(root,str(binary.parent.parent)); cmd=[str(binary),f"-Duser.home={env['HOME']}","-jar",str(jar),f"-Xembulk_home={env['EMBULK_HOME']}","run","config.yml"]
+    stdout,stderr=root/"stdout.log",root/"stderr.log"
+    with stdout.open("xb") as out,stderr.open("xb") as err:
+        process=subprocess.Popen(cmd,cwd=root,env=env,stdout=out,stderr=err,start_new_session=True); timed=False
+        try: code=process.wait(timeout=TIMEOUT)
+        except subprocess.TimeoutExpired: timed=True; os.killpg(process.pid,signal.SIGKILL); code=process.wait()
+    (root/"exit.txt").write_text(str(code)+"\n",encoding="ascii")
+    outputs=inventory(root/"output"); decoded=decode_codec(case,outputs,root)
+    value={"case":case,"uuid":run_uuid,"artifact":{"sha256":JAR_SHA},"java":detail(root/"java-version.txt",root),"input":detail(root/input_name,root),"config":detail(root/"config.yml",root),"process":{"exit":code,"timed_out":timed,"stdout":detail(stdout,root),"stderr":detail(stderr,root)},"outputs":outputs,"decoded":decoded}
+    write_json(root/"manifest.json",value); validate(root/"manifest.json")
+    print(f"T0014_S02_CASE={case}|exit={code}|timed_out={str(timed).lower()}|evidence={root}",flush=True); return root
+def main():
+    run=Path(tempfile.mkdtemp(prefix="emburk-t0014-s02-run-",dir="/private/tmp")); jar=snapshot(pinned_bytes(dict(os.environ)),run); binary,version=java(dict(os.environ)); run_uuid=str(uuid.uuid4()); cases=[]
+    for case in CASES:
+        root=run_case(case,jar,binary,version,run_uuid); cases.append({"case":case,"path":str(root),"manifest_sha256":digest((root/"manifest.json").read_bytes())})
+    write_json(run/"manifest.json",{"uuid":run_uuid,"artifact_sha256":JAR_SHA,"cases":cases}); validate_summary(run/"manifest.json"); print(f"T0014_S02_EVIDENCE_DIR={run}"); return 0
+if __name__=="__main__":
+    try: raise SystemExit(main())
+    except (OSError,ValueError,subprocess.SubprocessError) as error: print(f"T0014_S02_CAPTURE_ERROR={error}",file=sys.stderr); raise SystemExit(2)


### PR DESCRIPTION
T-0014/S02 for #17 (3 SP slice; parent remains open). Reference-only stage-6 preparation with pinned bundled JSON, gzip/bzip2 and rename/remove modules. Exact primary and independent Demo at dad393c3aaf154b447ab38e97c18ec2ab5988a60: 9 harness tests pass; five real observations have no timeouts. JSON and both codecs succeed; rename-then-remove succeeds; reverse order exits 1. Compare codec decoded content, retaining raw compressed bytes. Corrected documented columns mapping replaces rejected initial invalid fixture attempts, recorded in packet.

Independent stdout SHA256 231c8726eb81e213307a47e0c720c8a52adc4b128c93af25a036d72e1fb8bd63. No native format implementation or general parity claim. No dependencies installed, implementation translated or artifacts redistributed. Includes serial #117 publication closeout. See docs/provenance/T-0014-formats-oracle.md.