### PR TITLE
feat(t-0025): validated native spool resume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,12 +60,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -68,6 +95,16 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -98,6 +135,7 @@ dependencies = [
  "flate2",
  "saphyr-parser",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -108,6 +146,15 @@ checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -242,6 +289,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +335,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Emburk is an independent, Rust-native bulk data loader inspired by Embulk. It is intended to give existing Embulk users a practical migration path while developing a smaller, safer, and more observable execution engine.
 
-Emburk is at the bootstrap stage. The current binary only verifies the Rust development environment; it does not transfer data yet.
+Emburk has an experimental native File-to-File pipeline with a bounded configuration profile, CSV and JSON input, CSV output, gzip/bzip2 codecs, column filters, ordered parallel formatting, and cooperative cancellation. Selected results are compared against pinned Embulk artifacts. General plugin compatibility, validated recovery, and production readiness remain under development.
 
 ## Why Emburk
 
@@ -17,7 +17,7 @@ Embulk demonstrated the value of a pluggable, parallel data loader, but the upst
 - **Rust-native by default:** the execution core and progressively reimplemented plugins are designed to run without a JVM.
 - **Compact core:** the core is designed to own orchestration and stable contracts, while utilities and integrations stay outside it.
 - **Pluggable by design:** built-ins are intended to be statically linked; external plugins will use a versioned, isolated protocol.
-- **Practical migration:** optional JVM and JRuby hosts provide a bridge for selected unported plugins.
+- **Practical migration:** planned optional JVM and JRuby hosts will bridge selected unported plugins.
 - **Correctness before speed:** transactions, cleanup, cancellation, and resume behavior are specified and tested before optimization.
 - **Evidence-based compatibility:** support is claimed only for pinned versions that pass differential tests against Embulk.
 - **Traceable reimplementation:** upstream behavior and design documents may inform Emburk, but source is not mechanically translated into Rust.
@@ -47,6 +47,7 @@ Embulk demonstrated the value of a pluggable, parallel data loader, but the upst
 - [Roadmap](docs/ROADMAP.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Compatibility](docs/COMPATIBILITY.md)
+- [Experimental native pipeline](docs/NATIVE_PIPELINE.md)
 - [Documentation index](docs/README.md)
 
 ## Independence and License

--- a/TODO.md
+++ b/TODO.md
@@ -46,8 +46,11 @@ Parent #17 remains Backlog, S01/S02 total 8 SP, Initial/Current 8 unchanged.
 T-0033/S01 is Done through PR #119 (95b5592), accepting 8 SP after independent
 97-test/thirteen-comparison Demo at 39c97d8. Parent #26 remains Backlog,
 Current 8 / Initial 5 unchanged. Full T-0033/T-0034/T-0035 parents remain
-unaccepted. T-0024/S01 is In Progress (forecast 5 SP) for bounded formatting
-and cancellation; parent Current/Initial 8 unchanged, resume follows separately.
+unaccepted. T-0024/S01 is Done through PR #120 (24b99fa), accepting 5 SP
+after primary and independent Demo at 4970e46: 106 passes, eight intentional
+ignores and thirteen selected comparisons. Parent Current/Initial 8 unchanged.
+T-0025/S02 is In Progress (forecast 8 SP) for validated native resume. Parent
+Current 13 includes accepted S01 (5 SP) and this forecast; Initial remains 8.
 
 T-0031/S01 is Done through PR #110 (`c5fb13f`), accepting 5 SP, for a native UTF-8 line-record
 File-to-File command under ADR-0015. It consumes T-0021/S06 without claiming
@@ -93,8 +96,8 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0021 | Define workspace boundaries and core traits (S01–S06 integrated; remaining contracts queued) | Backlog | P1 | 13 | T-0012, T-0013 | Rust Core Implementer | Unit/Contract |
 | T-0022 | Implement configuration loading and the MVP CLI (S01 Done) | Backlog | P1 | 8 | T-0021 | Rust Core Implementer | Unit/Contract |
 | T-0023 | Implement logical schema and Arrow-compatible batches (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 21 | T-0012, T-0021 | Compatibility Host Implementer | Differential (Embulk) |
-| T-0024 | Implement bounded scheduling, backpressure, and cancellation (S01 active) | In Progress | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
-| T-0025 | Implement atomic transaction and resume state (publication S01 Done) | Backlog | P1 | 8 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
+| T-0024 | Implement bounded scheduling, backpressure, and cancellation (S01 Done) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
+| T-0025 | Implement atomic transaction and resume state (S01 Done; S02 active) | In Progress | P1 | 13 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
 | T-0026 | Implement structured errors and observability | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |
 
 ## T-0030 — Native File-to-File ETL

--- a/crates/emburk-cli/src/main.rs
+++ b/crates/emburk-cli/src/main.rs
@@ -24,12 +24,22 @@ fn main() {
         )
     {
         println!(
-            "Usage: emburk run CONFIG\n       emburk transfer-lines INPUT OUTPUT\n       emburk transfer-lines-stdout INPUT\n       emburk transfer-lines-null INPUT"
+            "Usage: emburk run CONFIG [--state STATE_DIR]\n       emburk resume CONFIG STATE_DIR\n       emburk transfer-lines INPUT OUTPUT\n       emburk transfer-lines-stdout INPUT\n       emburk transfer-lines-null INPUT"
         );
         return;
     }
     let cancelled = Arc::new(AtomicBool::new(false));
     let (command, result) = match arguments.as_slice() {
+        #[cfg(unix)]
+        [_, command, config, flag, directory] if command == "run" && flag == "--state" => (
+            "run",
+            stateful(Path::new(config), Path::new(directory), &cancelled, false),
+        ),
+        #[cfg(unix)]
+        [_, command, config, directory] if command == "resume" => (
+            "resume",
+            stateful(Path::new(config), Path::new(directory), &cancelled, true),
+        ),
         [_, command, config] if command == "run" => {
             let signal_flag = Arc::clone(&cancelled);
             let result = ctrlc::set_handler(move || signal_flag.store(true, Ordering::Release))
@@ -62,6 +72,18 @@ fn main() {
             1
         });
     }
+}
+
+#[cfg(unix)]
+fn stateful(
+    config: &Path,
+    directory: &Path,
+    cancelled: &Arc<AtomicBool>,
+    resume: bool,
+) -> Result<(), String> {
+    let flag = Arc::clone(cancelled);
+    ctrlc::set_handler(move || flag.store(true, Ordering::Release)).map_err(|e| e.to_string())?;
+    emburk_core::run_config_resumable(config, directory, cancelled, resume).map(|_| ())
 }
 
 fn open_input(input: &Path) -> Result<File, String> {

--- a/crates/emburk-cli/tests/validated_resume.rs
+++ b/crates/emburk-cli/tests/validated_resume.rs
@@ -1,0 +1,261 @@
+#![cfg(unix)]
+use std::{
+    fs::{self, File, OpenOptions},
+    io::Write,
+    os::unix::fs::{MetadataExt, PermissionsExt},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::atomic::{AtomicUsize, Ordering},
+    thread,
+    time::{Duration, Instant},
+};
+static NEXT: AtomicUsize = AtomicUsize::new(0);
+fn root() -> PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "emburk-resume-cli-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir(&p).unwrap();
+    fs::create_dir(p.join("output")).unwrap();
+    p
+}
+fn config(json: bool, codec: &str) -> String {
+    let parser = if json {
+        "    type: json\n"
+    } else {
+        "    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    skip_header_lines: 1\n"
+    };
+    format!(
+        "in:\n  type: file\n  path_prefix: input\n  parser:\n{parser}    columns:\n    - {{name: id, type: long}}\n    - {{name: name, type: string}}\nfilters:\n- type: rename\n  columns: {{name: label}}\nout:\n  type: file\n  path_prefix: output/result\n  file_ext: csv\n{codec}  formatter:\n    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    header_line: true\n    quote_policy: MINIMAL\nexec:\n  max_threads: 4\n  min_output_tasks: 1\n"
+    )
+}
+fn command(p: &Path, args: &[&str]) -> Command {
+    let mut c = Command::new(env!("CARGO_BIN_EXE_emburk"));
+    c.current_dir(p).args(args);
+    c
+}
+fn run(p: &Path, args: &[&str], success: bool) {
+    let result = command(p, args).output().unwrap();
+    assert_eq!(
+        result.status.success(),
+        success,
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+fn interrupted(json: bool, codec: &str) -> PathBuf {
+    let p = root();
+    fs::write(p.join("config.yml"), config(json, codec)).unwrap();
+    let mut input = File::create_new(p.join("input")).unwrap();
+    if !json {
+        input.write_all(b"id,name\n").unwrap();
+    }
+    let row = if json {
+        b"{\"id\":1,\"name\":\"abcdefghijklmnopqrstuvwxyz\"}\n".as_slice()
+    } else {
+        b"1,abcdefghijklmnopqrstuvwxyz\n".as_slice()
+    };
+    let block = row.repeat(4096);
+    for _ in 0..64 {
+        input.write_all(&block).unwrap();
+    }
+    drop(input);
+    let log = File::create_new(p.join("interruption.stderr")).unwrap();
+    let mut child = command(&p, &["run", "config.yml", "--state", "state"])
+        .stderr(log)
+        .stdout(Stdio::null())
+        .spawn()
+        .unwrap();
+    let start = Instant::now();
+    let mut active = false;
+    while start.elapsed() < Duration::from_secs(10) {
+        if p.join("state/00000000000000000001.json").exists() {
+            active = true;
+            break;
+        }
+        if child.try_wait().unwrap().is_some() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(2));
+    }
+    if active {
+        assert!(
+            Command::new("/bin/kill")
+                .args(["-INT", &child.id().to_string()])
+                .status()
+                .unwrap()
+                .success()
+        );
+    } else {
+        let _ = child.kill();
+    }
+    let deadline = Instant::now();
+    while child.try_wait().unwrap().is_none() && deadline.elapsed() < Duration::from_secs(10) {
+        thread::sleep(Duration::from_millis(5));
+    }
+    if child.try_wait().unwrap().is_none() {
+        child.kill().unwrap();
+    }
+    let status = child.wait().unwrap();
+    assert!(active, "no durable active checkpoint: {}", p.display());
+    assert_eq!(status.code(), Some(130));
+    assert!(!p.join("output/result000.00.csv").exists());
+    p
+}
+#[test]
+fn actual_sigint_resume_matches_plain_run_and_repeated_resume_preserves_inode() {
+    for (json, codec) in [
+        (false, ""),
+        (true, ""),
+        (false, "  encoders:\n  - {type: gzip, level: 6}\n"),
+        (true, "  encoders:\n  - {type: bzip2, level: 9}\n"),
+    ] {
+        let p = interrupted(json, codec);
+        run(&p, &["resume", "config.yml", "state"], true);
+        let output = p.join("output/result000.00.csv");
+        let bytes = fs::read(&output).unwrap();
+        let ino = fs::metadata(&output).unwrap().ino();
+        run(&p, &["resume", "config.yml", "state"], true);
+        assert_eq!(fs::metadata(&output).unwrap().ino(), ino);
+        let baseline = root();
+        fs::copy(p.join("input"), baseline.join("input")).unwrap();
+        fs::copy(p.join("config.yml"), baseline.join("config.yml")).unwrap();
+        run(&baseline, &["run", "config.yml"], true);
+        assert_eq!(
+            bytes,
+            fs::read(baseline.join("output/result000.00.csv")).unwrap()
+        );
+    }
+}
+#[test]
+fn tampering_is_rejected_without_truncating_spool_or_touching_output() {
+    for kind in [
+        "input",
+        "config",
+        "spool",
+        "generation",
+        "conflict",
+        "permissions",
+        "extra-input",
+    ] {
+        let p = interrupted(false, "");
+        let spool = p.join("state/spool");
+        OpenOptions::new()
+            .append(true)
+            .open(&spool)
+            .unwrap()
+            .write_all(b"uncheckpointed-tail")
+            .unwrap();
+        match kind {
+            "input" => {
+                OpenOptions::new()
+                    .append(true)
+                    .open(p.join("input"))
+                    .unwrap()
+                    .write_all(b"2,changed\n")
+                    .unwrap();
+            }
+            "config" => {
+                OpenOptions::new()
+                    .append(true)
+                    .open(p.join("config.yml"))
+                    .unwrap()
+                    .write_all(b"\n# changed\n")
+                    .unwrap();
+            }
+            "spool" => {
+                OpenOptions::new()
+                    .write(true)
+                    .open(&spool)
+                    .unwrap()
+                    .write_all(b"corrupt")
+                    .unwrap();
+            }
+            "generation" => {
+                fs::remove_file(p.join("state/00000000000000000000.json")).unwrap();
+            }
+            "conflict" => {
+                fs::write(p.join("output/result000.00.csv"), b"untouched").unwrap();
+            }
+            "permissions" => {
+                fs::set_permissions(&spool, fs::Permissions::from_mode(0o644)).unwrap();
+            }
+            "extra-input" => {
+                fs::write(p.join("input-extra"), b"id,name\n").unwrap();
+            }
+            _ => unreachable!(),
+        }
+        let before = fs::read(&spool).unwrap();
+        run(&p, &["resume", "config.yml", "state"], false);
+        assert_eq!(before, fs::read(&spool).unwrap());
+        if kind == "conflict" {
+            assert_eq!(
+                fs::read(p.join("output/result000.00.csv")).unwrap(),
+                b"untouched"
+            );
+        } else {
+            assert!(!p.join("output/result000.00.csv").exists());
+        }
+    }
+}
+#[test]
+fn valid_tail_recovery_lock_exclusion_and_missing_state_are_safe() {
+    let p = interrupted(false, "");
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(p.join("state/lock"))
+        .unwrap();
+    lock.try_lock().unwrap();
+    run(&p, &["resume", "config.yml", "state"], false);
+    drop(lock);
+    OpenOptions::new()
+        .append(true)
+        .open(p.join("state/spool"))
+        .unwrap()
+        .write_all(b"partial trailing record")
+        .unwrap();
+    run(&p, &["resume", "config.yml", "state"], true);
+    run(&p, &["resume", "config.yml", "absent"], false);
+    assert!(!p.join("absent").exists());
+    let target = p.join("output/result000.00.csv");
+    let bytes = fs::read(&target).unwrap();
+    fs::rename(&target, p.join("original-output")).unwrap();
+    fs::write(&target, &bytes).unwrap();
+    run(&p, &["resume", "config.yml", "state"], false);
+    assert_eq!(fs::read(&target).unwrap(), bytes);
+}
+
+#[test]
+fn modeled_crashes_before_and_after_output_link_recover() {
+    for linked in [true, false] {
+        let p = root();
+        fs::write(p.join("config.yml"), config(false, "")).unwrap();
+        fs::write(p.join("input"), b"id,name\n1,Ada\n").unwrap();
+        run(&p, &["run", "config.yml", "--state", "state"], true);
+        let output = p.join("output/result000.00.csv");
+        let ino = fs::metadata(&output).unwrap().ino();
+        let mut generations = fs::read_dir(p.join("state"))
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .filter(|p| p.extension().is_some_and(|s| s == "json"))
+            .collect::<Vec<_>>();
+        generations.sort();
+        // Removing only the final Published generation reproduces the persisted
+        // Publishing state observable after a crash immediately after output link.
+        fs::remove_file(generations.last().unwrap()).unwrap();
+        if !linked {
+            // Retain the original inode away from the destination to model a
+            // durable prepared checkpoint whose output was never linked.
+            fs::rename(&output, p.join("prepared-not-linked")).unwrap();
+        }
+        run(&p, &["resume", "config.yml", "state"], true);
+        assert_eq!(fs::read(&output).unwrap(), b"id,label\n1,Ada\n");
+        if linked {
+            assert_eq!(fs::metadata(output).unwrap().ino(), ino);
+        } else {
+            assert_ne!(fs::metadata(output).unwrap().ino(), ino);
+        }
+    }
+}

--- a/crates/emburk-core/Cargo.toml
+++ b/crates/emburk-core/Cargo.toml
@@ -9,3 +9,4 @@ saphyr-parser = { version = "=0.0.11", default-features = false }
 serde_json = "=1.0.151"
 flate2 = { version = "=1.1.10", default-features = false, features = ["miniz_oxide"] }
 bzip2 = "=0.6.1"
+sha2 = { version = "=0.11.0", default-features = false }

--- a/crates/emburk-core/src/checkpoint.rs
+++ b/crates/emburk-core/src/checkpoint.rs
@@ -1,0 +1,537 @@
+//! Private, bounded Unix formatted-spool checkpoints. Not an Embulk state format.
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{Read, Seek, SeekFrom, Write},
+    os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt},
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+const MAX_MANIFEST: u64 = 64 * 1024;
+const MAX_SPOOL: u64 = 8 * 1024 * 1024 * 1024;
+const MAX_GENERATIONS: u64 = 65536;
+static NEXT: AtomicU64 = AtomicU64::new(0);
+type Result<T> = std::result::Result<T, String>;
+fn error(e: impl std::fmt::Display) -> String {
+    e.to_string()
+}
+pub(crate) fn hash(bytes: &[u8]) -> String {
+    hex(Sha256::digest(bytes).as_slice())
+}
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+fn digest_file(file: &mut File, length: u64) -> Result<Sha256> {
+    file.seek(SeekFrom::Start(0)).map_err(error)?;
+    let mut remaining = length;
+    let mut digest = Sha256::new();
+    let mut bytes = [0; 65536];
+    while remaining != 0 {
+        let size = bytes.len().min(remaining as usize);
+        let count = file.read(&mut bytes[..size]).map_err(error)?;
+        if count == 0 {
+            return Err("truncated checkpoint content".into());
+        }
+        digest.update(&bytes[..count]);
+        remaining -= count as u64;
+    }
+    Ok(digest)
+}
+pub(crate) fn identity(path: &Path) -> Result<Value> {
+    let metadata = fs::symlink_metadata(path).map_err(error)?;
+    if !metadata.is_file() {
+        return Err("identity requires a regular non-symlink file".into());
+    }
+    let mut file = File::open(path).map_err(error)?;
+    let digest = digest_file(&mut file, metadata.len())?;
+    if file.metadata().map_err(error)?.len() != metadata.len() {
+        return Err("file changed while hashing".into());
+    }
+    Ok(
+        json!({"dev":metadata.dev(),"ino":metadata.ino(),"len":metadata.len(),"sha256":hex(&digest.finalize())}),
+    )
+}
+fn private(path: &Path, directory: bool) -> Result<()> {
+    let m = fs::symlink_metadata(path).map_err(error)?;
+    if (directory && !m.is_dir())
+        || (!directory && !m.is_file())
+        || m.mode() & 0o777 != if directory { 0o700 } else { 0o600 }
+    {
+        return Err(format!(
+            "unsafe state type or permissions: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+fn fields(value: &Value, keys: &[&str]) -> Result<()> {
+    let object = value.as_object().ok_or("checkpoint object required")?;
+    if object.len() != keys.len() || keys.iter().any(|key| !object.contains_key(*key)) {
+        return Err("checkpoint fields differ".into());
+    }
+    Ok(())
+}
+fn number(value: &Value, key: &str) -> Result<u64> {
+    value[key]
+        .as_u64()
+        .ok_or_else(|| format!("invalid checkpoint {key}"))
+}
+fn validate_identity(value: &Value) -> Result<()> {
+    fields(value, &["dev", "ino", "len", "sha256"])?;
+    for key in ["dev", "ino", "len"] {
+        number(value, key)?;
+    }
+    let digest = value["sha256"].as_str().ok_or("invalid content hash")?;
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return Err("invalid content hash".into());
+    }
+    Ok(())
+}
+pub(crate) struct State {
+    root: PathBuf,
+    _lock: File,
+    pub(crate) spool: File,
+    pub(crate) latest: Value,
+    digest: Sha256,
+    length: u64,
+    records: u64,
+    saved_length: u64,
+    saved_records: u64,
+    previous: Value,
+    next: u64,
+}
+impl State {
+    pub(crate) fn open(root: &Path, context: Value, resume: bool) -> Result<Self> {
+        if !resume {
+            fs::DirBuilder::new()
+                .mode(0o700)
+                .create(root)
+                .map_err(error)?;
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(root.join("lock"))
+                .map_err(error)?;
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(root.join("spool"))
+                .map_err(error)?;
+            File::open(root).and_then(|f| f.sync_all()).map_err(error)?;
+        }
+        private(root, true)?;
+        private(&root.join("lock"), false)?;
+        let lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(root.join("lock"))
+            .map_err(error)?;
+        lock.try_lock()
+            .map_err(|e| format!("state lock unavailable: {e}"))?;
+        private(&root.join("spool"), false)?;
+        let spool = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(root.join("spool"))
+            .map_err(error)?;
+        let metadata = spool.metadata().map_err(error)?;
+        if metadata.nlink() != 1 || metadata.len() > MAX_SPOOL {
+            return Err("unsafe spool identity or size".into());
+        }
+        let run = format!(
+            "{}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(error)?
+                .as_nanos(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut state = Self {
+            root: root.to_owned(),
+            _lock: lock,
+            spool,
+            latest: json!({"version":1,"sequence":0,"previous":null,"run_id":run,"context":context,"phase":"Writing","spool":{"dev":metadata.dev(),"ino":metadata.ino(),"len":0,"sha256":hash(b"")},"records":0,"prepared":null}),
+            digest: Sha256::new(),
+            length: 0,
+            records: 0,
+            saved_length: 0,
+            saved_records: 0,
+            previous: Value::Null,
+            next: 0,
+        };
+        if resume {
+            state.load()?;
+        }
+        Ok(state)
+    }
+    fn load(&mut self) -> Result<()> {
+        let context = self.latest["context"].clone();
+        let mut generations = Vec::new();
+        let mut entries = 0;
+        for entry in fs::read_dir(&self.root).map_err(error)? {
+            entries += 1;
+            if entries > MAX_GENERATIONS * 2 + 2 {
+                return Err("state entry limit exceeded".into());
+            }
+            let entry = entry.map_err(error)?;
+            let name = entry
+                .file_name()
+                .into_string()
+                .map_err(|_| "invalid state filename")?;
+            if name == "spool" || name == "lock" {
+                continue;
+            }
+            private(&entry.path(), false)?;
+            if let Some(digits) = name.strip_suffix(".json") {
+                if digits.len() != 20 || !digits.bytes().all(|b| b.is_ascii_digit()) {
+                    return Err("invalid generation filename".into());
+                }
+                generations.push((digits.parse::<u64>().map_err(error)?, entry.path()));
+            } else if let Some(digits) = name
+                .strip_prefix(".checkpoint-")
+                .and_then(|s| s.strip_suffix(".tmp"))
+            {
+                if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit() || b == b'-') {
+                    return Err("unknown checkpoint residue".into());
+                }
+            } else {
+                return Err("unknown state entry".into());
+            }
+        }
+        generations.sort_by_key(|item| item.0);
+        if generations.is_empty() || generations.len() as u64 > MAX_GENERATIONS {
+            return Err("missing or excessive generations".into());
+        }
+        let mut run = None;
+        let mut prior_length = 0;
+        let mut prior_records = 0;
+        let mut prior_phase = "Writing".to_owned();
+        for (expected, (sequence, path)) in generations.into_iter().enumerate() {
+            if sequence != expected as u64 {
+                return Err("checkpoint chain gap".into());
+            }
+            let mut bytes = Vec::new();
+            File::open(path)
+                .map_err(error)?
+                .take(MAX_MANIFEST + 1)
+                .read_to_end(&mut bytes)
+                .map_err(error)?;
+            if bytes.len() as u64 > MAX_MANIFEST {
+                return Err("manifest too large".into());
+            }
+            let value: Value = serde_json::from_slice(&bytes).map_err(error)?;
+            if serde_json::to_vec(&value).map_err(error)? != bytes {
+                return Err("noncanonical or duplicate checkpoint fields".into());
+            }
+            fields(
+                &value,
+                &[
+                    "version", "sequence", "previous", "run_id", "context", "phase", "spool",
+                    "records", "prepared",
+                ],
+            )?;
+            validate_identity(&value["spool"])?;
+            if !value["prepared"].is_null() {
+                validate_identity(&value["prepared"])?;
+            }
+            let phase = value["phase"].as_str().ok_or("invalid phase")?;
+            if phase == "Published"
+                && (!matches!(prior_phase.as_str(), "Publishing" | "Published")
+                    || value["prepared"] != self.latest["prepared"])
+            {
+                return Err("published identity differs from prepared generation".into());
+            }
+            if !matches!(phase, "Writing" | "Ready" | "Publishing" | "Published")
+                || (prior_phase != "Writing" && phase == "Writing")
+                || (prior_phase == "Published" && phase != "Published")
+            {
+                return Err("invalid checkpoint phase transition".into());
+            }
+            let length = number(&value["spool"], "len")?;
+            let records = number(&value, "records")?;
+            if value["version"] != 1
+                || number(&value, "sequence")? != sequence
+                || value["previous"] != self.previous
+                || value["context"] != context
+                || length > MAX_SPOOL
+                || length < prior_length
+                || records < prior_records
+                || records > MAX_SPOOL
+                || value["spool"]["dev"] != self.latest["spool"]["dev"]
+                || value["spool"]["ino"] != self.latest["spool"]["ino"]
+            {
+                return Err("checkpoint identity or chain mismatch".into());
+            }
+            if prior_phase != "Writing" && (length != prior_length || records != prior_records) {
+                return Err("completed spool changed".into());
+            }
+            if matches!(phase, "Publishing" | "Published") == value["prepared"].is_null() {
+                return Err("prepared identity/phase mismatch".into());
+            }
+            let id = value["run_id"].as_str().ok_or("invalid run id")?;
+            if id.is_empty() || id.len() > 128 || run.as_ref().is_some_and(|r| r != id) {
+                return Err("run identity mismatch".into());
+            }
+            run = Some(id.to_owned());
+            prior_length = length;
+            prior_records = records;
+            prior_phase = phase.to_owned();
+            self.previous = Value::String(hash(&bytes));
+            self.next = sequence + 1;
+            self.latest = value;
+        }
+        self.length = prior_length;
+        self.records = prior_records;
+        self.saved_length = prior_length;
+        self.saved_records = prior_records;
+        self.digest = digest_file(&mut self.spool, self.length)?;
+        if self.latest["spool"]["sha256"] != hex(&self.digest.clone().finalize()) {
+            return Err("spool content mismatch".into());
+        }
+        self.spool.seek(SeekFrom::Start(0)).map_err(error)?;
+        Ok(())
+    }
+    pub(crate) fn records(&self) -> u64 {
+        self.records
+    }
+    pub(crate) fn phase(&self) -> &str {
+        self.latest["phase"].as_str().unwrap_or("")
+    }
+    pub(crate) fn compare(&mut self, bytes: &[u8]) -> Result<()> {
+        let position = self.spool.stream_position().map_err(error)?;
+        if position + bytes.len() as u64 > self.length {
+            return Err("replayed prefix exceeds checkpoint".into());
+        }
+        let mut actual = vec![0; bytes.len()];
+        self.spool.read_exact(&mut actual).map_err(error)?;
+        if actual != bytes {
+            return Err("replayed prefix differs from spool".into());
+        }
+        Ok(())
+    }
+    pub(crate) fn finish_validation(&mut self) -> Result<()> {
+        if self.spool.stream_position().map_err(error)? != self.length {
+            return Err("checkpoint record count differs from prefix".into());
+        }
+        self.spool.set_len(self.length).map_err(error)?;
+        self.spool
+            .seek(SeekFrom::Start(self.length))
+            .map_err(error)?;
+        Ok(())
+    }
+    pub(crate) fn append(&mut self, bytes: &[u8], record: bool) -> Result<()> {
+        if bytes.len() > 3 * 1024 * 1024 || self.length + bytes.len() as u64 > MAX_SPOOL {
+            return Err("spool bounds exceeded".into());
+        }
+        self.spool.write_all(bytes).map_err(error)?;
+        self.digest.update(bytes);
+        self.length += bytes.len() as u64;
+        self.records += u64::from(record);
+        if self.records - self.saved_records >= 1024
+            || self.length - self.saved_length >= 4 * 1024 * 1024
+        {
+            self.save("Writing", Value::Null)?;
+        }
+        Ok(())
+    }
+    pub(crate) fn save(&mut self, phase: &str, prepared: Value) -> Result<()> {
+        self.save_with(phase, prepared, |_| Ok(()))
+    }
+    // Original fault seam for unit tests; production always supplies a no-op.
+    fn save_with(
+        &mut self,
+        phase: &str,
+        prepared: Value,
+        mut before: impl FnMut(&str) -> Result<()>,
+    ) -> Result<()> {
+        if self.next >= MAX_GENERATIONS {
+            return Err("checkpoint generation limit exceeded".into());
+        }
+        before("spool-sync")?;
+        self.spool.sync_all().map_err(error)?;
+        let mut value = self.latest.clone();
+        value["sequence"] = json!(self.next);
+        value["previous"] = self.previous.clone();
+        value["phase"] = json!(phase);
+        value["prepared"] = prepared;
+        value["spool"]["len"] = json!(self.length);
+        value["spool"]["sha256"] = json!(hex(&self.digest.clone().finalize()));
+        value["records"] = json!(self.records);
+        let bytes = serde_json::to_vec(&value).map_err(error)?;
+        if bytes.len() as u64 > MAX_MANIFEST {
+            return Err("manifest too large".into());
+        }
+        let nonce = NEXT.fetch_add(1, Ordering::Relaxed);
+        let temp = self.root.join(format!(
+            ".checkpoint-{}-{}-{nonce}.tmp",
+            self.next,
+            std::process::id()
+        ));
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temp)
+            .map_err(error)?;
+        before("manifest-write")?;
+        file.write_all(&bytes)
+            .and_then(|()| file.sync_all())
+            .map_err(error)?;
+        before("manifest-link")?;
+        fs::hard_link(&temp, self.root.join(format!("{:020}.json", self.next))).map_err(error)?;
+        before("directory-sync")?;
+        File::open(&self.root)
+            .and_then(|f| f.sync_all())
+            .map_err(error)?;
+        before("temporary-remove")?;
+        fs::remove_file(temp).map_err(error)?;
+        File::open(&self.root)
+            .and_then(|f| f.sync_all())
+            .map_err(error)?;
+        self.previous = json!(hash(&bytes));
+        self.next += 1;
+        self.saved_length = self.length;
+        self.saved_records = self.records;
+        self.latest = value;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn root() -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "emburk-checkpoint-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&p).unwrap();
+        p.join("state")
+    }
+    fn staged() -> (PathBuf, State) {
+        let p = root();
+        let mut s = State::open(&p, json!({"test":1}), false).unwrap();
+        s.append(b"header\n", false).unwrap();
+        s.save("Writing", Value::Null).unwrap();
+        (p, s)
+    }
+    #[test]
+    fn chain_rejects_changed_published_identity() {
+        let (p, mut s) = staged();
+        s.save("Ready", Value::Null).unwrap();
+        let a = json!({"dev":1,"ino":2,"len":3,"sha256":hash(b"one")});
+        let b = json!({"dev":1,"ino":9,"len":3,"sha256":hash(b"two")});
+        s.save("Publishing", a).unwrap();
+        s.save("Published", b).unwrap();
+        drop(s);
+        assert!(
+            State::open(&p, json!({"test":1}), true)
+                .err()
+                .unwrap()
+                .contains("published identity")
+        );
+    }
+    #[test]
+    fn interrupted_generation_operations_recover_only_complete_visible_generations() {
+        for phase in [
+            "spool-sync",
+            "manifest-write",
+            "manifest-link",
+            "directory-sync",
+            "temporary-remove",
+        ] {
+            let (p, mut s) = staged();
+            s.append(b"row\n", true).unwrap();
+            assert!(
+                s.save_with("Writing", Value::Null, |at| if at == phase {
+                    Err("injected".into())
+                } else {
+                    Ok(())
+                })
+                .is_err()
+            );
+            drop(s);
+            let mut s = State::open(&p, json!({"test":1}), true).unwrap();
+            s.compare(b"header\n").unwrap();
+            let visible = matches!(phase, "directory-sync" | "temporary-remove");
+            assert_eq!(s.records(), u64::from(visible));
+            if visible {
+                s.compare(b"row\n").unwrap();
+            }
+            s.finish_validation().unwrap();
+        }
+    }
+    #[test]
+    fn uncheckpointed_tail_is_untouched_until_exact_prefix_validates() {
+        let (p, mut s) = staged();
+        s.spool.write_all(b"tail").unwrap();
+        drop(s);
+        let mut s = State::open(&p, json!({"test":1}), true).unwrap();
+        assert!(s.compare(b"wrong\n").is_err());
+        assert_eq!(fs::read(p.join("spool")).unwrap(), b"header\ntail");
+        drop(s);
+        let mut s = State::open(&p, json!({"test":1}), true).unwrap();
+        s.compare(b"header\n").unwrap();
+        s.finish_validation().unwrap();
+        assert_eq!(fs::read(p.join("spool")).unwrap(), b"header\n");
+    }
+    #[test]
+    fn bounds_are_checked_before_writing_and_previous_generation_survives() {
+        let (p, mut s) = staged();
+        let original = fs::read(p.join("spool")).unwrap();
+        s.length = MAX_SPOOL;
+        assert!(s.append(b"x", true).is_err());
+        assert_eq!(fs::read(p.join("spool")).unwrap(), original);
+        s.length = original.len() as u64;
+        s.next = MAX_GENERATIONS;
+        assert!(s.save("Writing", Value::Null).is_err());
+        drop(s);
+        assert!(State::open(&p, json!({"test":1}), true).is_ok());
+    }
+    #[test]
+    fn generation_collision_does_not_overwrite_and_incomplete_temp_is_not_adopted() {
+        let (p, mut s) = staged();
+        let residue = p.join(".checkpoint-99-999-1.tmp");
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&residue)
+            .unwrap()
+            .write_all(b"torn")
+            .unwrap();
+        s.next = 0;
+        assert!(s.save("Writing", Value::Null).is_err());
+        drop(s);
+        let s = State::open(&p, json!({"test":1}), true).unwrap();
+        assert_eq!(s.records(), 0);
+        assert_eq!(fs::read(residue).unwrap(), b"torn");
+    }
+    #[test]
+    fn duplicate_manifest_fields_and_unsafe_links_are_rejected() {
+        let (p, s) = staged();
+        drop(s);
+        let path = p.join("00000000000000000000.json");
+        let bytes = fs::read(&path).unwrap();
+        let mut duplicate = b"{\"version\":1,".to_vec();
+        duplicate.extend_from_slice(&bytes[1..]);
+        fs::write(&path, duplicate).unwrap();
+        assert!(State::open(&p, json!({"test":1}), true).is_err());
+        fs::write(&path, bytes).unwrap();
+        let saved = p.join("saved");
+        fs::rename(p.join("spool"), &saved).unwrap();
+        std::os::unix::fs::symlink(&saved, p.join("spool")).unwrap();
+        assert!(State::open(&p, json!({"test":1}), true).is_err());
+    }
+}

--- a/crates/emburk-core/src/configured_csv.rs
+++ b/crates/emburk-core/src/configured_csv.rs
@@ -299,6 +299,12 @@ fn execute(profile: Profile, cancel: &AtomicBool) -> Result<usize, String> {
     if cancel.load(Ordering::Acquire) {
         return Err("cancelled".into());
     }
+    let Some(input_path) = select_input(&profile)? else {
+        return Ok(0);
+    };
+    execute_input(profile, cancel, input_path)
+}
+fn select_input(profile: &Profile) -> Result<Option<PathBuf>, String> {
     let parent = profile
         .input
         .parent()
@@ -326,9 +332,13 @@ fn execute(profile: Profile, cancel: &AtomicBool) -> Result<usize, String> {
             }
         }
     }
-    let Some(input_path) = matches.pop() else {
-        return Ok(0);
-    };
+    Ok(matches.pop())
+}
+fn execute_input(
+    profile: Profile,
+    cancel: &AtomicBool,
+    input_path: PathBuf,
+) -> Result<usize, String> {
     let file = File::open(&input_path).map_err(|e| format!("cannot open input: {e}"))?;
     let mut source = Source {
         input: native_formats::reader(file, profile.decoder),
@@ -363,6 +373,167 @@ fn execute(profile: Profile, cancel: &AtomicBool) -> Result<usize, String> {
     })
     .map_err(|error| error.to_string())
 }
