### PR TITLE
feat(t-0024): bounded ordered workers and cooperative cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,9 +60,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "emburk-cli"
 version = "0.1.0"
 dependencies = [
+ "ctrlc",
  "emburk-core",
 ]
 
@@ -78,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +143,33 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "proc-macro2"
@@ -205,6 +283,21 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/TODO.md
+++ b/TODO.md
@@ -43,9 +43,11 @@ ignores and eight CSV comparisons. Parent #22 remains open in Backlog;
 Initial/Current 8 unchanged. T-0014/S02 is Done through PR #118 (ecf9cc4),
 accepting 3 SP after independent five-case agreement and nine tests at dad393c3.
 Parent #17 remains Backlog, S01/S02 total 8 SP, Initial/Current 8 unchanged.
-T-0033/S01 is In Progress, forecast 8 SP for bounded JSON/codecs/filters.
-Parent #26 Current changes 5 to 8 for this broader configured consumer;
-Initial 5 remains unchanged. Full T-0033/T-0034/T-0035 parents remain unaccepted.
+T-0033/S01 is Done through PR #119 (95b5592), accepting 8 SP after independent
+97-test/thirteen-comparison Demo at 39c97d8. Parent #26 remains Backlog,
+Current 8 / Initial 5 unchanged. Full T-0033/T-0034/T-0035 parents remain
+unaccepted. T-0024/S01 is In Progress (forecast 5 SP) for bounded formatting
+and cancellation; parent Current/Initial 8 unchanged, resume follows separately.
 
 T-0031/S01 is Done through PR #110 (`c5fb13f`), accepting 5 SP, for a native UTF-8 line-record
 File-to-File command under ADR-0015. It consumes T-0021/S06 without claiming
@@ -91,7 +93,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0021 | Define workspace boundaries and core traits (S01–S06 integrated; remaining contracts queued) | Backlog | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI (S01 Done) | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 21 | T-0012, T-0021 | Compatibility Host Implementer | Differential (Embulk) |
-| T-0024 | Implement bounded scheduling, backpressure, and cancellation | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
+| T-0024 | Implement bounded scheduling, backpressure, and cancellation (S01 active) | In Progress | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0025 | Implement atomic transaction and resume state (publication S01 Done) | Backlog | P1 | 8 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
 | T-0026 | Implement structured errors and observability | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |
 
