### PR TITLE
feat(t-0033): bounded JSON codecs and ordered filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,40 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "emburk-cli"
@@ -19,7 +49,48 @@ dependencies = [
 name = "emburk-core"
 version = "0.1.0"
 dependencies = [
+ "bzip2",
+ "flate2",
  "saphyr-parser",
+ "serde_json",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -49,6 +120,54 @@ dependencies = [
  "arraydeque",
  "thiserror",
 ]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "syn"
@@ -86,3 +205,9 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/TODO.md
+++ b/TODO.md
@@ -40,9 +40,12 @@ Parent #25 remains open in Backlog, Initial/Current 8 unchanged; broader CSV
 scope is not accepted. T-0025/S01 is Done through PR #117 (aac0003), accepting
 5 SP after primary and independent Demo at 725dd7e: 87 passes, eight existing
 ignores and eight CSV comparisons. Parent #22 remains open in Backlog;
-Initial/Current 8 unchanged. T-0014/S02 is In Progress (forecast 3 SP) for
-five bundled format/filter observations. Its packet is on the dedicated
-research/t-0014-formats-oracle branch; parent Initial/Current 8 unchanged.
+Initial/Current 8 unchanged. T-0014/S02 is Done through PR #118 (ecf9cc4),
+accepting 3 SP after independent five-case agreement and nine tests at dad393c3.
+Parent #17 remains Backlog, S01/S02 total 8 SP, Initial/Current 8 unchanged.
+T-0033/S01 is In Progress, forecast 8 SP for bounded JSON/codecs/filters.
+Parent #26 Current changes 5 to 8 for this broader configured consumer;
+Initial 5 remains unchanged. Full T-0033/T-0034/T-0035 parents remain unaccepted.
 
 T-0031/S01 is Done through PR #110 (`c5fb13f`), accepting 5 SP, for a native UTF-8 line-record
 File-to-File command under ADR-0015. It consumes T-0021/S06 without claiming
@@ -78,7 +81,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S13 Done; remaining contracts queued) | Backlog | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
-| T-0014 | Scaffold the differential harness (S01 Done, S02 active) | In Progress | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0014 | Scaffold the differential harness (S01/S02 Done) | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
 
@@ -99,7 +102,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0030 | Epic: Native File-to-File ETL | Backlog | P1 | — | T-0020 | Project Manager | Planning |
 | T-0031 | Implement file/config inputs and file/stdout/null outputs (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 8 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0032 | Implement the CSV parser and formatter (configured S01 integrated) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
-| T-0033 | Implement the JSON parser | Backlog | P1 | 5 | T-0023 | Plugin Implementer | Differential (Embulk) |
+| T-0033 | Implement the JSON parser (bounded formats S01 active) | In Progress | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |
 | T-0035 | Implement rename and remove-columns filters | Backlog | P1 | 3 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0036 | Implement format guessing | Backlog | P1 | 5 | T-0032, T-0033, T-0034 | Plugin Implementer | Differential (Embulk) |

--- a/crates/emburk-cli/tests/native_formats.rs
+++ b/crates/emburk-cli/tests/native_formats.rs
@@ -1,0 +1,104 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+static NEXT: AtomicUsize = AtomicUsize::new(0);
+
+fn config(filters: &str, decoder: &str, encoder: &str) -> String {
+    format!(
+        "in:\n  type: file\n  path_prefix: input\n{decoder}  parser:\n    type: json\n    columns:\n    - {{name: id, type: long}}\n    - {{name: name, type: string}}\n{filters}out:\n  type: file\n  path_prefix: output/result\n  file_ext: csv\n{encoder}  formatter:\n    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    header_line: true\n    quote_policy: MINIMAL\nexec:\n  max_threads: 1\n  min_output_tasks: 1\n"
+    )
+}
+fn run(config: &str, input: &[u8]) -> (PathBuf, Output) {
+    let root = std::env::temp_dir().join(format!(
+        "emburk-native-formats-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir(&root).unwrap();
+    fs::create_dir(root.join("output")).unwrap();
+    fs::write(root.join("config.yml"), config).unwrap();
+    fs::write(root.join("input"), input).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_emburk"))
+        .args(["run", "config.yml"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    (root, output)
+}
+#[test]
+fn json_multiline_sequence_nulls_and_arbitrary_names_transfer() {
+    let cfg = config("", "", "")
+        .replace("name: id", "name: sequence")
+        .replace("name: name", "name: label");
+    let input = "{\n\"label\":\"a, \\\"quote\\\" ☃\",\"sequence\":-9223372036854775808\n}\n{\"sequence\":2,\"label\":\"\"} {\"sequence\":null}";
+    let (root, result) = run(&cfg, input.as_bytes());
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("output/result000.00.csv")).unwrap(),
+        "sequence,label\n-9223372036854775808,\"a, \"\"quote\"\" ☃\"\n2,\"\"\n,\n"
+    );
+}
+#[test]
+fn ordered_filters_preserve_positional_values_and_validate_before_output() {
+    let filters = "filters:\n- type: rename\n  columns: {id: name, name: id}\n- type: remove_columns\n  remove: [name]\n";
+    let (root, result) = run(&config(filters, "", ""), b"{\"id\":7,\"name\":\"Ada\"}");
+    assert!(result.status.success());
+    assert_eq!(
+        fs::read(root.join("output/result000.00.csv")).unwrap(),
+        b"id\nAda\n"
+    );
+    let invalid = "filters:\n- type: remove_columns\n  remove: [missing]\n";
+    let (root, result) = run(&config(invalid, "", ""), b"not valid input");
+    assert!(!result.status.success());
+    assert!(String::from_utf8_lossy(&result.stderr).contains("remove column not found"));
+    assert_eq!(fs::read_dir(root.join("output")).unwrap().count(), 0);
+}
+#[test]
+fn invalid_json_and_corrupt_codecs_never_publish() {
+    for input in [
+        b"{\"id\":1}\n{".as_slice(),
+        b"{\"id\":\"wrong type\"}",
+        b"{\"name\":false}",
+        b"{\"name\":\"\xff\"}",
+        b"[]",
+    ] {
+        let (root, result) = run(&config("", "", ""), input);
+        assert!(!result.status.success());
+        assert_eq!(fs::read_dir(root.join("output")).unwrap().count(), 0);
+    }
+    for codec in ["gzip", "bzip2"] {
+        let decoder = format!("  decoders:\n  - {{type: {codec}}}\n");
+        let (root, result) = run(&config("", &decoder, ""), b"corrupted compressed bytes");
+        assert!(!result.status.success());
+        assert_eq!(fs::read_dir(root.join("output")).unwrap().count(), 0);
+    }
+}
+#[test]
+fn unsupported_profile_options_fail_before_output() {
+    for cfg in [
+        config("", "  decoders:\n  - {type: zip}\n", ""),
+        config("", "", "  encoders:\n  - {type: gzip, level: 1}\n"),
+        config("filters:\n- type: rename\n  rules: []\n", "", ""),
+    ] {
+        let (root, result) = run(&cfg, b"{\"id\":1}");
+        assert!(!result.status.success());
+        assert_eq!(fs::read_dir(root.join("output")).unwrap().count(), 0);
+    }
+}
+
+#[test]
+fn repeated_json_columns_cannot_expand_past_record_budget() {
+    let cfg = config("", "", "").replace("{name: id, type: long}", "{name: name, type: string}");
+    let input = format!("{{\"name\":\"{}\"}}", "x".repeat(700_000));
+    let (root, result) = run(&cfg, input.as_bytes());
+    assert!(!result.status.success());
+    assert!(String::from_utf8_lossy(&result.stderr).contains("selected record exceeds"));
+    assert_eq!(fs::read_dir(root.join("output")).unwrap().count(), 0);
+}

--- a/crates/emburk-core/Cargo.toml
+++ b/crates/emburk-core/Cargo.toml
@@ -6,3 +6,6 @@ license = "Apache-2.0"
 
 [dependencies]
 saphyr-parser = { version = "=0.0.11", default-features = false }
+serde_json = "=1.0.151"
+flate2 = { version = "=1.1.10", default-features = false, features = ["miniz_oxide"] }
+bzip2 = "=0.6.1"

--- a/crates/emburk-core/src/configured_csv.rs
+++ b/crates/emburk-core/src/configured_csv.rs
@@ -3,13 +3,14 @@ use crate::{
     csv_stream,
     logical_record::{LogicalRecord, LogicalValue},
     logical_schema::{LogicalColumn, LogicalSchema, LogicalType},
+    native_formats::{self, Codec, Encoder},
     publication,
     record_handoff::{RecordSink, RecordSource, SinkError, SourceError, handoff_owned_records},
     yaml_profile::{self, Node},
 };
 use std::{
     fs::{self, File},
-    io::{BufReader, BufWriter},
+    io::{BufRead, Write},
     path::{Path, PathBuf},
 };
 
@@ -23,6 +24,10 @@ struct Profile {
     output: PathBuf,
     skip: usize,
     schema: LogicalSchema,
+    json: bool,
+    decoder: Codec,
+    encoder: Codec,
+    projection: Vec<(usize, String)>,
 }
 pub fn run_config(path: &Path) -> Result<usize, String> {
     let p = compile(yaml_profile::load(path)?.compile_node()?)?;
@@ -70,41 +75,51 @@ fn require(m: &[(String, Node)], key: &str, value: &str) -> Result<(), String> {
 }
 fn compile(root: Node) -> Result<Profile, String> {
     let top = map(&root)?;
-    exact(top, &["in", "out", "exec"])?;
+    exact(top, &["in", "out", "exec", "filters"])?;
     let input = map(one(top, "in")?)?;
-    exact(input, &["type", "path_prefix", "parser"])?;
+    exact(input, &["type", "path_prefix", "parser", "decoders"])?;
     require(input, "type", "file")?;
     let parser = map(one(input, "parser")?)?;
-    exact(
-        parser,
-        &[
-            "type",
-            "charset",
-            "newline",
-            "delimiter",
-            "quote",
-            "escape",
-            "skip_header_lines",
-            "columns",
-        ],
-    )?;
-    for (k, v) in [
-        ("type", "csv"),
-        ("charset", "UTF-8"),
-        ("newline", "LF"),
-        ("delimiter", ","),
-        ("quote", "\""),
-        ("escape", "\""),
-    ] {
-        require(parser, k, v)?
-    }
-    let skips = values(parser, "skip_header_lines");
-    if skips.is_empty() {
-        return Err("required skip_header_lines".into());
+    let json = match scalar(one(parser, "type")?)? {
+        "csv" => false,
+        "json" => true,
+        _ => return Err("unsupported parser type".into()),
     };
-    let skip = scalar(skips.last().unwrap())?
-        .parse()
-        .map_err(|_| "invalid skip_header_lines")?;
+    let skip = if json {
+        exact(parser, &["type", "columns"])?;
+        0
+    } else {
+        exact(
+            parser,
+            &[
+                "type",
+                "charset",
+                "newline",
+                "delimiter",
+                "quote",
+                "escape",
+                "skip_header_lines",
+                "columns",
+            ],
+        )?;
+        for (k, v) in [
+            ("type", "csv"),
+            ("charset", "UTF-8"),
+            ("newline", "LF"),
+            ("delimiter", ","),
+            ("quote", "\""),
+            ("escape", "\""),
+        ] {
+            require(parser, k, v)?
+        }
+        let skips = values(parser, "skip_header_lines");
+        if skips.is_empty() {
+            return Err("required skip_header_lines".into());
+        };
+        scalar(skips.last().unwrap())?
+            .parse()
+            .map_err(|_| "invalid skip_header_lines")?
+    };
     let Node::Seq(cols) = one(parser, "columns")? else {
         return Err("columns must be sequence".into());
     };
@@ -125,7 +140,10 @@ fn compile(root: Node) -> Result<Profile, String> {
         });
     }
     let output = map(one(top, "out")?)?;
-    exact(output, &["type", "path_prefix", "file_ext", "formatter"])?;
+    exact(
+        output,
+        &["type", "path_prefix", "file_ext", "formatter", "encoders"],
+    )?;
     require(output, "type", "file")?;
     require(output, "file_ext", "csv")?;
     let formatter = map(one(output, "formatter")?)?;
@@ -158,6 +176,50 @@ fn compile(root: Node) -> Result<Profile, String> {
     exact(exec, &["max_threads", "min_output_tasks"])?;
     require(exec, "max_threads", "1")?;
     require(exec, "min_output_tasks", "1")?;
+    let mut projection: Vec<_> = columns
+        .iter()
+        .enumerate()
+        .map(|(index, column)| (index, column.name.clone()))
+        .collect();
+    if let Some(filters) = optional(top, "filters")? {
+        let Node::Seq(filters) = filters else {
+            return Err("filters must be sequence".into());
+        };
+        for filter in filters {
+            let filter = map(filter)?;
+            match scalar(one(filter, "type")?)? {
+                "rename" => {
+                    exact(filter, &["type", "columns"])?;
+                    let renames = map(one(filter, "columns")?)?;
+                    for (name, _) in renames {
+                        one(renames, name)?;
+                        if !projection.iter().any(|(_, current)| current == name) {
+                            return Err(format!("rename column not found: {name}"));
+                        }
+                    }
+                    for (_, name) in &mut projection {
+                        if let Some(new) = optional(renames, name)? {
+                            *name = scalar(new)?.to_owned();
+                        }
+                    }
+                }
+                "remove_columns" => {
+                    exact(filter, &["type", "remove"])?;
+                    let Node::Seq(remove) = one(filter, "remove")? else {
+                        return Err("remove must be sequence".into());
+                    };
+                    let names = remove.iter().map(scalar).collect::<Result<Vec<_>, _>>()?;
+                    for name in &names {
+                        if !projection.iter().any(|(_, current)| current == name) {
+                            return Err(format!("remove column not found: {name}"));
+                        }
+                    }
+                    projection.retain(|(_, name)| !names.contains(&name.as_str()));
+                }
+                _ => return Err("unsupported filter type".into()),
+            }
+        }
+    }
     Ok(Profile {
         input: PathBuf::from(scalar(one(input, "path_prefix")?)?),
         output: PathBuf::from(format!(
@@ -165,6 +227,10 @@ fn compile(root: Node) -> Result<Profile, String> {
             scalar(one(output, "path_prefix")?)?
         )),
         skip,
+        json,
+        decoder: codec(input, "decoders", false)?,
+        encoder: codec(output, "encoders", true)?,
+        projection,
         schema: LogicalSchema::new(
             columns
                 .iter()
@@ -181,6 +247,42 @@ fn compile(root: Node) -> Result<Profile, String> {
                 .collect(),
         ),
     })
+}
+fn optional<'a>(mapping: &'a [(String, Node)], key: &str) -> Result<Option<&'a Node>, String> {
+    match values(mapping, key).as_slice() {
+        [] => Ok(None),
+        [value] => Ok(Some(*value)),
+        _ => Err(format!("duplicate option {key}")),
+    }
+}
+fn codec(mapping: &[(String, Node)], key: &str, encoder: bool) -> Result<Codec, String> {
+    let Some(value) = optional(mapping, key)? else {
+        return Ok(Codec::Plain);
+    };
+    let Node::Seq(items) = value else {
+        return Err(format!("{key} must be sequence"));
+    };
+    let [item] = items.as_slice() else {
+        return Err("only one codec is supported".into());
+    };
+    let item = map(item)?;
+    exact(
+        item,
+        if encoder {
+            &["type", "level"]
+        } else {
+            &["type"]
+        },
+    )?;
+    let (codec, level) = match scalar(one(item, "type")?)? {
+        "gzip" => (Codec::Gzip, "6"),
+        "bzip2" => (Codec::Bzip2, "9"),
+        _ => return Err("unsupported codec type".into()),
+    };
+    if encoder {
+        require(item, "level", level)?;
+    }
+    Ok(codec)
 }
 fn execute(profile: Profile) -> Result<usize, String> {
     let parent = profile
@@ -215,33 +317,78 @@ fn execute(profile: Profile) -> Result<usize, String> {
     };
     let file = File::open(&input_path).map_err(|e| format!("cannot open input: {e}"))?;
     let mut source = Source {
-        input: BufReader::new(file),
+        input: native_formats::reader(file, profile.decoder),
         profile: &profile,
         skipped: 0,
     };
     publication::write_atomic(&profile.output, |output| {
+        let mut encoded = Encoder::new(output, profile.encoder);
         csv_stream::write_row(
-            output,
+            &mut encoded,
             &profile
-                .schema
-                .columns()
-                .map(|column| Some(column.name().to_owned()))
+                .projection
+                .iter()
+                .map(|(_, name)| Some(name.clone()))
                 .collect::<Vec<_>>(),
         )
         .map_err(|error| format!("CSV header failed: {error}"))?;
-        let mut sink = Sink { output };
-        handoff_owned_records(&mut source, &mut sink)
-            .map_err(|error| format!("CSV transfer failed: {error:?}"))
+        let mut sink = Sink {
+            output: &mut encoded,
+            projection: &profile.projection,
+        };
+        let count = handoff_owned_records(&mut source, &mut sink)
+            .map_err(|error| format!("record transfer failed: {error:?}"))?;
+        encoded
+            .finish()
+            .map_err(|error| format!("codec finalization failed: {error}"))?;
+        Ok(count)
     })
     .map_err(|error| error.to_string())
 }
 struct Source<'a> {
-    input: BufReader<File>,
+    input: Box<dyn BufRead>,
     profile: &'a Profile,
     skipped: usize,
 }
 impl RecordSource for Source<'_> {
     fn next_record(&mut self) -> Result<Option<LogicalRecord>, SourceError> {
+        if self.profile.json {
+            let Some(object) = native_formats::read_json(&mut self.input)
+                .map_err(|error| SourceError(error.to_string()))?
+            else {
+                return Ok(None);
+            };
+            let mut cells = Vec::new();
+            let mut selected_bytes = 0usize;
+            for column in self.profile.schema.columns() {
+                let value = &object[column.name()];
+                selected_bytes = selected_bytes
+                    .checked_add(value.as_str().map_or(8, str::len))
+                    .ok_or_else(|| SourceError("JSON selected record size overflow".into()))?;
+                if selected_bytes > 1024 * 1024 {
+                    return Err(SourceError(
+                        "JSON selected record exceeds 1048576 bytes".into(),
+                    ));
+                }
+                cells.push(if value.is_null() {
+                    LogicalValue::Null
+                } else if column.logical_type() == LogicalType::Signed64 {
+                    LogicalValue::Signed64(
+                        value
+                            .as_i64()
+                            .ok_or_else(|| SourceError("JSON field is not signed64".into()))?,
+                    )
+                } else {
+                    LogicalValue::Text(
+                        value
+                            .as_str()
+                            .ok_or_else(|| SourceError("JSON field is not string".into()))?
+                            .to_owned(),
+                    )
+                });
+            }
+            return Ok(Some(LogicalRecord::new(cells)));
+        }
         loop {
             let Some(row) =
                 csv_stream::read_record(&mut self.input).map_err(|e| SourceError(e.to_string()))?
@@ -278,14 +425,17 @@ impl RecordSource for Source<'_> {
         }
     }
 }
-struct Sink<'a> {
-    output: &'a mut BufWriter<File>,
+struct Sink<'a, W: Write> {
+    output: &'a mut W,
+    projection: &'a [(usize, String)],
 }
-impl RecordSink for Sink<'_> {
+impl<W: Write> RecordSink for Sink<'_, W> {
     fn accept(&mut self, r: LogicalRecord) -> Result<(), SinkError> {
-        let row = r
-            .cells()
-            .map(|v| match v {
+        let cells = r.cells().collect::<Vec<_>>();
+        let row = self
+            .projection
+            .iter()
+            .map(|(index, _)| match cells[*index] {
                 LogicalValue::Null => None,
                 LogicalValue::Signed64(v) => Some(v.to_string()),
                 LogicalValue::Text(v) => Some(v.clone()),

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -42,6 +42,7 @@ mod text_transfer;
 
 mod configured_csv;
 mod csv_stream;
+mod native_formats;
 mod publication;
 mod yaml_profile;
 

--- a/crates/emburk-core/src/native_formats.rs
+++ b/crates/emburk-core/src/native_formats.rs
@@ -1,0 +1,226 @@
+//! Bounded JSON-object framing and streaming selected codecs.
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader, BufWriter, Write},
+};
+
+#[derive(Clone, Copy)]
+pub(crate) enum Codec {
+    Plain,
+    Gzip,
+    Bzip2,
+}
+pub(crate) fn reader(file: File, codec: Codec) -> Box<dyn BufRead> {
+    match codec {
+        Codec::Plain => Box::new(BufReader::new(file)),
+        Codec::Gzip => Box::new(BufReader::new(flate2::read::MultiGzDecoder::new(file))),
+        Codec::Bzip2 => Box::new(BufReader::new(bzip2::read::MultiBzDecoder::new(file))),
+    }
+}
+pub(crate) enum Encoder<'a> {
+    Plain(&'a mut BufWriter<File>),
+    Gzip(flate2::write::GzEncoder<&'a mut BufWriter<File>>),
+    Bzip2(bzip2::write::BzEncoder<&'a mut BufWriter<File>>),
+}
+impl<'a> Encoder<'a> {
+    pub(crate) fn new(output: &'a mut BufWriter<File>, codec: Codec) -> Self {
+        match codec {
+            Codec::Plain => Self::Plain(output),
+            Codec::Gzip => Self::Gzip(flate2::write::GzEncoder::new(
+                output,
+                flate2::Compression::new(6),
+            )),
+            Codec::Bzip2 => Self::Bzip2(bzip2::write::BzEncoder::new(
+                output,
+                bzip2::Compression::new(9),
+            )),
+        }
+    }
+    pub(crate) fn finish(self) -> io::Result<()> {
+        match self {
+            Self::Plain(out) => out.flush(),
+            Self::Gzip(out) => {
+                out.finish()?;
+                Ok(())
+            }
+            Self::Bzip2(out) => {
+                out.finish()?;
+                Ok(())
+            }
+        }
+    }
+}
+impl Write for Encoder<'_> {
+    fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Plain(w) => w.write(b),
+            Self::Gzip(w) => w.write(b),
+            Self::Bzip2(w) => w.write(b),
+        }
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Plain(w) => w.flush(),
+            Self::Gzip(w) => w.flush(),
+            Self::Bzip2(w) => w.flush(),
+        }
+    }
+}
+const MAX: usize = 1024 * 1024;
+const DEPTH: usize = 64;
+pub(crate) fn read_json(input: &mut impl BufRead) -> io::Result<Option<serde_json::Value>> {
+    let mut data = Vec::new();
+    let mut started = false;
+    let mut depth = 0usize;
+    let mut quote = false;
+    let mut escaped = false;
+    loop {
+        let mut b = [0];
+        let n = input.read(&mut b)?;
+        if n == 0 {
+            if !started {
+                return Ok(None);
+            };
+            return Err(io::Error::other("truncated JSON object"));
+        }
+        let c = b[0];
+        if !started {
+            if matches!(c, b' ' | b'\t' | b'\r' | b'\n') {
+                continue;
+            }
+            if c != b'{' {
+                return Err(io::Error::other("JSON value must be object"));
+            }
+            started = true;
+            depth = 1;
+            data.push(c);
+            continue;
+        }
+        if data.len() == MAX {
+            return Err(io::Error::other("JSON object exceeds 1048576 bytes"));
+        }
+        data.push(c);
+        if quote {
+            if escaped {
+                escaped = false
+            } else if c == b'\\' {
+                escaped = true
+            } else if c == b'"' {
+                quote = false
+            };
+            continue;
+        }
+        match c {
+            b'"' => quote = true,
+            b'{' | b'[' => {
+                depth += 1;
+                if depth > DEPTH {
+                    return Err(io::Error::other("JSON depth exceeds 64"));
+                }
+            }
+            b'}' | b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    serde_json::from_slice::<serde_json::Value>(&data)
+        .map_err(|e| io::Error::other(format!("invalid JSON object: {e}")))
+        .and_then(|v| {
+            if v.is_object() {
+                Ok(Some(v))
+            } else {
+                Err(io::Error::other("JSON value must be object"))
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        io::{Cursor, Read},
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+    #[test]
+    fn reads_object_sequence_with_multiline_quotes_and_unicode() {
+        let mut input =
+            Cursor::new(" \n{\n\"text\":\"brace } [ and \\\" quote ☃\",\"id\":1}\n{\"id\":2}");
+        let first = read_json(&mut input).unwrap().unwrap();
+        assert_eq!(first["text"], "brace } [ and \" quote ☃");
+        assert_eq!(read_json(&mut input).unwrap().unwrap()["id"], 2);
+        assert!(read_json(&mut input).unwrap().is_none());
+    }
+    #[test]
+    fn rejects_malformed_nonobjects_and_invalid_utf8() {
+        for bytes in [
+            b"[]".as_slice(),
+            b"{",
+            b"{]",
+            b"{\"x\":\"\xff\"}",
+            b"{\"x\":\"\\q\"}",
+            b"\x0b{}",
+        ] {
+            assert!(read_json(&mut Cursor::new(bytes)).is_err());
+        }
+    }
+    #[test]
+    fn exact_json_byte_limit_is_enforced_before_growth() {
+        for extra in [0, 1] {
+            let input = format!("{{\"x\":\"{}\"}}", "a".repeat(MAX - 8 + extra));
+            assert_eq!(input.len(), MAX + extra);
+            assert_eq!(read_json(&mut Cursor::new(input)).is_ok(), extra == 0);
+        }
+    }
+    #[test]
+    fn arrays_and_objects_both_count_toward_depth() {
+        for extra in [0, 1] {
+            let input = format!(
+                "{{\"x\":{}0{}}}",
+                "[".repeat(DEPTH - 1 + extra),
+                "]".repeat(DEPTH - 1 + extra)
+            );
+            assert_eq!(read_json(&mut Cursor::new(input)).is_ok(), extra == 0);
+        }
+    }
+    #[test]
+    fn codecs_round_trip_and_reject_truncation() {
+        for codec in [Codec::Gzip, Codec::Bzip2] {
+            let root = std::env::temp_dir().join(format!(
+                "emburk-codec-test-{}-{}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir(&root).unwrap();
+            let path = root.join("stream");
+            let mut output = BufWriter::new(File::create_new(&path).unwrap());
+            let mut encoder = Encoder::new(&mut output, codec);
+            encoder.write_all(b"id,name\n1,Ada\n").unwrap();
+            encoder.finish().unwrap();
+            output.flush().unwrap();
+            drop(output);
+            let mut decoded = Vec::new();
+            reader(File::open(&path).unwrap(), codec)
+                .read_to_end(&mut decoded)
+                .unwrap();
+            assert_eq!(decoded, b"id,name\n1,Ada\n");
+            let size = fs::metadata(&path).unwrap().len();
+            fs::OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .unwrap()
+                .set_len(size - 3)
+                .unwrap();
+            assert!(
+                reader(File::open(&path).unwrap(), codec)
+                    .read_to_end(&mut Vec::new())
+                    .is_err()
+            );
+        }
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,11 @@ plugin types become public, and the empty lifecycle coordinator stays separate.
 
 ## Principles
 
+ADR-0019 admits the selected native_formats adapter for bounded JSON framing,
+streaming codecs and ordered schema projections inside the configured consumer.
+Dependencies remain private and codec finalization precedes publication.
+T-0033/S01 implementation/acceptance is in progress, not a public plugin API.
+
 ADR-0016 extends only CLI composition with stdout locking and std::io::sink
 adapters. Both use the same core transfer entry point; no new public core or
 plugin API is introduced. Stdout data and stderr summaries remain separate.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -15,7 +15,8 @@ independent runs. This is a private native consumer, not a verified generic
 plugin. General CSV and configuration behavior outside that selected matrix
 remains unfinished, not an accepted exception. T-0025/S01 integrated native
 no-clobber publication safety through PR #117; its failure policy is not
-observed Embulk parity. T-0014/S02 is reference-only format/filter preparation.
+observed Embulk parity. T-0014/S02 (#118) supplies five selected real JSON,
+gzip/bzip2 and filter-order observations; T-0033/S01 native acceptance is pending.
 
 The implementation objective is strict reproduction of observable behavior for
 the pinned core and admitted plugins. Technical constraints, disproportionate

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,8 +9,9 @@ observations integrated through PR #115. T-0032/S01 integrated through PR #116
 after primary and independent eight-case comparison and 81 passing tests.
 This satisfies the bounded stages 2–4 consumer, not full configuration/plugin
 gates. Stage 5 integrated as T-0025/S01 through PR #117 after fault/interruption
-acceptance. Stage 6 reference-only preparation is T-0014/S02; native formats
-and stage 7 remain open.
+acceptance. Stage 6 reference-only preparation T-0014/S02 integrated through
+PR #118. T-0033/S01 implements the selected native pipeline formats; stage 7
+and broader parent gates remain open.
 
 ## Phase 0: Governance and Compatibility Contract
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -50,8 +50,9 @@ T-0032/S01 consumer is Done through PR #116 (66c6125), after 81 passing tests,
 eight existing ignores and eight independently matching selected real file
 projections at 59a7cca. T-0025/S01 is Done through PR #117 (aac0003): 87 passes,
 eight existing ignores, actual interruption and operation-failure tests, and
-unchanged eight-case CSV comparison. T-0014/S02 now captures selected stage-6
-format/filter observations; native formats and stage 7 remain unfinished.
+unchanged eight-case CSV comparison. T-0014/S02 is Done through PR #118:
+nine tests and matching independent five-case format/filter observations.
+T-0033/S01 now implements bounded native formats; stage 7 remains unfinished.
 The owner-authorized
 [seven-stage sequence](IMPLEMENTATION_SEQUENCE.md) remains uncompleted work.
 
@@ -80,7 +81,7 @@ strict controls and unchanged S12 regression. T-0031/S01 is Done through PR #110
 (`c5fb13f`) for the explicitly requested experimental native File-to-File path.
 T-0031/S02 is Done through PR #112 (`2ec236e`) for experimental stdout/null
 consumers: 71 tests passed, eight existing intentional ignores, primary and
-independent acceptance at `c5df504`. T-0014/S02 now occupies one WIP lane; the full
+independent acceptance at `c5df504`. T-0033/S01 now occupies one WIP lane; the full
 file/plugin parent stays open. Core transfer semantics remain unchanged.
 
 | Item | State | Purpose |
@@ -97,9 +98,8 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 
-T-0025/S01 is Done through PR #117. T-0014/S02 uses
-one lane for bundled format/filter reference observations
-on research/t-0014-formats-oracle; its packet and evidence are disjoint.
+T-0025/S01 is Done through PR #117. T-0014/S02 is Done through PR #118.
+T-0033/S01 uses one lane for native JSON/codecs/filters on its dedicated branch.
 Other unfinished stable tasks remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
 is the coordination mirror. Its 52 items, lifecycle states, initial estimates,

--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,58 @@
+# Third-party notices
+
+This is a development attribution record, not a complete release notice bundle
+or SBOM. Cargo.lock and provenance packets identify selected dependencies.
+Release packaging must reconcile all distributed code, licenses and notices.
+No Embulk implementation source is copied into this project.
+
+## libbz2-rs-sys 0.2.5
+
+The unmodified dependency is used through bzip2 0.6.1. The following license
+text is retained from libbz2-rs-sys-0.2.5/LICENSE, package SHA256
+34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c.
+
+```text
+The original program, "bzip2", the associated library "libbzip2", and all
+documentation, are
+
+Copyright (C) 1996-2021 Julian R Seward.
+Copyright (C) 2019-2020 Federico Mena Quintero
+Copyright (C) 2021 Micah Snyder
+
+This Rust translation, "libbzip2-rs" is a derived work based on "bzip2" and
+"libbzip2", and is Copyright (C) 2024-2025 Trifecta Tech Foundation and contributors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. The origin of this software must not be misrepresented; you must
+   not claim that you wrote the original software.  If you use this
+   software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+3. Altered source versions must be plainly marked as such, and must
+   not be misrepresented as being the original software.
+
+4. The name of the author may not be used to endorse or promote
+   products derived from this software without specific prior written
+   permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Julian Seward, jseward@acm.org
+bzip2/libbzip2 version 1.1.0 of 6 September 2010
+```

--- a/docs/decisions/ADR-0019-bounded-native-formats.md
+++ b/docs/decisions/ADR-0019-bounded-native-formats.md
@@ -1,0 +1,23 @@
+# ADR-0019: Bounded native formats in the configured pipeline
+
+- Status: Accepted for T-0033/S01 implementation; acceptance pending
+- Date: 2026-09-06
+
+Extend the existing private configured pipeline rather than expose a premature
+generic plugin API. Keep dependency types inside a native_formats adapter.
+JSON object framing bounds bytes and nesting before parsing; codec readers
+stream into the same row boundary and codec writers finish before publication.
+Ordered schema projections implement selected rename/remove behavior without
+losing alignment with row values. Validate options before creating output.
+
+Use the exact reviewed serde_json/flate2/bzip2 graph in the T-0033/S01 packet.
+No C backend, optional arbitrary precision or unbounded JSON depth is admitted.
+Existing YAML, CSV, logical values, old line consumers and publication states
+remain separate. Reference-only T-0014/S02 establishes the selected five real
+cases; native acceptance must compare actual exits and plain/decoded output.
+Different valid compression bitstreams do not imply different record content,
+but cannot be called bitstream parity. No broader Embulk behavior is inferred.
+
+This decision expands ADR-0017's supported formats only within the accepted
+future evidence scope; it does not complete any full parent plugin contract.
+Stage 7 must separately establish bounded parallelism and validated recovery.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -480,3 +480,9 @@ primary and independent Demo at 725dd7e: 87 passes, eight existing ignores,
 eight CSV matches and actual interruption coverage. T-0014/S02 independently
 prepares stage-6 reference observations; initial incorrect rename fixtures
 were rejected and corrected before acceptance. Native stages 6–7 remain open.
+
+T-0014/S02 integrated through PR #118 (ecf9cc4), accepting 3 SP after primary
+and independent Demo at dad393c3: nine tests and five matching real projections.
+T-0033/S01 admits the exact reviewed JSON/codec dependency subset and begins
+the bounded stage-6 consumer. Attribution is recorded; full release/security/
+patent clearance and all broader plugin/resume claims remain unreviewed/open.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -39,6 +39,7 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0014/S01 File/CSV oracle](T-0014-file-csv-oracle.md) | Done, PR #115; eight reference observations |
 | [T-0032/S01 configured CSV](T-0032-configured-csv.md) | Done through PR #116; eight selected comparisons and 81 tests |
 | [T-0025/S01 safe publication](T-0025-safe-publication.md) | Done through PR #117; fault/interruption acceptance |
-| [T-0014/S02 format/filter observations](T-0014-formats-oracle.md) | In Progress; reference-only stage-6 preparation |
+| [T-0014/S02 format/filter observations](T-0014-formats-oracle.md) | Done through PR #118; five real reference cases |
+| [T-0033/S01 native formats](T-0033-native-formats.md) | In Progress; bounded JSON/codecs/filters |
 | [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | Done, PR #110; native-only record consumer |
 | [T-0031/S02 experimental stdout/null](T-0031-output-targets.md) | Done, PR #112; unchanged core transfer |

--- a/docs/provenance/T-0014-formats-oracle.md
+++ b/docs/provenance/T-0014-formats-oracle.md
@@ -1,6 +1,6 @@
 # T-0014/S02 bundled format and filter observations
 
-Issue: [#17](https://github.com/bhind/emburk/issues/17). State: In Progress.
+Issue: [#17](https://github.com/bhind/emburk/issues/17). State: Done through PR #118.
 Forecast: 3 SP. Reference-only preparation for stage 6.
 
 ## Authority and dependencies
@@ -92,6 +92,25 @@ names, decoded/plain content); raw compressed bytes may differ and stay retained
 Set EMBURK_REFERENCE_JAR and JAVA_HOME to the pinned local artifact and Java17.
 
 ## Evidence class, stop rule and non-claims
+
+Accepted 3 SP through ecf9cc47c964fc678de98992afc13335b9521ea0 after primary
+and independent exact Demo at dad393c3aaf154b447ab38e97c18ec2ab5988a60.
+Nine harness tests passed. All five actual input/config/exit/output-name and
+plain/decoded-content projections matched between runs; no timeouts. JSON,
+gzip, bzip2 and rename-then-remove exit 0; reverse filter order exits 1 without
+output. Compressed bytes are retained, not normalized into bitstream parity.
+
+Primary /private/tmp/t0014-s02-primary.ermKcq stdout SHA256
+f5147a0066bc816327cdbd73bb88736e6b456e352900f68ef42bbf19ac3c8879;
+stderr b35463792dff49415b3025f515a855650b957e546842ecbbcd8a81a9573f833a.
+Independent /private/tmp/emburk-t0014-s02-acceptance.XjNBHt stdout SHA256
+231c8726eb81e213307a47e0c720c8a52adc4b128c93af25a036d72e1fb8bd63;
+stderr 212d7f3f8085850412f7dd751ef30309fa2a5c6cfc44fe45b2db05bc1c185736.
+Both numeric exit 0, exit-file SHA256
+9a271f2a916b0b6ee6cecb2426f0b3206ef074578be55d9bc94f6f3fe3ab86aa.
+Raw runs: /private/tmp/emburk-t0014-s02-run-tm_jxcje and
+/private/tmp/emburk-t0014-s02-run-kj60p8_o. Parent #17 remains open in Backlog;
+S01/S02 accept 8 SP total, not full harness completion.
 
 Reference-only observation plus Unit/Contract harness controls. Stop on artifact
 mismatch, unsafe filesystem writes, unexplained timeout or source/IP issue.

--- a/docs/provenance/T-0033-native-formats.md
+++ b/docs/provenance/T-0033-native-formats.md
@@ -1,0 +1,108 @@
+# T-0033/S01 bounded native formats and filters
+
+Issue: [#26](https://github.com/bhind/emburk/issues/26). State: In Progress.
+Forecast: 8 SP. One independently acceptable stage-6 configured-pipeline slice;
+JSON, codec and filter parent tasks remain open outside the selected profile.
+
+## Authority and dependencies
+
+Owner authorized stages 1–7 and routine testing/integration absent incidents.
+PM owns dependency admission and acceptance. T-0032/S01 (#116), T-0025/S01
+(#117) and T-0014/S02 (#118, ecf9cc4) are integrated. Source/runtime observation
+provenance is T-0014-formats-oracle.md; no upstream implementation translation.
+
+## Branch and allowlist
+
+Branch feat/t-0033-native-formats. PM initially owns Cargo.lock and core Cargo.toml
+for metadata-only resolution and exact dependency review. After admission,
+Rust Core Implementer owns only those two files, core/src/lib.rs,
+core/src/configured_csv.rs, core/src/native_formats.rs,
+crates/emburk-cli/tests/native_formats.rs, and
+tests/t0033_native_formats_differential_test.sh; core paths are under crates/.
+One serial source mutation owner. PM owns this packet, ADR-0019, STATUS/TODO/
+ROADMAP/COMPATIBILITY/ARCHITECTURE, IMPLEMENTATION_SEQUENCE, provenance index,
+T-0014/S02 closeout, third-party notices and daily log. Reviewers remain read-only.
+Do not alter publication.rs, prior source/schema/CSV/oracle/test files.
+
+The implementer supplied only the uncompiled native_formats adapter and then
+paused. PM took serial source ownership of the same allowlist for integration,
+array-depth correction, explicit test coverage and the retained comparator.
+
+## Dependency admission
+
+Admit exactly serde_json=1.0.151 (default std), flate2=1.1.10
+(default-features=false, miniz_oxide), bzip2=0.6.1 (default libbz2-rs-sys).
+No C backend or zlib build, no optional unbounded-depth/derive/precision/indexmap
+features. Cargo.lock fixes each selected transitive version/checksum. Before
+building, compare every registry entry against the previously downloaded
+official package archive inventory plus the integrated YAML graph; stop on new
+or changed entries. The prospective 37-package metadata graph was not built.
+Only the selected subset is admitted here; sha2/ctrlc are not admitted yet.
+
+Sources accessed 2026-09-06: exact version archives from
+https://static.crates.io/crates/serde_json/serde_json-1.0.151.crate,
+https://static.crates.io/crates/flate2/flate2-1.1.10.crate,
+https://static.crates.io/crates/bzip2/bzip2-0.6.1.crate and equivalent exact
+Cargo.lock-version archive locators for transitives. Manifest/license metadata
+was inspected; consult public API documentation/signatures only as needed.
+Use linked dependency APIs, not copied implementation. Direct crates are
+MIT OR Apache-2.0. Transitive exceptions: adler2 (0BSD OR MIT OR Apache-2.0),
+memchr (Unlicense OR MIT), miniz_oxide (MIT OR Zlib OR Apache-2.0),
+libbz2-rs-sys (bzip2-1.0.6), unicode-ident (Unicode-3.0 with MIT/Apache terms).
+Preserve required attribution for distributed material. Archives had no NOTICE;
+this is not a complete release SBOM, security audit or patent/FTO clearance.
+PM admits ordinary local compilation under the authorized implementation
+workflow; any tool approval denial remains binding and requires escalation.
+
+Metadata resolution produced 23 exact registry entries, all matching the
+previously reviewed archive checksums or integrated YAML graph. The selected
+normal/build graph excludes serde/serde_derive (lock-only conditional entries).
+New selected build.rs files in crc32fast 1.5.1, serde_core 1.0.229, zmij 1.0.23
+and serde_json 1.0.151 were inspected from those exact archives: compiler/target
+feature detection, rustc --version and serde_core generation under OUT_DIR.
+No additional installer/network action was found in these scripts. This is a
+bounded build-script observation, not an audit of all dependency implementation.
+No new procedural macro is selected beyond the integrated YAML graph.
+The bzip2 backend license is retained in docs/THIRD_PARTY_NOTICES.md.
+
+## Acceptance
+
+Extend `emburk run CONFIG` with explicit JSON long/string columns, optional
+single gzip/bzip2 decoder and encoder (levels 6/9), and ordered rename columns
+mapping / remove_columns remove list. Validate all options before output.
+All use the same private logical schema/record pipeline and safe publication.
+Support arbitrary selected values/names; no fixture-constant special cases.
+
+JSON framing accepts a whitespace-separated sequence of objects, including
+multiline objects. Retain at most 1 MiB per raw object, depth at most 64, before
+serde parsing; strict UTF-8 and malformed/nonobject values visibly fail.
+Selected fields support signed64, text, null/missing. Selected row payload is
+also capped at 1 MiB before cloning repeated schema fields. Broader JSON coercion,
+root pointers, arrays and malformed-row recovery remain unfinished, not parity.
+Codec streams must finalize successfully before publication; truncated/corrupt
+input cannot publish. No whole-file decompression or all-record collection.
+Apply filters in declared order and preserve column/value alignment; missing
+remove target fails before output as observed. General rename rules/keep remain
+unsupported. Output extension/naming remains the observed explicit CSV profile.
+
+Run all five S02 fixture configs through actual native CLI and pinned reference.
+Compare exact exits, full output names, and plain/decoded bytes. Preserve raw
+compressed output, do not assert compressed bitstream identity. Keep all eight
+earlier CSV comparisons and 87 existing workspace tests. Add native tests for
+JSON byte/depth bounds, escaped/multiline/UTF-8 cases, wrong scalar types,
+truncated codec streams, unknown options, filter ordering and no partial final.
+
+## Demo Command
+
+`cargo fmt --all -- --check && cargo clippy --locked --workspace --all-targets -- -D warnings && cargo test --locked --workspace && bash tests/t0032_configured_csv_differential_test.sh && bash tests/t0033_native_formats_differential_test.sh && git diff --check`
+
+Set the pinned local EMBURK_REFERENCE_JAR and Java17 JAVA_HOME. Retain final-head
+primary/independent evidence and negative controls; no points before integration.
+
+## Evidence class, stop rule and non-claims
+
+Selected Differential plus Unit/Contract and local Integration. Stop on new
+unreviewed dependency, codec finalization/cleanup failure, unexplained reference
+mismatch, source/IP uncertainty or output damage. No full plugin certification,
+all JSON/coercion/options support, compressed bitstream identity, distributed
+transaction, parallel performance, cancellation/resume or legal clearance claim.

--- a/tests/t0033_native_formats_differential_test.sh
+++ b/tests/t0033_native_formats_differential_test.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+: "${EMBURK_REFERENCE_JAR:?EMBURK_REFERENCE_JAR is required}"
+: "${JAVA_HOME:?JAVA_HOME is required}"
+cargo build --locked --workspace
+python3 -I -B - <<'PY'
+import bz2, gzip, importlib.util, json, os, shutil, subprocess, tempfile, uuid
+from pathlib import Path
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+repository = Path.cwd().resolve()
+spec = importlib.util.spec_from_file_location("oracle", repository / "tools/formats-oracle/run.py")
+oracle = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(oracle)
+cases = ("json-scalars", "gzip-csv", "bzip2-csv", "rename-then-remove", "remove-before-rename")
+require(oracle.CASES == cases, "reference matrix changed")
+root = Path(tempfile.mkdtemp(prefix="emburk-t0033-differential-", dir="/private/tmp"))
+print(f"T0033_S01_EVIDENCE_DIR={root}", flush=True)
+jar = oracle.snapshot(oracle.pinned_bytes(dict(os.environ)), root)
+java, version = oracle.java(dict(os.environ))
+binary = repository / "target/debug/emburk"
+run_uuid = str(uuid.uuid4())
+summary = {"uuid": run_uuid, "revision": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+           "binary_sha256": oracle.digest(binary.read_bytes()), "cases": [], "result": "incomplete"}
+try:
+    for name in cases:
+        reference = oracle.run_case(name, jar, java, version, run_uuid)
+        observed = oracle.validate(reference / "manifest.json")
+        require(observed["uuid"] == run_uuid and observed["case"] == name and not observed["process"]["timed_out"], "invalid reference identity/timeout")
+        native = root / name
+        native.mkdir()
+        (native / "output").mkdir()
+        shutil.copyfile(reference / "config.yml", native / "config.yml")
+        input_name = observed["input"]["name"]
+        shutil.copyfile(reference / input_name, native / input_name)
+        with (native / "stdout.log").open("xb") as stdout, (native / "stderr.log").open("xb") as stderr:
+            process = subprocess.run([str(binary), "run", "config.yml"], cwd=native,
+                                     env={"PATH": os.defpath}, stdout=stdout, stderr=stderr, timeout=60)
+        (native / "exit.txt").write_text(f"{process.returncode}\n", encoding="ascii")
+        outputs = oracle.inventory(native / "output")
+        result = {"case": name, "reference": str(reference), "native": str(native), "exit": process.returncode,
+                  "outputs": outputs, "input": oracle.detail(native / input_name, native),
+                  "config": oracle.detail(native / "config.yml", native),
+                  "stdout": oracle.detail(native / "stdout.log", native), "stderr": oracle.detail(native / "stderr.log", native),
+                  "reference_manifest_sha256": oracle.digest((reference / "manifest.json").read_bytes())}
+        summary["cases"].append(result)
+        expected_exit = observed["process"]["exit"] + (os.environ.get("EMBURK_TEST_DIFF_MISMATCH") == "1")
+        require(process.returncode == expected_exit, f"{name}: exit mismatch")
+        require([item["name"] for item in outputs] == [item["name"] for item in observed["outputs"]], f"{name}: output names mismatch")
+        decoded = []
+        for item in outputs:
+            native_bytes = (native / "output" / item["name"]).read_bytes()
+            reference_bytes = (reference / "output" / item["name"]).read_bytes()
+            if name in ("gzip-csv", "bzip2-csv"):
+                decode = gzip.decompress if name == "gzip-csv" else bz2.decompress
+                native_bytes, reference_bytes = decode(native_bytes), decode(reference_bytes)
+                decoded_path = native / (item["name"] + ".decoded")
+                decoded_path.write_bytes(native_bytes)
+                decoded.append(oracle.detail(decoded_path, native))
+            require(native_bytes == reference_bytes, f"{name}: plain/decoded bytes mismatch")
+        result["decoded"] = decoded
+        print(f"T0033_S01_MATCH={name}", flush=True)
+    require(len(summary["cases"]) == 5, "incomplete matrix")
+    summary["result"] = "pass"
+finally:
+    (root / "manifest.json").write_text(json.dumps(summary, sort_keys=True) + "\n", encoding="utf-8")
+PY


### PR DESCRIPTION
T-0033/S01 for #26, 8 SP independently acceptable stage-6 slice. Streams selected JSON objects, gzip/bzip2 codecs and ordered rename/remove projections through the same configured pipeline and safe publication. Exact admitted dependency graph and attribution recorded; no upstream implementation copying.

Primary and independent exact Demo at 39c97d86165d1a23e5a7d929d229942c358de351 pass: 97 tests, eight existing intentional ignores, eight old CSV comparisons and five new format/filter comparisons. Negative forced-exit mismatch returns 1. Read-only review found no concrete defect. Primary stdout SHA256 4167421e21da60d60ab15d3448d94f972f9da42d4ba418e3b4c6d4b7621f5870; independent stdout ef2b624e5938d6fdc7ba91ff77fb6873d3212fe166b777f2fa51e57e329a0bc9.

Codec comparisons are decoded-content, not compressed-bitstream identity. JSON/config/options remain explicitly bounded; no full plugin or resume claim. See packet docs/provenance/T-0033-native-formats.md and ADR-0019. Includes #118 closeout. Parent remains open.