+#[cfg(unix)]
+pub fn run_config_resumable(
+    config: &Path,
+    directory: &Path,
+    cancel: &AtomicBool,
+    resume: bool,
+) -> Result<usize, String> {
+    use crate::checkpoint::{self, State};
+    use serde_json::{Value, json};
+    use std::io::{Read, Seek, SeekFrom};
+    let cancelled = || {
+        if cancel.load(Ordering::Acquire) {
+            Err("cancelled".to_owned())
+        } else {
+            Ok(())
+        }
+    };
+    cancelled()?;
+    let raw = yaml_profile::load(config)?;
+    let config_hash = checkpoint::hash(&raw.bytes);
+    let profile = compile(raw.compile_node()?)?;
+    let input = select_input(&profile)?.ok_or("stateful run requires one matched input")?;
+    let input_identity = checkpoint::identity(&input)?;
+    let input = fs::canonicalize(input).map_err(|e| e.to_string())?;
+    let parent = profile
+        .output
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    let output = fs::canonicalize(parent).map_err(|e| e.to_string())?.join(
+        profile
+            .output
+            .file_name()
+            .ok_or("missing output filename")?,
+    );
+    let context = json!({"profile":"configured-spool-v1", "config_sha256":config_hash,"input_path":input.to_str().ok_or("stateful input path must be UTF-8")?,"input":input_identity,"output":output.to_str().ok_or("stateful output path must be UTF-8")?});
+    let revalidate = || -> Result<(), String> {
+        cancelled()?;
+        if checkpoint::hash(&yaml_profile::load(config)?.bytes) != config_hash
+            || checkpoint::identity(&input)? != input_identity
+            || select_input(&profile)?
+                .map(fs::canonicalize)
+                .transpose()
+                .map_err(|e| e.to_string())?
+                != Some(input.clone())
+        {
+            return Err("configuration or input changed".into());
+        }
+        Ok(())
+    };
+    if !resume && fs::symlink_metadata(&output).is_ok() {
+        return Err("output already exists".into());
+    }
+    let mut state = State::open(directory, context, resume)?;
+    let mut source = Source {
+        input: native_formats::reader(
+            File::open(&input).map_err(|e| e.to_string())?,
+            profile.decoder,
+        ),
+        profile: &profile,
+        skipped: 0,
+    };
+    let mut header = Vec::new();
+    csv_stream::write_row(
+        &mut header,
+        &profile
+            .projection
+            .iter()
+            .map(|(_, name)| Some(name.clone()))
+            .collect::<Vec<_>>(),
+    )
+    .map_err(|e| e.to_string())?;
+    let mut already_published = false;
+    if resume {
+        state.compare(&header)?;
+        for _ in 0..state.records() {
+            cancelled()?;
+            let record = source
+                .next_record()
+                .map_err(|e| e.0)?
+                .ok_or("input ended before checkpoint")?;
+            state.compare(&format_record(record, &profile.projection)?)?;
+        }
+        if state.phase() != "Writing" && source.next_record().map_err(|e| e.0)?.is_some() {
+            return Err("completed spool omits input records".into());
+        }
+        match fs::symlink_metadata(&output) {
+            Ok(_) => {
+                if !matches!(state.phase(), "Publishing" | "Published")
+                    || checkpoint::identity(&output)? != state.latest["prepared"]
+                {
+                    return Err("existing output conflicts with prepared identity".into());
+                }
+                already_published = true;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && state.phase() != "Published" => {}
+            Err(e) => return Err(format!("cannot recover published output: {e}")),
+        }
+        revalidate()?;
+        state.finish_validation()?;
+    } else {
+        state.append(&header, false)?;
+        state.save("Writing", Value::Null)?;
+    }
+    if already_published {
+        File::open(&output)
+            .and_then(|f| f.sync_all())
+            .map_err(|e| e.to_string())?;
+        File::open(output.parent().unwrap())
+            .and_then(|f| f.sync_all())
+            .map_err(|e| e.to_string())?;
+        if state.phase() != "Published" {
+            let prepared = state.latest["prepared"].clone();
+            state.save("Published", prepared)?;
+        }
+        return usize::try_from(state.records()).map_err(|e| e.to_string());
+    }
+    if state.phase() == "Writing" {
+        bounded_parallel::run(
+            profile.workers,
+            cancel,
+            || source.next_record().map_err(|e| e.0),
+            |record| format_record(record, &profile.projection),
+            |bytes| state.append(&bytes, true),
+        )?;
+        state.save("Ready", Value::Null)?;
+    }
+    revalidate()?;
+    state
+        .spool
+        .seek(SeekFrom::Start(0))
+        .map_err(|e| e.to_string())?;
+    let mut spool = state.spool.try_clone().map_err(|e| e.to_string())?;
+    publication::write_prepared(
+        &output,
+        cancel,
+        |output| {
+            let mut encoder = Encoder::new(output, profile.encoder);
+            let mut bytes = [0; 65536];
+            loop {
+                cancelled()?;
+                let n = spool.read(&mut bytes).map_err(|e| e.to_string())?;
+                if n == 0 {
+                    break;
+                }
+                encoder.write_all(&bytes[..n]).map_err(|e| e.to_string())?;
+            }
+            encoder.finish().map_err(|e| e.to_string())?;
+            Ok(())
+        },
+        |temporary, _| {
+            revalidate()?;
+            state.save("Publishing", checkpoint::identity(temporary)?)
+        },
+    )
+    .map_err(|e| e.to_string())?;
+    let prepared = state.latest["prepared"].clone();
+    state.save("Published", prepared)?;
+    usize::try_from(state.records()).map_err(|e| e.to_string())
+}
+
 struct Source<'a> {
     input: Box<dyn BufRead>,
     profile: &'a Profile,

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -1,5 +1,12 @@
 #![forbid(unsafe_code)]
 
+#[cfg(unix)]
+mod checkpoint;
+
+#[cfg(unix)]
+#[doc(hidden)]
+pub use configured_csv::run_config_resumable;
+
 // This is deliberately private until a later packet authorizes an API consumer.
 #[allow(
     dead_code,

--- a/crates/emburk-core/src/publication.rs
+++ b/crates/emburk-core/src/publication.rs
@@ -14,6 +14,7 @@ pub(crate) enum Phase {
     Write,
     Flush,
     FileSync,
+    PreparePublication,
     Link,
     TargetDirectorySync,
     TemporaryRemove,
@@ -65,7 +66,16 @@ pub(crate) fn write_atomic<T>(
     cancel: &AtomicBool,
     write: impl FnOnce(&mut BufWriter<File>) -> Result<T, String>,
 ) -> Result<T, PublicationError> {
-    write_with(target, write, |phase| {
+    write_prepared(target, cancel, write, |_, _| Ok(()))
+}
+
+pub(crate) fn write_prepared<T>(
+    target: &Path,
+    cancel: &AtomicBool,
+    write: impl FnOnce(&mut BufWriter<File>) -> Result<T, String>,
+    prepared: impl FnOnce(&Path, &Path) -> Result<(), String>,
+) -> Result<T, PublicationError> {
+    write_with_prepared(target, write, prepared, |phase| {
         if matches!(phase, Phase::Write | Phase::Link) && cancel.load(Ordering::Acquire) {
             Err(io::Error::other("cancelled"))
         } else {
@@ -76,9 +86,18 @@ pub(crate) fn write_atomic<T>(
 
 // The hook is private and is supplied with faults only by unit tests. It runs
 // immediately before the corresponding real operation, never from environment.
+#[cfg(test)]
 fn write_with<T>(
     target: &Path,
     write: impl FnOnce(&mut BufWriter<File>) -> Result<T, String>,
+    before: impl FnMut(Phase) -> io::Result<()>,
+) -> Result<T, PublicationError> {
+    write_with_prepared(target, write, |_, _| Ok(()), before)
+}
+fn write_with_prepared<T>(
+    target: &Path,
+    write: impl FnOnce(&mut BufWriter<File>) -> Result<T, String>,
+    prepared: impl FnOnce(&Path, &Path) -> Result<(), String>,
     mut before: impl FnMut(Phase) -> io::Result<()>,
 ) -> Result<T, PublicationError> {
     let failure = |phase, state, cleanup, temporary, message| PublicationError {
@@ -146,6 +165,9 @@ fn write_with<T>(
         before(Phase::FileSync)
             .and_then(|()| output.get_ref().sync_all())
             .map_err(|e| (Phase::FileSync, e.to_string()))?;
+        before(Phase::PreparePublication)
+            .map_err(|e| (Phase::PreparePublication, e.to_string()))?;
+        prepared(&temporary, target).map_err(|e| (Phase::PreparePublication, e))?;
         before(Phase::Link)
             .and_then(|()| fs::hard_link(&temporary, target))
             .map_err(|e| (Phase::Link, e.to_string()))?;
@@ -393,5 +415,35 @@ mod tests {
                 if is_link { 2 } else { 1 }
             );
         }
+    }
+
+    #[test]
+    fn prepared_hook_runs_after_sync_before_link_and_can_prevent_publication() {
+        let target = target();
+        let cancel = AtomicBool::new(false);
+        let error = write_prepared(&target, &cancel, content, |temporary, final_path| {
+            assert_eq!(fs::read(temporary).unwrap(), b"complete\n");
+            assert!(!final_path.exists());
+            Err("prepared failure".into())
+        })
+        .unwrap_err();
+        assert_eq!(error.phase, Phase::PreparePublication);
+        assert_eq!(error.state, State::NotPublished);
+        assert!(!target.exists());
+        assert_eq!(fs::read_dir(target.parent().unwrap()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn prepared_hook_cancellation_prevents_link() {
+        let target = target();
+        let cancel = AtomicBool::new(false);
+        let error = write_prepared(&target, &cancel, content, |_, _| {
+            cancel.store(true, Ordering::Release);
+            Ok(())
+        })
+        .unwrap_err();
+        assert_eq!(error.phase, Phase::Link);
+        assert_eq!(error.state, State::NotPublished);
+        assert!(!target.exists());
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,8 @@ streaming codecs and ordered schema projections inside the configured consumer.
 Dependencies remain private and codec finalization precedes publication.
 T-0033/S01 integrated through PR #119, not a public plugin API. ADR-0020 now
 defines bounded scoped formatting workers, a single ordered writer, and a
-borrowed cancellation flag. T-0024/S01 implementation/acceptance is in progress.
+borrowed cancellation flag. T-0024/S01 integrated through PR #120. T-0025/S02
+develops private validated spool recovery; no generic resume API is accepted.
 
 ADR-0016 extends only CLI composition with stdout locking and std::io::sink
 adapters. Both use the same core transfer entry point; no new public core or

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -18,8 +18,9 @@ no-clobber publication safety through PR #117; its failure policy is not
 observed Embulk parity. T-0014/S02 (#118) supplies five selected real JSON,
 gzip/bzip2 and filter-order observations. T-0033/S01 (#119) matches those five
 selected projections with native execution; codec bytes are compared only
-after decoding. T-0024/S01 develops native bounded workers/cancellation, not
-Embulk scheduler or performance parity.
+after decoding. T-0024/S01 (#120) accepts native bounded workers/cancellation,
+not Embulk scheduler or performance parity. T-0025/S02 develops validated native
+resume; its checkpoint format is not an Embulk resume-file compatibility claim.
 
 The implementation objective is strict reproduction of observable behavior for
 the pinned core and admitted plugins. Technical constraints, disproportionate

--- a/docs/NATIVE_PIPELINE.md
+++ b/docs/NATIVE_PIPELINE.md
@@ -1,0 +1,129 @@
+# Experimental native pipeline
+
+This guide describes the selected native profile, not general Embulk plugin
+compatibility. Use a new output prefix: existing final files are never replaced.
+The configured path is intended for trusted local Unix filesystems.
+
+## Minimal configured transfer
+
+Build with `cargo build --locked`. In a separate job directory create an
+`input.csv` file containing:
+
+```csv
+id,name
+1,Ada
+2,"comma, snowman ☃"
+```
+
+Create the `output` directory and save this as `config.yml`:
+
+```yaml
+in:
+  type: file
+  path_prefix: input.csv
+  parser:
+    type: csv
+    charset: UTF-8
+    newline: LF
+    delimiter: ','
+    quote: '"'
+    escape: '"'
+    skip_header_lines: 1
+    columns:
+    - {name: id, type: long}
+    - {name: name, type: string}
+out:
+  type: file
+  path_prefix: output/result
+  file_ext: csv
+  formatter:
+    type: csv
+    charset: UTF-8
+    newline: LF
+    delimiter: ','
+    quote: '"'
+    escape: '"'
+    header_line: true
+    quote_policy: MINIMAL
+exec:
+  max_threads: 4
+  min_output_tasks: 1
+```
+
+Run `/path/to/emburk/target/debug/emburk run config.yml` from the job directory.
+Relative paths resolve against the process working directory, not the config
+file's parent. The selected single-task output is `output/result000.00.csv`.
+At most one regular input may match the prefix. An unmatched ordinary run
+produces no output. The output directory must already exist.
+
+## Selected formats and filters
+
+- JSON input: replace the parser with `type: json` and the same `columns` list;
+  omit CSV parser options. Input is a sequence of JSON objects. Only configured
+  long/string/null fields are supported, not arbitrary coercions.
+- Compressed input: add `decoders: [{type: gzip}]` or
+  `decoders: [{type: bzip2}]` under `in`.
+- Compressed output: add `encoders: [{type: gzip, level: 6}]` or
+  `encoders: [{type: bzip2, level: 9}]` under `out`.
+- Column filters: top-level `filters` may contain
+  `{type: rename, columns: {name: label}}` and
+  `{type: remove_columns, remove: [label]}` in the intended order. References
+  use the schema at that point; swapping filters can be invalid.
+
+Unknown options and unsupported profiles fail explicitly. Configuration is
+bounded to 64 KiB; logical records are bounded to 1 MiB and 256 columns. One
+to eight workers format records; source parsing is serial. The whole admitted,
+not-yet-written window is bounded to twice the worker count, with ordered output.
+
+## Cancellation and output safety
+
+SIGINT requests cooperative cancellation. Before publication, cancellation
+returns exit 130 and does not expose a partial final file. Blocking filesystem
+operations do not have a hard interruption deadline. Once a final file is
+linked, cancellation or cleanup errors cannot roll it back.
+
+Output is staged in an owned private sibling temporary, finalized and synced,
+then linked without clobbering an existing destination. Errors distinguish
+unpublished output from published output with uncertain durability or cleanup.
+Inspect reported state and retained paths before retrying; never assume a
+nonzero exit means that no output exists. Abrupt process death can leave owned
+temporary residue. There is no automatic removal of unrelated files.
+
+## Stateful run and resume
+
+T-0025/S02 implements the following explicit commands; final acceptance is
+pending. Start with a state-directory path that does not exist:
+
+```sh
+emburk run config.yml --state job-state
+emburk resume config.yml job-state
+```
+
+After SIGINT, keep the input, configuration, working directory and state intact.
+Resume validates the input/configuration hashes, checkpoint chain and exact
+reformatted saved prefix before trimming any uncheckpointed spool tail. It
+rejects changed inputs/configuration, conflicting outputs and concurrent state
+writers. Repeating resume after success validates the prepared output identity
+without replacing it. If the final target was deleted after success, recovery
+fails instead of silently publishing it again.
+
+State is private to this native profile and local Unix filesystem. It retains
+an uncompressed formatted spool (maximum 8 GiB), bounded 64 KiB manifests and
+at most 65,536 generations. Checkpoints occur every 1,024 valid records or
+4 MiB, plus the header and completion. Prefix replay and full input hashes take
+I/O time; compression restarts from the complete verified spool. This is not a
+compressed fast-seek or an Embulk resume-file implementation. Preserve retained
+state until inspected; automated state garbage collection is not implemented.
+
+Ordinary `run` does not checkpoint. The earlier `transfer-lines`
+commands remain experimental and do not inherit the configured publication
+contract.
+
+## Evidence boundary
+
+Eight selected CSV cases and five JSON/codec/filter cases are compared with
+pinned Embulk executables. Compressed results are compared after decoding;
+compressed bitstream equality is not promised. Native worker and failure tests
+do not establish Embulk scheduler, transaction or resume parity. See
+[Compatibility](COMPATIBILITY.md) and [Current status](STATUS.md) for accepted
+revisions and non-claims.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Repository records are the authoritative project memory. GitHub Issues and the G
 - [Roadmap](ROADMAP.md)
 - [Architecture](ARCHITECTURE.md)
 - [Compatibility](COMPATIBILITY.md)
+- [Experimental native pipeline](NATIVE_PIPELINE.md)
 - [GitHub Project operations](PROJECT_OPERATIONS.md)
 - [Development](DEVELOPMENT.md)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,9 +10,10 @@ after primary and independent eight-case comparison and 81 passing tests.
 This satisfies the bounded stages 2–4 consumer, not full configuration/plugin
 gates. Stage 5 integrated as T-0025/S01 through PR #117 after fault/interruption
 acceptance. Stage 6 reference-only preparation T-0014/S02 integrated through
-PR #118. T-0033/S01 integrated stage 6 through PR #119. Stage 7 starts with
-T-0024/S01 bounded ordered formatting/cancellation; validated checkpoint/resume
-and broader parent gates remain open.
+PR #118. T-0033/S01 integrated stage 6 through PR #119. Stage 7's bounded
+ordered formatting/cancellation integrated as T-0024/S01 through PR #120.
+T-0025/S02 addresses validated checkpoint/resume; its acceptance and broader
+parent gates remain open.
 
 ## Phase 0: Governance and Compatibility Contract
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-09-06
 
-Development state: `bootstrap`
+Development state: `experimental native pipeline`
 
 ## Implemented facts
 
@@ -54,7 +54,9 @@ unchanged eight-case CSV comparison. T-0014/S02 is Done through PR #118:
 nine tests and matching independent five-case format/filter observations.
 T-0033/S01 is Done through PR #119 (95b5592): 97 tests and thirteen selected
 comparisons passed independently at 39c97d8. T-0024/S01 now starts stage 7 with
-bounded ordered formatting/cancellation; checkpoint/resume remains unfinished.
+bounded ordered formatting/cancellation, now integrated through PR #120
+(24b99fa) after 106 passes and thirteen independent comparisons at 4970e46.
+T-0025/S02 implements validated native resume; acceptance remains unfinished.
 The owner-authorized
 [seven-stage sequence](IMPLEMENTATION_SEQUENCE.md) remains uncompleted work.
 
@@ -83,7 +85,7 @@ strict controls and unchanged S12 regression. T-0031/S01 is Done through PR #110
 (`c5fb13f`) for the explicitly requested experimental native File-to-File path.
 T-0031/S02 is Done through PR #112 (`2ec236e`) for experimental stdout/null
 consumers: 71 tests passed, eight existing intentional ignores, primary and
-independent acceptance at `c5df504`. T-0024/S01 now occupies one WIP lane; the full
+independent acceptance at `c5df504`. T-0025/S02 now occupies one WIP lane; the full
 file/plugin parent stays open. Core transfer semantics remain unchanged.
 
 | Item | State | Purpose |
@@ -101,8 +103,8 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 
 T-0025/S01 is Done through PR #117. T-0014/S02 is Done through PR #118.
-T-0033/S01 is Done through PR #119. T-0024/S01 uses one lane for bounded
-formatting workers and cancellation on its dedicated branch.
+T-0033/S01 is Done through PR #119. T-0024/S01 is Done through PR #120.
+T-0025/S02 uses one lane for validated native resume on its dedicated branch.
 Other unfinished stable tasks remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
 is the coordination mirror. Its 52 items, lifecycle states, initial estimates,
@@ -150,7 +152,7 @@ In particular, the repository does not yet demonstrate:
 
 - Embulk-compatible configuration, schema, value, lifecycle, or resume
   behavior;
-- bounded parallel ETL or File-to-File transfer;
+- general parallel ETL beyond the selected single-file ordered formatter;
 - successful loading of any unchanged Java or Ruby plugin;
 - exactly-once behavior for any source/output combination;
 - a performance, security-isolation, production-readiness, or ecosystem

--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -5,6 +5,13 @@ or SBOM. Cargo.lock and provenance packets identify selected dependencies.
 Release packaging must reconcile all distributed code, licenses and notices.
 No Embulk implementation source is copied into this project.
 
+T-0025/S02 uses sha2 0.11.0 (MIT/Apache-2.0) as an unmodified dependency for
+private checkpoint content hashes. Exact transitive versions/checksums are
+locked; [the packet](provenance/T-0025-validated-resume.md) records archive
+admission and the offline cache. Hashes detect content changes; they do not
+authenticate state against a malicious same-UID writer. Full release notice
+bundling, security review and patent/FTO remain unreviewed.
+
 ## libbz2-rs-sys 0.2.5
 
 The unmodified dependency is used through bzip2 0.6.1. The following license

--- a/docs/decisions/ADR-0020-bounded-format-workers.md
+++ b/docs/decisions/ADR-0020-bounded-format-workers.md
@@ -1,6 +1,6 @@
 # ADR-0020: Bounded ordered format workers
 
-- Status: Accepted for T-0024/S01 implementation; acceptance pending
+- Status: Accepted and integrated through PR #120 (T-0024/S01)
 - Date: 2026-09-06
 
 Use at most eight scoped native format workers with admission window twice the

--- a/docs/decisions/ADR-0021-validated-native-spool-resume.md
+++ b/docs/decisions/ADR-0021-validated-native-spool-resume.md
@@ -1,0 +1,46 @@
+# ADR-0021: Validated native spool resume
+
+- Status: Accepted for implementation; executable acceptance pending
+- Date: 2026-09-06
+- Scope: T-0025/S02, private single-input configured Unix profile
+
+## Decision
+
+Persist the uncompressed formatted output in a private, bounded spool. Resume
+validates exact configuration, raw source content and identity, destination,
+profile version, checkpoint chain, spool identity and saved prefix. Replaying
+the parser and formatter must reproduce the saved prefix byte-for-byte before
+any uncheckpointed tail is truncated. A saved row count alone is insufficient.
+
+Encoding restarts from the verified completed spool. This avoids depending on
+undocumented partial compressed-stream state. Recovery is O(N) prefix replay,
+not a fast-seek optimization. State and spool remain available after completion.
+
+A persistent kernel file lock prevents cooperating concurrent writers without
+stale PID heuristics. Explicitly created state directories are private (0700),
+with regular private files (0600). Immutable generations are published only
+after synchronization, through exclusive hard links and directory sync. Record
+size, manifest size, spool size and generation count all have explicit caps.
+
+Before linking the final output, persist its prepared device/inode, length and
+content hash after synchronization. Recovery recognizes a linked output only
+when that prepared identity and content match. An unrelated existing output is
+always a conflict, including equal bytes with a different identity. Publication
+continues to use ADR-0018's no-clobber boundary; published output is never rolled
+back because of a later cleanup or checkpoint failure.
+
+## Consequences and limits
+
+The ordinary run path remains unchanged. Explicit stateful commands require
+exactly one selected regular input. Checkpoint state is a versioned private
+native format, not an Embulk resume-file format or generic plugin contract.
+
+The spool adds disk usage and full-source hashing/replay adds I/O. State cleanup,
+multi-source recovery, remote stores and compressed fast seek remain out of
+scope. Same-UID trusted stable local filesystems are assumed; kernel locks do
+not stop unrelated writers. No hardware power-loss, hostile path-race,
+distributed transaction or exactly-once guarantee is accepted.
+
+Source/API/dependency provenance, exact bounds, Demo and stop rules are in the
+[mutation packet](../provenance/T-0025-validated-resume.md). Acceptance requires
+actual interrupted transfers and recovery conflicts, not documentation alone.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -20,3 +20,8 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0014](ADR-0014-private-positional-logical-batch.md) | Private positional logical batch admission before physical encoding | Accepted |
 | [ADR-0015](ADR-0015-experimental-text-file-transfer.md) | Experimental text File-to-File consumer | Accepted for T-0031/S01 only |
 | [ADR-0016](ADR-0016-experimental-stream-output-targets.md) | Experimental stdout/null adapters | Accepted for T-0031/S02 only |
+| [ADR-0017](ADR-0017-bounded-configured-csv.md) | Bounded configured CSV consumer | Accepted through PR #116 |
+| [ADR-0018](ADR-0018-single-output-publication.md) | Single-output no-clobber publication | Accepted through PR #117 |
+| [ADR-0019](ADR-0019-bounded-native-formats.md) | Bounded native formats and projections | Accepted through PR #119 |
+| [ADR-0020](ADR-0020-bounded-format-workers.md) | Bounded ordered formatting workers | Accepted through PR #120 |
+| [ADR-0021](ADR-0021-validated-native-spool-resume.md) | Validated native spool resume | Accepted for implementation; acceptance pending |

--- a/docs/log/2026-09-06.md
+++ b/docs/log/2026-09-06.md
@@ -491,3 +491,10 @@ T-0033/S01 integrated through PR #119 (95b5592), accepting 8 SP after exact
 primary and independent Demo at 39c97d8: 97 tests, eight existing ignores,
 eight CSV and five additional format/filter matches. Stage 6 is accepted only
 within that bounded profile. T-0024/S01 starts stage 7; validated resume follows.
+
+T-0024/S01 integrated through PR #120 (24b99fa), accepting 5 SP after exact
+primary and independent Demo at 4970e46: 106 passes, eight existing ignores,
+and thirteen selected live reference matches. Bounded admission, ordered
+formatting, panic/error cleanup and actual SIGINT were exercised. Parent #21
+returns to Backlog, Current/Initial 8 unchanged. T-0025/S02 begins validated
+native resume under ADR-0021, forecast 8 SP; parent Current 13 / Initial 8.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -41,6 +41,7 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0025/S01 safe publication](T-0025-safe-publication.md) | Done through PR #117; fault/interruption acceptance |
 | [T-0014/S02 format/filter observations](T-0014-formats-oracle.md) | Done through PR #118; five real reference cases |
 | [T-0033/S01 native formats](T-0033-native-formats.md) | Done through PR #119; thirteen selected comparisons |
-| [T-0024/S01 bounded workers](T-0024-bounded-parallel.md) | In Progress; native ordering/admission/cancellation |
+| [T-0024/S01 bounded workers](T-0024-bounded-parallel.md) | Done through PR #120; native ordering/admission/cancellation |
+| [T-0025/S02 validated resume](T-0025-validated-resume.md) | In Progress; private validated spool recovery |
 | [T-0031/S01 experimental file transfer](T-0031-file-to-file.md) | Done, PR #110; native-only record consumer |
 | [T-0031/S02 experimental stdout/null](T-0031-output-targets.md) | Done, PR #112; unchanged core transfer |

--- a/docs/provenance/T-0024-bounded-parallel.md
+++ b/docs/provenance/T-0024-bounded-parallel.md
@@ -1,7 +1,7 @@
 # T-0024/S01 bounded formatting and cancellation
 
-Issue: [#21](https://github.com/bhind/emburk/issues/21). State: In Progress.
-Forecast: 5 SP. First independently acceptable part of stage 7; resume follows.
+Issue: [#21](https://github.com/bhind/emburk/issues/21). State: Done via PR #120.
+Accepted: 5 SP. First independently acceptable part of stage 7; resume follows.
 
 ## Authority and dependencies
 
@@ -85,6 +85,20 @@ Pinned local EMBURK_REFERENCE_JAR and Java17 JAVA_HOME are required. Retain
 final-head primary/independent command logs, hashes and numeric exits.
 
 ## Evidence class, stop rule and non-claims
+
+Integrated as 24b99fab7763f4417e20422ec8a1e239d1b4069f after primary and
+independent exact Demo at 4970e46a5cae9891743e78a07ef9cd418f0559ba: 106 passes,
+eight existing intentional ignores, eight CSV and five format/filter matches.
+Primary logs: /private/tmp/t0024-s01-primary.R6aQam; stdout SHA256
+ea7dc931f9605d9686297a8b1171e50dd4a60a25ad2382f0d045e482d14b7dec,
+stderr 8bedbdde19abc64b5c6efd222d3ecb7c25da1984681604a334b9ee63e5a3b002.
+Independent logs: /private/tmp/t0024-s01-independent.IZVa9s; stdout SHA256
+323ca5ca237d94366e97fdd81c6717915be364383471f13af85b99595ea3fdba,
+stderr 5a4892be096f2141486beb3202ac6341bb695d22524a7e9d7c86215717fbe982.
+Both exits 0; exit-file SHA256
+9a271f2a916b0b6ee6cecb2426f0b3206ef074578be55d9bc94f6f3fe3ab86aa.
+Independent pre/post revision and tracked status were unchanged. Project audits
+passed with one active item before integration. Parent remains open in Backlog.
 
 Unit/Contract and local Integration, selected differential regressions only.
 Stop on unbounded admission, ordering mismatch, deadlock, unjoined worker,

--- a/docs/provenance/T-0025-validated-resume.md
+++ b/docs/provenance/T-0025-validated-resume.md
@@ -1,0 +1,100 @@
+# T-0025/S02 validated native resume
+
+Issue: [#22](https://github.com/bhind/emburk/issues/22). State: In Progress.
+Forecast: 8 SP; accepted S01 is 5 SP. Parent Current becomes 13, Initial stays 8.
+
+## Authority and dependencies
+
+Owner authorized the seven-stage sequence and routine integration. S01 safe
+publication is integrated in PR #117; bounded workers/cancellation in PR #120
+(24b99fab7763f4417e20422ec8a1e239d1b4069f). This completes the bounded native
+stage-seven profile, not the full Embulk transaction or scheduler contracts.
+
+## Branch and allowlist
+
+Branch: feat/t-0025-validated-resume. Implementation owner: Rust Core
+Implementer, serial ownership of crates/emburk-core/src/checkpoint.rs,
+configured_csv.rs, publication.rs, lib.rs, crates/emburk-cli/src/main.rs,
+crates/emburk-cli/tests/validated_resume.rs, crates/emburk-core/Cargo.toml and
+Cargo.lock. PM owns this packet and canonical documentation only. Reviewers
+do not mutate tracked files. No other worktree may be changed.
+
+PM also owns README.md, docs/NATIVE_PIPELINE.md and documentation indexes.
+PM owns docs/THIRD_PARTY_NOTICES.md for the new hash dependency attribution.
+After the initial checkpoint scaffold, the implementer is restricted to
+publication.rs for the prepared hook and unit tests; PM takes serial source
+ownership for the remaining checkpoint/configuration/CLI integration after
+that sub-step returns. There are no concurrent tracked-source writers.
+
+## Acceptance contract
+
+Expose an explicit state-directory run and resume command. Preserve ordinary
+run behavior. Checkpoint the uncompressed formatted spool; restart encoding
+from that spool, never append an uncertain compressed stream. Bound manifest,
+record, spool and generation sizes. Exclusively create private state; hold a
+kernel file lock for the entire operation, rejecting concurrent writers.
+
+Validate exact configuration and input identity/content, output destination,
+profile version, checkpoint chain, spool identity/length/hash and actual
+reformatted prefix before mutating resume state. Never blindly skip N records.
+Only validated owned uncheckpointed tails may be truncated. Recheck source
+identity/content before publication. Retain state for inspection.
+
+Persist the prepared output identity after file synchronization and before
+no-clobber publication. Recovery may recognize an already-linked output only
+by matching the prepared identity and content, never by filename alone. A
+conflicting output remains untouched. Cancellation preserves a usable durable
+checkpoint. Repeated successful resume must not republish or overwrite.
+
+Tests cover actual interrupted CLI/resume, input/config/spool tampering,
+concurrent lock rejection, incomplete tails, publication crash windows and
+repeat resume. Existing 106 tests and thirteen reference comparisons remain.
+
+Protocol v1 bounds: 64 KiB manifest, 8 GiB spool, 65,536 generations; checkpoint
+each 1,024 valid records or 4 MiB, plus header and completion. Generations use
+20-digit sequence names, exact version/sequence/previous-hash/run identity,
+configuration hash, canonical input identity/hash, canonical target, spool
+identity/length/hash, record count, phase and optional prepared output identity.
+Exclusive synchronized temporary records become immutable through hard links.
+Recognized incomplete temporaries are not authoritative generations. Reject
+unknown entries, gaps, unsafe file types/modes and mismatched chain identities.
+
+The initial dependency network retry was denied. No network bypass was used:
+seven exact archives already retained in the provenance inventory were hashed
+against Cargo.lock, then copied into a temporary offline Cargo cache at
+/private/tmp/emburk-resume-cargo.FrbGlD. The original user cache was unchanged.
+All subsequent builds can use this CARGO_HOME with --offline --locked.
+The seven new exact archives (sha2, block-buffer, cpufeatures, crypto-common,
+digest, hybrid-array and typenum) contain no build.rs scripts. Their exact
+versions and archive checksums are retained in Cargo.lock; no source bodies
+were copied into Emburk.
+
+## Dependency and provenance boundary
+
+Only sha2=0.11.0 (default-features=false) may be newly admitted, after exact
+lock graph verification against the already inspected prospective archive
+inventory. Official archive: https://static.crates.io/crates/sha2/sha2-0.11.0.crate
+SHA256: 446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4.
+Accessed 2026-09-06. MIT/Apache-2.0; no implementation copied. Unreviewed
+dependency security, release SBOM and patent/FTO are not cleared.
+
+The std File::try_lock API documentation was inspected at
+https://doc.rust-lang.org/std/fs/struct.File.html#method.try_lock on 2026-09-06,
+Rust 1.98.1 commit 48a229ceaefd4985c50990b14116b6d856af0985 (MIT/Apache-2.0).
+Kernel lock release on handle closure avoids stale PID guessing. API usage
+only, not copied implementation; locks do not prevent unrelated file writes.
+
+## Demo Command
+
+`cargo fmt --all -- --check && cargo clippy --locked --workspace --all-targets -- -D warnings && cargo test --locked --workspace && bash tests/t0032_configured_csv_differential_test.sh && bash tests/t0033_native_formats_differential_test.sh && git diff --check`
+
+Use the pinned local reference JAR and Java 17. Retain primary and independent
+final-revision logs, hashes and numeric exits before PR integration.
+
+## Evidence class, stop rule and non-claims
+
+Native Unit/Contract and Integration; differential regressions only. Stop on
+data loss, unsafe recovery, unbounded state, dependency mismatch or unexplained
+reference mismatch. Trusted same-UID stable local Unix filesystem only. No
+hostile path-race, hardware power-loss, fast seek, generic resume-file format,
+distributed transaction, exactly-once or full Embulk resume parity claim.


### PR DESCRIPTION
Implements T-0025/S02 for Issue #22 (8 SP forecast). Explicit run CONFIG --state DIR and resume CONFIG DIR; bounded private spool/generation chain; exact input/configuration identity and replayed-prefix validation; kernel lock; prepared output identity and no-clobber recovery. Real SIGINT tests span CSV, JSON, gzip and bzip2; tests reject tampering, concurrent state writers, conflicts, unsafe links and changed published identity, and model pre/post-link crashes. Primary exact Demo at 0d39e51c718ffaf2b88359a3f029bd62bff0cb9c passed: 118 tests, eight existing intentional ignores, all thirteen selected actual Embulk comparisons. Independent exact acceptance is running; merge only after it passes. Evidence /private/tmp/t0025-s02-primary.ptA370. Updates T-0024/S01 closeout and user guide. No full Embulk resume-file/plugin parity, hostile filesystem, hardware power-loss or exactly-once claim. Parent stays open.