@@ -102,7 +104,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0030 | Epic: Native File-to-File ETL | Backlog | P1 | — | T-0020 | Project Manager | Planning |
 | T-0031 | Implement file/config inputs and file/stdout/null outputs (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 8 | T-0022, T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0032 | Implement the CSV parser and formatter (configured S01 integrated) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
-| T-0033 | Implement the JSON parser (bounded formats S01 active) | In Progress | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
+| T-0033 | Implement the JSON parser (bounded formats S01 Done) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |
 | T-0035 | Implement rename and remove-columns filters | Backlog | P1 | 3 | T-0023 | Plugin Implementer | Differential (Embulk) |
 | T-0036 | Implement format guessing | Backlog | P1 | 5 | T-0032, T-0033, T-0034 | Plugin Implementer | Differential (Embulk) |

--- a/crates/emburk-cli/Cargo.toml
+++ b/crates/emburk-cli/Cargo.toml
@@ -10,3 +10,4 @@ path = "src/main.rs"
 
 [dependencies]
 emburk-core = { path = "../emburk-core" }
+ctrlc = "=3.5.2"

--- a/crates/emburk-cli/src/main.rs
+++ b/crates/emburk-cli/src/main.rs
@@ -5,6 +5,10 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{self, BufReader},
     path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 fn main() {
@@ -20,15 +24,21 @@ fn main() {
         )
     {
         println!(
-            "Usage: emburk transfer-lines INPUT OUTPUT\n       emburk transfer-lines-stdout INPUT\n       emburk transfer-lines-null INPUT"
+            "Usage: emburk run CONFIG\n       emburk transfer-lines INPUT OUTPUT\n       emburk transfer-lines-stdout INPUT\n       emburk transfer-lines-null INPUT"
         );
         return;
     }
+    let cancelled = Arc::new(AtomicBool::new(false));
     let (command, result) = match arguments.as_slice() {
-        [_, command, config] if command == "run" => (
-            "run",
-            emburk_core::run_config(Path::new(config)).map(|_| ()),
-        ),
+        [_, command, config] if command == "run" => {
+            let signal_flag = Arc::clone(&cancelled);
+            let result = ctrlc::set_handler(move || signal_flag.store(true, Ordering::Release))
+                .map_err(|error| format!("cannot install SIGINT handler: {error}"))
+                .and_then(|()| {
+                    emburk_core::run_config_with_cancel(Path::new(config), &cancelled).map(|_| ())
+                });
+            ("run", result)
+        }
         [_, command, input, output] if command == "transfer-lines" => (
             "transfer-lines",
             transfer(Path::new(input), Path::new(output)),
@@ -46,7 +56,11 @@ fn main() {
     };
     if let Err(error) = result {
         eprintln!("emburk: {command} failed: {error}");
-        std::process::exit(1);
+        std::process::exit(if cancelled.load(Ordering::Acquire) {
+            130
+        } else {
+            1
+        });
     }
 }
 

--- a/crates/emburk-cli/tests/bounded_parallel.rs
+++ b/crates/emburk-cli/tests/bounded_parallel.rs
@@ -1,0 +1,155 @@
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::atomic::{AtomicUsize, Ordering},
+    thread,
+    time::{Duration, Instant},
+};
+static NEXT: AtomicUsize = AtomicUsize::new(0);
+fn root() -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "emburk-parallel-cli-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir(&root).unwrap();
+    fs::create_dir(root.join("output")).unwrap();
+    root
+}
+fn config(workers: usize, json: bool, encoder: &str) -> String {
+    let parser = if json {
+        "    type: json\n"
+    } else {
+        "    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    skip_header_lines: 1\n"
+    };
+    format!(
+        "in:\n  type: file\n  path_prefix: input\n  parser:\n{parser}    columns:\n    - {{name: id, type: long}}\n    - {{name: name, type: string}}\nfilters:\n- type: rename\n  columns: {{name: label}}\nout:\n  type: file\n  path_prefix: output/result\n  file_ext: csv\n{encoder}  formatter:\n    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    header_line: true\n    quote_policy: MINIMAL\nexec:\n  max_threads: {workers}\n  min_output_tasks: 1\n"
+    )
+}
+fn command(root: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_emburk"));
+    command.args(["run", "config.yml"]).current_dir(root);
+    command
+}
+#[test]
+fn serial_and_parallel_selected_formats_are_byte_deterministic() {
+    for json in [false, true] {
+        for encoder in [
+            "",
+            "  encoders:\n  - {type: gzip, level: 6}\n",
+            "  encoders:\n  - {type: bzip2, level: 9}\n",
+        ] {
+            let mut baseline = None;
+            for workers in [1, 4, 8] {
+                let root = root();
+                fs::write(root.join("config.yml"), config(workers, json, encoder)).unwrap();
+                let mut input = if json {
+                    String::new()
+                } else {
+                    String::from("id,name\n")
+                };
+                for id in 0..2000 {
+                    if json {
+                        input.push_str(&format!("{{\"id\":{id},\"name\":\"row, {id} ☃\"}}\n"));
+                    } else {
+                        input.push_str(&format!("{id},\"row, {id} ☃\"\n"));
+                    }
+                }
+                fs::write(root.join("input"), input).unwrap();
+                let result = command(&root).output().unwrap();
+                assert!(
+                    result.status.success(),
+                    "{}",
+                    String::from_utf8_lossy(&result.stderr)
+                );
+                let bytes = fs::read(root.join("output/result000.00.csv")).unwrap();
+                if let Some(expected) = &baseline {
+                    assert_eq!(&bytes, expected);
+                } else {
+                    baseline = Some(bytes);
+                }
+            }
+        }
+    }
+}
+#[test]
+fn worker_limits_fail_before_output() {
+    for workers in [0, 9] {
+        let root = root();
+        fs::write(root.join("config.yml"), config(workers, false, "")).unwrap();
+        fs::write(root.join("input"), b"id,name\n1,Ada\n").unwrap();
+        assert!(!command(&root).status().unwrap().success());
+        assert_eq!(fs::read_dir(root.join("output")).unwrap().count(), 0);
+    }
+}
+#[cfg(unix)]
+#[test]
+fn sigint_cancels_active_transfer_and_reaps_without_publishing() {
+    for encoder in [
+        "",
+        "  encoders:\n  - {type: gzip, level: 6}\n",
+        "  encoders:\n  - {type: bzip2, level: 9}\n",
+    ] {
+        let root = root();
+        fs::write(root.join("config.yml"), config(4, false, encoder)).unwrap();
+        let mut input = fs::File::create_new(root.join("input")).unwrap();
+        input.write_all(b"id,name\n").unwrap();
+        let block = b"1,abcdefghijklmnopqrstuvwxyz\n".repeat(4096);
+        for _ in 0..256 {
+            input.write_all(&block).unwrap();
+        }
+        drop(input);
+        let stderr = fs::File::create_new(root.join("stderr.log")).unwrap();
+        let mut child = command(&root)
+            .stdout(Stdio::null())
+            .stderr(stderr)
+            .spawn()
+            .unwrap();
+        let start = Instant::now();
+        let mut active = false;
+        while start.elapsed() < Duration::from_secs(5) {
+            if fs::read_dir(root.join("output")).unwrap().any(|e| {
+                e.unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".emburk-output-")
+            }) {
+                active = true;
+                break;
+            }
+            if child.try_wait().unwrap().is_some() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+        let signalled = active
+            && Command::new("/bin/kill")
+                .args(["-INT", &child.id().to_string()])
+                .status()
+                .unwrap()
+                .success();
+        let wait_start = Instant::now();
+        let mut status = None;
+        while wait_start.elapsed() < Duration::from_secs(5) {
+            status = child.try_wait().unwrap();
+            if status.is_some() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        if status.is_none() {
+            let _ = child.kill();
+        }
+        let status = child.wait().unwrap();
+        assert!(signalled, "could not observe and signal an active child");
+        assert_eq!(
+            status.code(),
+            Some(130),
+            "{}",
+            fs::read_to_string(root.join("stderr.log")).unwrap()
+        );
+        assert_eq!(fs::read_dir(root.join("output")).unwrap().count(), 0);
+    }
+}

--- a/crates/emburk-core/src/bounded_parallel.rs
+++ b/crates/emburk-core/src/bounded_parallel.rs
@@ -1,0 +1,338 @@
+//! Bounded ordered formatter coordination using only scoped std threads.
+use std::{
+    collections::BTreeMap,
+    panic::{self, AssertUnwindSafe},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, RecvTimeoutError},
+    },
+    thread,
+    time::Duration,
+};
+
+const MAX_WORKERS: usize = 8;
+const MAX_RESULT: usize = 3 * 1024 * 1024;
+pub(crate) fn run<T: Send>(
+    workers: usize,
+    cancel: &AtomicBool,
+    mut next: impl FnMut() -> Result<Option<T>, String>,
+    format: impl Fn(T) -> Result<Vec<u8>, String> + Sync,
+    mut emit: impl FnMut(Vec<u8>) -> Result<(), String>,
+) -> Result<usize, String> {
+    if !(1..=MAX_WORKERS).contains(&workers) {
+        return Err("workers must be 1 through 8".into());
+    }
+    if cancel.load(Ordering::Acquire) {
+        return Err("cancelled".into());
+    }
+    let window = workers * 2;
+    let (job_tx, job_rx) = mpsc::sync_channel::<(usize, T)>(window);
+    let (result_tx, result_rx) = mpsc::sync_channel::<(usize, Result<Vec<u8>, String>)>(window);
+    let jobs = Arc::new(Mutex::new(job_rx));
+    thread::scope(|scope| {
+        let mut handles = Vec::new();
+        let mut failure = None;
+        for _ in 0..workers {
+            let format = &format;
+            let jobs = Arc::clone(&jobs);
+            let result_tx = result_tx.clone();
+            match thread::Builder::new()
+                .name("emburk-format".into())
+                .spawn_scoped(scope, move || {
+                    loop {
+                        if cancel.load(Ordering::Acquire) {
+                            break;
+                        }
+                        let job = match jobs
+                            .lock()
+                            .map_err(|_| ())
+                            .and_then(|r| r.recv().map_err(|_| ()))
+                        {
+                            Ok(v) => v,
+                            Err(_) => break,
+                        };
+                        let (seq, item) = job;
+                        if cancel.load(Ordering::Acquire) {
+                            break;
+                        }
+                        let value = panic::catch_unwind(AssertUnwindSafe(|| format(item)))
+                            .map_err(|_| "formatter panicked".to_owned())
+                            .and_then(|v| v);
+                        let value = value.and_then(|v| {
+                            if v.len() > MAX_RESULT {
+                                Err("formatted record exceeds 3145728 bytes".into())
+                            } else {
+                                Ok(v)
+                            }
+                        });
+                        if result_tx.send((seq, value)).is_err() {
+                            break;
+                        }
+                    }
+                }) {
+                Ok(handle) => handles.push(handle),
+                Err(error) => {
+                    failure = Some(format!("cannot start worker: {error}"));
+                    break;
+                }
+            }
+        }
+        drop(result_tx);
+        let mut admitted = 0usize;
+        let mut committed = 0usize;
+        let mut done = false;
+        let mut pending = BTreeMap::new();
+        let coordinator = panic::catch_unwind(AssertUnwindSafe(|| {
+            while failure.is_none() && (!done || committed < admitted) {
+                if cancel.load(Ordering::Acquire) {
+                    failure = Some("cancelled".into());
+                    break;
+                }
+                while !done && admitted - committed < window {
+                    if cancel.load(Ordering::Acquire) {
+                        failure = Some("cancelled".into());
+                        break;
+                    }
+                    match next() {
+                        Ok(Some(v)) => {
+                            if job_tx.send((admitted, v)).is_err() {
+                                failure = Some("worker channel closed".into());
+                                break;
+                            }
+                            admitted += 1
+                        }
+                        Ok(None) => {
+                            done = true;
+                            break;
+                        }
+                        Err(e) => {
+                            failure = Some(e);
+                            break;
+                        }
+                    }
+                }
+                if failure.is_some() {
+                    break;
+                }
+                if committed == admitted {
+                    continue;
+                }
+                match result_rx.recv_timeout(Duration::from_millis(20)) {
+                    Ok((seq, value)) => match value {
+                        Ok(v) => {
+                            pending.insert(seq, v);
+                            while let Some(v) = pending.remove(&committed) {
+                                if cancel.load(Ordering::Acquire) {
+                                    failure = Some("cancelled".into());
+                                    break;
+                                }
+                                if let Err(e) = emit(v) {
+                                    failure = Some(e);
+                                    break;
+                                }
+                                committed += 1
+                            }
+                        }
+                        Err(e) => {
+                            failure = Some(e);
+                            break;
+                        }
+                    },
+                    Err(RecvTimeoutError::Timeout) => continue,
+                    Err(RecvTimeoutError::Disconnected) => {
+                        failure = Some("worker channel closed".into());
+                        break;
+                    }
+                }
+            }
+        }));
+        if coordinator.is_err() {
+            failure = Some("coordinator callback panicked".into());
+        }
+        drop(job_tx);
+        drop(result_rx);
+        for handle in handles {
+            if handle.join().is_err() && failure.is_none() {
+                failure = Some("worker panicked".into())
+            }
+        }
+        failure.map_or(Ok(committed), Err)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Barrier, atomic::AtomicUsize};
+    #[test]
+    fn out_of_order_workers_keep_order_and_bound_entire_uncommitted_window() {
+        let admitted = AtomicUsize::new(0);
+        let committed = AtomicUsize::new(0);
+        let high = AtomicUsize::new(0);
+        let mut output = Vec::new();
+        let mut sequence = 0usize;
+        let count = run(
+            2,
+            &AtomicBool::new(false),
+            || {
+                if sequence == 31 {
+                    return Ok(None);
+                }
+                let value = sequence;
+                sequence += 1;
+                let total = admitted.fetch_add(1, Ordering::SeqCst) + 1;
+                let outstanding = total - committed.load(Ordering::SeqCst);
+                high.fetch_max(outstanding, Ordering::SeqCst);
+                assert!(outstanding <= 4);
+                Ok(Some(value))
+            },
+            |value| {
+                if value % 4 == 0 {
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Ok(vec![value as u8])
+            },
+            |bytes| {
+                output.extend(bytes);
+                committed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(count, 31);
+        assert_eq!(output, (0..31).collect::<Vec<u8>>());
+        assert_eq!(high.load(Ordering::SeqCst), 4);
+    }
+    #[test]
+    fn selected_workers_really_execute_concurrently() {
+        let barrier = Barrier::new(3);
+        let active = AtomicUsize::new(0);
+        let peak = AtomicUsize::new(0);
+        let mut values = 0..6;
+        run(
+            3,
+            &AtomicBool::new(false),
+            || Ok(values.next()),
+            |value| {
+                let concurrent = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(concurrent, Ordering::SeqCst);
+                barrier.wait();
+                active.fetch_sub(1, Ordering::SeqCst);
+                Ok(vec![value])
+            },
+            |_| Ok(()),
+        )
+        .unwrap();
+        assert_eq!(peak.load(Ordering::SeqCst), 3);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+    #[test]
+    fn callback_failures_and_worker_panic_return_without_blocked_joins() {
+        for mode in [
+            "source",
+            "formatter",
+            "writer",
+            "panic",
+            "oversize",
+            "source-panic",
+            "writer-panic",
+        ] {
+            let mut count = 0;
+            let result = run(
+                2,
+                &AtomicBool::new(false),
+                || {
+                    count += 1;
+                    if mode == "source-panic" && count == 3 {
+                        panic!("injected source panic");
+                    }
+                    if mode == "source" && count == 3 {
+                        return Err("source failure".into());
+                    }
+                    Ok((count < 20).then_some(count))
+                },
+                |_| {
+                    if mode == "panic" {
+                        panic!("injected formatter panic");
+                    }
+                    if mode == "formatter" {
+                        return Err("formatter failure".into());
+                    }
+                    if mode == "oversize" {
+                        return Ok(vec![0; MAX_RESULT + 1]);
+                    }
+                    Ok(vec![1])
+                },
+                |_| {
+                    if mode == "writer-panic" {
+                        panic!("injected writer panic");
+                    }
+                    if mode == "writer" {
+                        Err("writer failure".into())
+                    } else {
+                        Ok(())
+                    }
+                },
+            );
+            assert!(result.is_err(), "{mode}");
+        }
+    }
+    #[test]
+    fn invalid_workers_and_precancellation_do_not_admit_input() {
+        for workers in [0, 9] {
+            assert!(
+                run::<()>(
+                    workers,
+                    &AtomicBool::new(false),
+                    || panic!("admitted"),
+                    |_| Ok(vec![]),
+                    |_| Ok(())
+                )
+                .is_err()
+            );
+        }
+        assert_eq!(
+            run::<()>(
+                1,
+                &AtomicBool::new(true),
+                || panic!("admitted"),
+                |_| Ok(vec![]),
+                |_| Ok(())
+            )
+            .unwrap_err(),
+            "cancelled"
+        );
+    }
+    #[test]
+    fn cancellation_while_waiting_joins_workers_without_ordered_output() {
+        let cancel = AtomicBool::new(false);
+        let started = AtomicBool::new(false);
+        let mut emitted = 0;
+        thread::scope(|scope| {
+            scope.spawn(|| {
+                while !started.load(Ordering::Acquire) {
+                    thread::yield_now();
+                }
+                cancel.store(true, Ordering::Release);
+            });
+            let mut values = 0..10;
+            let result = run(
+                2,
+                &cancel,
+                || Ok(values.next()),
+                |_| {
+                    started.store(true, Ordering::Release);
+                    thread::sleep(Duration::from_millis(30));
+                    Ok(vec![0])
+                },
+                |_| {
+                    emitted += 1;
+                    Ok(())
+                },
+            );
+            assert_eq!(result.unwrap_err(), "cancelled");
+        });
+        assert_eq!(emitted, 0);
+    }
+}

--- a/crates/emburk-core/src/configured_csv.rs
+++ b/crates/emburk-core/src/configured_csv.rs
@@ -1,17 +1,18 @@
 //! Private single-file configured CSV execution profile.
 use crate::{
-    csv_stream,
+    bounded_parallel, csv_stream,
     logical_record::{LogicalRecord, LogicalValue},
     logical_schema::{LogicalColumn, LogicalSchema, LogicalType},
     native_formats::{self, Codec, Encoder},
     publication,
-    record_handoff::{RecordSink, RecordSource, SinkError, SourceError, handoff_owned_records},
+    record_handoff::{RecordSource, SourceError},
     yaml_profile::{self, Node},
 };
 use std::{
     fs::{self, File},
     io::{BufRead, Write},
     path::{Path, PathBuf},
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 #[derive(Clone)]
@@ -28,10 +29,14 @@ struct Profile {
     decoder: Codec,
     encoder: Codec,
     projection: Vec<(usize, String)>,
+    workers: usize,
 }
 pub fn run_config(path: &Path) -> Result<usize, String> {
+    run_config_with_cancel(path, &AtomicBool::new(false))
+}
+pub fn run_config_with_cancel(path: &Path, cancel: &AtomicBool) -> Result<usize, String> {
     let p = compile(yaml_profile::load(path)?.compile_node()?)?;
-    execute(p)
+    execute(p, cancel)
 }
 fn scalar(n: &Node) -> Result<&str, String> {
     match n {
@@ -174,7 +179,12 @@ fn compile(root: Node) -> Result<Profile, String> {
     }
     let exec = map(one(top, "exec")?)?;
     exact(exec, &["max_threads", "min_output_tasks"])?;
-    require(exec, "max_threads", "1")?;
+    let workers = scalar(one(exec, "max_threads")?)?
+        .parse::<usize>()
+        .map_err(|_| "invalid max_threads")?;
+    if !(1..=8).contains(&workers) {
+        return Err("max_threads must be 1 through 8".into());
+    }
     require(exec, "min_output_tasks", "1")?;
     let mut projection: Vec<_> = columns
         .iter()
@@ -231,6 +241,7 @@ fn compile(root: Node) -> Result<Profile, String> {
         decoder: codec(input, "decoders", false)?,
         encoder: codec(output, "encoders", true)?,
         projection,
+        workers,
         schema: LogicalSchema::new(
             columns
                 .iter()
@@ -284,7 +295,10 @@ fn codec(mapping: &[(String, Node)], key: &str, encoder: bool) -> Result<Codec, 
     }
     Ok(codec)
 }
-fn execute(profile: Profile) -> Result<usize, String> {
+fn execute(profile: Profile, cancel: &AtomicBool) -> Result<usize, String> {
+    if cancel.load(Ordering::Acquire) {
+        return Err("cancelled".into());
+    }
     let parent = profile
         .input
         .parent()
@@ -321,7 +335,7 @@ fn execute(profile: Profile) -> Result<usize, String> {
         profile: &profile,
         skipped: 0,
     };
-    publication::write_atomic(&profile.output, |output| {
+    publication::write_atomic(&profile.output, cancel, |output| {
         let mut encoded = Encoder::new(output, profile.encoder);
         csv_stream::write_row(
             &mut encoded,
@@ -332,12 +346,16 @@ fn execute(profile: Profile) -> Result<usize, String> {
                 .collect::<Vec<_>>(),
         )
         .map_err(|error| format!("CSV header failed: {error}"))?;
-        let mut sink = Sink {
-            output: &mut encoded,
-            projection: &profile.projection,
-        };
-        let count = handoff_owned_records(&mut source, &mut sink)
-            .map_err(|error| format!("record transfer failed: {error:?}"))?;
+        let count = bounded_parallel::run(
+            profile.workers,
+            cancel,
+            || source.next_record().map_err(|error| error.0),
+            |record| format_record(record, &profile.projection),
+            |bytes| encoded.write_all(&bytes).map_err(|error| error.to_string()),
+        )?;
+        if cancel.load(Ordering::Acquire) {
+            return Err("cancelled".into());
+        }
         encoded
             .finish()
             .map_err(|error| format!("codec finalization failed: {error}"))?;
@@ -425,23 +443,18 @@ impl RecordSource for Source<'_> {
         }
     }
 }
-struct Sink<'a, W: Write> {
-    output: &'a mut W,
-    projection: &'a [(usize, String)],
-}
-impl<W: Write> RecordSink for Sink<'_, W> {
-    fn accept(&mut self, r: LogicalRecord) -> Result<(), SinkError> {
-        let cells = r.cells().collect::<Vec<_>>();
-        let row = self
-            .projection
-            .iter()
-            .map(|(index, _)| match cells[*index] {
-                LogicalValue::Null => None,
-                LogicalValue::Signed64(v) => Some(v.to_string()),
-                LogicalValue::Text(v) => Some(v.clone()),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        csv_stream::write_row(&mut self.output, &row).map_err(|e| SinkError(e.to_string()))
-    }
+fn format_record(r: LogicalRecord, projection: &[(usize, String)]) -> Result<Vec<u8>, String> {
+    let cells = r.cells().collect::<Vec<_>>();
+    let row = projection
+        .iter()
+        .map(|(index, _)| match cells[*index] {
+            LogicalValue::Null => None,
+            LogicalValue::Signed64(v) => Some(v.to_string()),
+            LogicalValue::Text(v) => Some(v.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut output = Vec::new();
+    csv_stream::write_row(&mut output, &row).map_err(|e| e.to_string())?;
+    Ok(output)
 }

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -40,6 +40,7 @@ mod record_handoff;
 // plugin API or a general record-transfer interface.
 mod text_transfer;
 
+mod bounded_parallel;
 mod configured_csv;
 mod csv_stream;
 mod native_formats;
@@ -48,6 +49,8 @@ mod yaml_profile;
 
 #[doc(hidden)]
 pub use configured_csv::run_config;
+#[doc(hidden)]
+pub use configured_csv::run_config_with_cancel;
 #[doc(hidden)]
 pub use text_transfer::transfer_lines;
 

--- a/crates/emburk-core/src/publication.rs
+++ b/crates/emburk-core/src/publication.rs
@@ -3,7 +3,7 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{self, BufWriter, Write},
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
 static NEXT: AtomicU64 = AtomicU64::new(0);
@@ -62,9 +62,16 @@ impl std::fmt::Display for PublicationError {
 
 pub(crate) fn write_atomic<T>(
     target: &Path,
+    cancel: &AtomicBool,
     write: impl FnOnce(&mut BufWriter<File>) -> Result<T, String>,
 ) -> Result<T, PublicationError> {
-    write_with(target, write, |_| Ok(()))
+    write_with(target, write, |phase| {
+        if matches!(phase, Phase::Write | Phase::Link) && cancel.load(Ordering::Acquire) {
+            Err(io::Error::other("cancelled"))
+        } else {
+            Ok(())
+        }
+    })
 }
 
 // The hook is private and is supplied with faults only by unit tests. It runs
@@ -328,13 +335,33 @@ mod tests {
     fn successful_publication_has_one_owner_only_file_and_preserves_value() {
         use std::os::unix::fs::PermissionsExt;
         let target = target();
-        assert_eq!(write_atomic(&target, content).unwrap(), 1);
+        assert_eq!(
+            write_atomic(&target, &AtomicBool::new(false), content).unwrap(),
+            1
+        );
         assert_eq!(fs::read(&target).unwrap(), b"complete\n");
         assert_eq!(
             fs::metadata(&target).unwrap().permissions().mode() & 0o777,
             0o600
         );
         assert_eq!(fs::read_dir(target.parent().unwrap()).unwrap().count(), 1);
+    }
+    #[test]
+    fn cancellation_after_writing_is_checked_again_before_link() {
+        let target = target();
+        let cancel = AtomicBool::new(false);
+        let error = write_atomic(&target, &cancel, |output| {
+            content(output)?;
+            cancel.store(true, Ordering::Release);
+            Ok(())
+        })
+        .unwrap_err();
+        assert_eq!(
+            (error.state, error.phase, error.cleanup),
+            (State::NotPublished, Phase::Link, Cleanup::Removed)
+        );
+        assert!(!target.exists());
+        assert_eq!(fs::read_dir(target.parent().unwrap()).unwrap().count(), 0);
     }
     #[test]
     fn existing_regular_and_symlink_destinations_are_never_replaced() {
@@ -348,7 +375,7 @@ mod tests {
             } else {
                 fs::write(&target, b"old").unwrap();
             }
-            let error = write_atomic(&target, content).unwrap_err();
+            let error = write_atomic(&target, &AtomicBool::new(false), content).unwrap_err();
             assert_eq!(
                 (error.state, error.phase, error.cleanup),
                 (State::NotPublished, Phase::Link, Cleanup::Removed)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,9 @@ plugin types become public, and the empty lifecycle coordinator stays separate.
 ADR-0019 admits the selected native_formats adapter for bounded JSON framing,
 streaming codecs and ordered schema projections inside the configured consumer.
 Dependencies remain private and codec finalization precedes publication.
-T-0033/S01 implementation/acceptance is in progress, not a public plugin API.
+T-0033/S01 integrated through PR #119, not a public plugin API. ADR-0020 now
+defines bounded scoped formatting workers, a single ordered writer, and a
+borrowed cancellation flag. T-0024/S01 implementation/acceptance is in progress.
 
 ADR-0016 extends only CLI composition with stdout locking and std::io::sink
 adapters. Both use the same core transfer entry point; no new public core or

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -16,7 +16,10 @@ plugin. General CSV and configuration behavior outside that selected matrix
 remains unfinished, not an accepted exception. T-0025/S01 integrated native
 no-clobber publication safety through PR #117; its failure policy is not
 observed Embulk parity. T-0014/S02 (#118) supplies five selected real JSON,
-gzip/bzip2 and filter-order observations; T-0033/S01 native acceptance is pending.
+gzip/bzip2 and filter-order observations. T-0033/S01 (#119) matches those five
+selected projections with native execution; codec bytes are compared only
+after decoding. T-0024/S01 develops native bounded workers/cancellation, not
+Embulk scheduler or performance parity.
 
 The implementation objective is strict reproduction of observable behavior for
 the pinned core and admitted plugins. Technical constraints, disproportionate

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,8 @@ after primary and independent eight-case comparison and 81 passing tests.
 This satisfies the bounded stages 2–4 consumer, not full configuration/plugin
 gates. Stage 5 integrated as T-0025/S01 through PR #117 after fault/interruption
 acceptance. Stage 6 reference-only preparation T-0014/S02 integrated through
-PR #118. T-0033/S01 implements the selected native pipeline formats; stage 7
+PR #118. T-0033/S01 integrated stage 6 through PR #119. Stage 7 starts with
+T-0024/S01 bounded ordered formatting/cancellation; validated checkpoint/resume
 and broader parent gates remain open.
 
 ## Phase 0: Governance and Compatibility Contract

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -52,7 +52,9 @@ projections at 59a7cca. T-0025/S01 is Done through PR #117 (aac0003): 87 passes,
 eight existing ignores, actual interruption and operation-failure tests, and
 unchanged eight-case CSV comparison. T-0014/S02 is Done through PR #118:
 nine tests and matching independent five-case format/filter observations.
-T-0033/S01 now implements bounded native formats; stage 7 remains unfinished.
+T-0033/S01 is Done through PR #119 (95b5592): 97 tests and thirteen selected
+comparisons passed independently at 39c97d8. T-0024/S01 now starts stage 7 with
+bounded ordered formatting/cancellation; checkpoint/resume remains unfinished.
 The owner-authorized
 [seven-stage sequence](IMPLEMENTATION_SEQUENCE.md) remains uncompleted work.
 
@@ -81,7 +83,7 @@ strict controls and unchanged S12 regression. T-0031/S01 is Done through PR #110
 (`c5fb13f`) for the explicitly requested experimental native File-to-File path.
 T-0031/S02 is Done through PR #112 (`2ec236e`) for experimental stdout/null
 consumers: 71 tests passed, eight existing intentional ignores, primary and
-independent acceptance at `c5df504`. T-0033/S01 now occupies one WIP lane; the full
+independent acceptance at `c5df504`. T-0024/S01 now occupies one WIP lane; the full
 file/plugin parent stays open. Core transfer semantics remain unchanged.
 
 | Item | State | Purpose |
@@ -99,7 +101,8 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 
 T-0025/S01 is Done through PR #117. T-0014/S02 is Done through PR #118.
-T-0033/S01 uses one lane for native JSON/codecs/filters on its dedicated branch.
+T-0033/S01 is Done through PR #119. T-0024/S01 uses one lane for bounded
+formatting workers and cancellation on its dedicated branch.
 Other unfinished stable tasks remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
 is the coordination mirror. Its 52 items, lifecycle states, initial estimates,

--- a/docs/decisions/ADR-0019-bounded-native-formats.md
+++ b/docs/decisions/ADR-0019-bounded-native-formats.md
@@ -1,6 +1,6 @@
 # ADR-0019: Bounded native formats in the configured pipeline
 
-- Status: Accepted for T-0033/S01 implementation; acceptance pending
+- Status: Accepted; T-0033/S01 integrated through PR #119
 - Date: 2026-09-06
 
 Extend the existing private configured pipeline rather than expose a premature

--- a/docs/decisions/ADR-0020-bounded-format-workers.md
+++ b/docs/decisions/ADR-0020-bounded-format-workers.md
@@ -1,0 +1,19 @@
+# ADR-0020: Bounded ordered format workers
+
+- Status: Accepted for T-0024/S01 implementation; acceptance pending
+- Date: 2026-09-06
+
+Use at most eight scoped native format workers with admission window twice the
+worker count. The window counts every admitted but not committed row, not just
+queued jobs. A serial parser produces owned records; workers format; one
+coordinator preserves order and owns codec output/publication. Result size and
+record size have explicit caps. Queues and pending results share the window.
+
+Core cancellation is a borrowed AtomicBool. The CLI admits the pinned ctrlc
+platform adapter solely to set that flag on SIGINT. On cancellation or failure,
+close channels and join all workers. Publication remains irreversible once its
+hard link succeeds; a late cancellation must not remove output. Existing line
+commands and generic plugin/lifecycle contracts are unchanged.
+
+This is original native scheduling, not an Embulk concurrency/performance
+claim. Validated checkpoint/resume is a subsequent independently accepted slice.

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -486,3 +486,8 @@ and independent Demo at dad393c3: nine tests and five matching real projections.
 T-0033/S01 admits the exact reviewed JSON/codec dependency subset and begins
 the bounded stage-6 consumer. Attribution is recorded; full release/security/
 patent clearance and all broader plugin/resume claims remain unreviewed/open.
+
+T-0033/S01 integrated through PR #119 (95b5592), accepting 8 SP after exact
+primary and independent Demo at 39c97d8: 97 tests, eight existing ignores,
+eight CSV and five additional format/filter matches. Stage 6 is accepted only
+within that bounded profile. T-0024/S01 starts stage 7; validated resume follows.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -40,6 +40,7 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0032/S01 configured CSV](T-0032-configured-csv.md) | Done through PR #116; eight selected comparisons and 81 tests |
 | [T-0025/S01 safe publication](T-0025-safe-publication.md) | Done through PR #117; fault/interruption acceptance |
 | [T-0014/S02 format/filter observations](T-0014-formats-oracle.md) | Done through PR #118; five real reference cases |
-| [T-0033/S01 native formats](T-0033-native-formats.md) | In Progress; bounded JSON/codecs/filters |
+| [T-0033/S01 native formats](T-0033-native-formats.md) | Done through PR #119; thirteen selected comparisons |
+| [T-0024/S01 bounded workers](T-0024-bounded-parallel.md) | In Progress; native ordering/admission/cancellation |
 | [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | Done, PR #110; native-only record consumer |
 | [T-0031/S02 experimental stdout/null](T-0031-output-targets.md) | Done, PR #112; unchanged core transfer |

--- a/docs/provenance/T-0024-bounded-parallel.md
+++ b/docs/provenance/T-0024-bounded-parallel.md
@@ -1,0 +1,93 @@
+# T-0024/S01 bounded formatting and cancellation
+
+Issue: [#21](https://github.com/bhind/emburk/issues/21). State: In Progress.
+Forecast: 5 SP. First independently acceptable part of stage 7; resume follows.
+
+## Authority and dependencies
+
+Owner authorized stages 1–7 and routine testing/integration absent incidents.
+T-0033/S01 integrated through PR #119 (95b5592), with 97 tests and thirteen
+selected comparisons at 39c97d8. Existing publication states remain unchanged.
+No Embulk scheduling/performance parity is inferred from native unit evidence.
+
+## Branch and allowlist
+
+Branch feat/t-0024-bounded-parallel. PM owns initial dependency metadata changes
+to Cargo.lock and crates/emburk-cli/Cargo.toml. Rust Core Implementer then owns
+only core/src/bounded_parallel.rs under crates/emburk-core; after that adapter
+returns, PM serially owns integration in core/src/lib.rs and configured_csv.rs,
+CLI src/main.rs and tests/bounded_parallel.rs, plus adapter review fixes.
+No concurrent source mutation. PM owns this packet, ADR-0020, STATUS/TODO/
+ROADMAP/COMPATIBILITY/ARCHITECTURE, implementation sequence, provenance index,
+T-0033 closeout, ADR-0019 status, third-party notices and daily log.
+Reviewers are read-only. PM additionally owns publication.rs only for a borrowed
+cancel flag check immediately before linking and its regression test. This is
+required to cover cancellation during flush/sync; publication states and
+no-clobber behavior remain unchanged. Do not mutate old regression sources.
+
+The adapter returned uncompiled without tests; PM then took serial ownership
+of the same source allowlist for compilation, integration and acceptance tests.
+
+## Dependency admission
+
+Add ctrlc=3.5.2 to the CLI only, default features (no termination feature).
+Official exact archive accessed 2026-09-06:
+https://static.crates.io/crates/ctrlc/ctrlc-3.5.2.crate, SHA256
+e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162.
+Compare all new lock entries with the previously verified prospective archive
+inventory before building. Selected platform graph: Unix nix/libc; macOS
+dispatch2/block2/objc2; Windows entries are lock-only here. Licenses are MIT or
+Apache-2.0 except dispatch2 (Zlib/Apache/MIT) and block2/objc2/objc2-encode (MIT).
+No new unsafe code in Emburk. Dependency unsafe/platform code is not audited
+by forbid(unsafe_code). Only API usage and manifest/build/license metadata
+influences this original adapter. Full security/SBOM/patent/FTO remains
+unreviewed; no redistribution or legal clearance claim. Stop on graph change
+or tool approval denial. sha2 is not admitted by this slice.
+
+The resolved registry lock contains 34 entries, all matching the prior exact
+archive inventory or integrated graph. Inspected new build.rs in nix 0.31.3,
+objc2 0.6.4 and libc 0.2.189: platform cfg generation, compiler/version probes
+(including optional emcc/freebsd-version probes), not an installer. Their
+package archive checksums/versions are fixed in Cargo.lock. No source bodies
+from Embulk were read or copied for this original scheduler.
+
+## Acceptance
+
+Configured exec.max_threads accepts 1–8 with min_output_tasks=1. Source parsing
+remains serial; worker threads format independent owned records, and only the
+coordinator writes results in source order. Admission counts the entire
+uncommitted window (queued, executing and out-of-order completed), at most
+2 * workers <=16 records. A worker count alone is not the memory bound.
+Selected record payload is <=1 MiB (existing CSV/JSON limits); formatted result
+is <=3 MiB including escaping/column overhead. Bound queues and reordering by
+the same window. Report worker panic/error instead of silently losing a row.
+No all-file collection, unbounded reorder map or blocked-join failure path.
+
+CLI SIGINT sets an AtomicBool through ctrlc; core only sees that borrowed
+cancellation flag. Check before admission, while waiting, before ordered write,
+and before encoder finalization. Pre-publication cancellation returns nonzero
+(CLI 130) and does not publish; cancel after irreversible publication cannot
+delete or roll back a target. Drop senders/receivers and join every worker on
+error/cancel. No hard interrupt latency promise for blocking filesystem I/O.
+
+Tests force out-of-order completion, admission high-water limit, source/worker/
+writer failure, panic, pre-cancellation and cancellation while waiting. Actual
+CLI tests compare serial/parallel bytes across selected CSV/JSON/codecs/filters,
+reject 0/>8 workers before output, and signal an active child with SIGINT then
+reap it, verifying unpublished output and cleanup. Keep all existing tests and
+both selected real-reference drivers. No benchmark/speedup claim is accepted.
+
+## Demo Command
+
+`cargo fmt --all -- --check && cargo clippy --locked --workspace --all-targets -- -D warnings && cargo test --locked --workspace && bash tests/t0032_configured_csv_differential_test.sh && bash tests/t0033_native_formats_differential_test.sh && git diff --check`
+
+Pinned local EMBURK_REFERENCE_JAR and Java17 JAVA_HOME are required. Retain
+final-head primary/independent command logs, hashes and numeric exits.
+
+## Evidence class, stop rule and non-claims
+
+Unit/Contract and local Integration, selected differential regressions only.
+Stop on unbounded admission, ordering mismatch, deadlock, unjoined worker,
+unsafe output, dependency/IP issue or unexplained reference mismatch. No full
+scheduler/plugin parity, speedup/RSS benchmark, multi-input/output scheduling,
+hard real-time cancellation, checkpoint or resume acceptance follows yet.

--- a/docs/provenance/T-0033-native-formats.md
+++ b/docs/provenance/T-0033-native-formats.md
@@ -1,6 +1,6 @@
 # T-0033/S01 bounded native formats and filters
 
-Issue: [#26](https://github.com/bhind/emburk/issues/26). State: In Progress.
+Issue: [#26](https://github.com/bhind/emburk/issues/26). State: Done through PR #119.
 Forecast: 8 SP. One independently acceptable stage-6 configured-pipeline slice;
 JSON, codec and filter parent tasks remain open outside the selected profile.
 
@@ -100,6 +100,25 @@ Set the pinned local EMBURK_REFERENCE_JAR and Java17 JAVA_HOME. Retain final-hea
 primary/independent evidence and negative controls; no points before integration.
 
 ## Evidence class, stop rule and non-claims
+
+Accepted 8 SP through merge 95b5592cfb9c344fd44203501d89edcb3d942e4c.
+Primary and independent exact Demo passed at
+39c97d86165d1a23e5a7d929d229942c358de351: 97 tests passed, eight existing
+intentional ignores; all eight CSV and five format/filter comparisons matched.
+Fmt/strict locked Clippy/diff-check passed. Negative forced exit mismatch under
+PYTHONOPTIMIZE returned 1 with incomplete retained evidence. No concrete defect
+found in read-only review. macOS arm64, Rust/Cargo 1.98.1, Java17.
+
+Primary /private/tmp/t0033-s01-primary.CzzNmN stdout SHA256
+4167421e21da60d60ab15d3448d94f972f9da42d4ba418e3b4c6d4b7621f5870;
+stderr 080f5b01bf72db11c7b74c2b6ae1e147e7e8d9872edbf8120c7c1fcb714b393d.
+Independent /private/tmp/emburk-t0033-acceptance.72IInY stdout SHA256
+ef2b624e5938d6fdc7ba91ff77fb6873d3212fe166b777f2fa51e57e329a0bc9;
+stderr 19f60937c3b8d111a50f0a9b51719b6958cdeb6b9c936209dc875ba78bce379b.
+Both exit 0; exit-file SHA256
+9a271f2a916b0b6ee6cecb2426f0b3206ef074578be55d9bc94f6f3fe3ab86aa.
+Parent #26 remains Backlog; Current 8 / Initial 5 unchanged. No points awarded
+to broader codec/filter parents by implication.
 
 Selected Differential plus Unit/Contract and local Integration. Stop on new
 unreviewed dependency, codec finalization/cleanup failure, unexplained reference


### PR DESCRIPTION
Implements T-0024/S01 (Issue #21), forecast 5 SP. Adds bounded ordered formatting workers (1–8), whole-window backpressure, panic/error cleanup, SIGINT cancellation and a final pre-publication check. Source parsing remains serial; resume is a separate slice. Primary and independent exact Demo passed at 4970e46a5cae9891743e78a07ef9cd418f0559ba: 106 tests passed, 8 intentional ignores, all 13 selected live Embulk comparisons matched. Evidence directories: /private/tmp/t0024-s01-primary.R6aQam and /private/tmp/t0024-s01-independent.IZVa9s. No full scheduler parity, performance or resume claim. Canonical packet: docs/provenance/T-0024-bounded-parallel.md. Parent remains open.