### PR TITLE
research(t-0036): retained guess reference observations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -112,7 +112,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0033 | Implement the JSON parser (bounded formats S01 Done) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |
 | T-0035 | Implement rename and remove-columns filters | Backlog | P1 | 3 | T-0023 | Plugin Implementer | Differential (Embulk) |
-| T-0036 | Implement format guessing | Backlog | P1 | 5 | T-0032, T-0033, T-0034 | Plugin Implementer | Differential (Embulk) |
+| T-0036 | Implement format guessing (S01 reference observations active, forecast 3 SP) | In Progress | P1 | 5 | T-0032, T-0033, T-0034 | Plugin Implementer | Differential (Embulk) |
 | T-0037 | Pass File-to-File differential and resume acceptance | Backlog | P0 | 5 | T-0014, T-0025, T-0031–T-0036 | Tester | Differential (Embulk) |
 
 ## T-0040 — Java compatibility host

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -64,6 +64,11 @@ explicit bounded native profile; broader parent compatibility gates remain open.
 
 ## Delivery queue
 
+T-0036/S01 is In Progress for actual guess observations, followed by bounded
+native guessing and T-0037 integrated acceptance under owner authorization.
+The first eight probes expose JSON-without-columns and charset/delimiter gaps;
+native guessing is not yet implemented or accepted.
+
 T-0012/S08 is integrated through PR #82. The owner approved continuation of
 T-0012/S09 after the reference-execution explanation. Stage A at `7e46379`
 captured 114/93 events with exact selected double bits preserved; primary

--- a/docs/provenance/T-0036-guess-observations.md
+++ b/docs/provenance/T-0036-guess-observations.md
@@ -1,0 +1,91 @@
+# T-0036/S01 guess reference observations
+
+Issue: [#29](https://github.com/bhind/emburk/issues/29). In Progress; forecast 3 SP.
+Owner authorized observation, bounded native guess, then integrated acceptance.
+The prior seven-stage slice is integrated through PR #122. Broader parser,
+codec and recovery parent contracts remain open; prerequisites here are only
+their independently accepted bounded slices, not inferred whole-parent Done.
+
+## Branch and allowlist
+
+Branch research/t-0036-guess-observations. PM owns this packet, docs/STATUS.md,
+TODO.md and tools/guess-oracle/run.py plus tests/test_guess_oracle.py. Initial
+black-box evidence is retained under fresh /private/tmp directories. Read-only
+specialists inspect provenance/runtime prerequisites without modifying sources.
+No native implementation is authorized before actual reference review.
+
+## Sources and intended observations
+
+Pinned Embulk 0.11.5 executable from
+https://github.com/embulk/embulk/releases/download/v0.11.5/embulk-0.11.5.jar,
+SHA256 e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47.
+Artifact admission/license/NOTICE is recorded in T-0014/S01 and S02 packets.
+Java17 local observation only; no redistribution. Accessed 2026-09-06.
+
+Official https://www.embulk.org/docs/built-in.html#guess-executor documents
+ordered gzip/bzip2/json/csv guessing and a default 32 KiB sample target. This
+describes a target, not native admission or a hard upstream memory bound.
+CLI `guess --help` on the exact JAR confirms partial-config and -o output options.
+Observed help exit 255 is not a successful guess execution.
+
+Default embedded module byte identities (outer JAR lib/ locator):
+
+| Module | Version | SHA256 |
+| --- | --- | --- |
+| embulk-guess-gzip | 0.11.1 | 58b26f44efd3d25b5283c3f2ddb11a865f7081c51bf016b8b61619812ec5e5ed |
+| embulk-guess-bzip2 | 0.11.1 | 7e6ae600c8dc4e6b9a076ee94ddbc039ed9c4f255dac4e5def16753cf6cf2c75 |
+| embulk-guess-json | 0.11.2 | 6de531904ee34002a2914cc5d9047b4ae08f44881192800151cd6a603f15bbdc |
+| embulk-guess-csv | 0.11.6 | f1be4ebefe3b35a862b6f7bbc5a9e889e853406270458b7290a7f589b824a65b |
+| embulk-util-guess | 0.4.0 | bebc7762e6338af3168bc9c6b88e9c2ed5bf4b701aef52e7c32f6872eeef0ed5 |
+
+All five contain META-INF/LICENSE (Apache-2.0), SHA256
+cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30.
+Util-guess additionally carries META-INF/LICENSE-icu4j SHA256
+8c00e858a96db33a9e42f2043b66d96f9d2381d76601a1b0c1ee15fa5a17ca48
+and META-INF/NOTICE SHA256
+3b7b199772a892bb30a5aff925f0fde71dd7e79bfc4dfec20be816516329fc63.
+Librarian inspected metadata only, not source bodies. These are admitted only
+for local black-box observation. Individual redistribution/security/ICU
+attribution and patent/FTO remain unreviewed.
+
+## Initial observations and implementation decision points
+
+Eight actual probes completed in
+/var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/emburk-t0036-guess-w03opomv.
+CSV/gzip/bzip2 generated long/string columns and explicit false CSV policies.
+JSON generated parser type/charset/newline but no columns: a guessed JSON
+configuration is not automatically runnable with the existing CSV output.
+Empty input exited 1. Prose was treated as one string column named c0, not
+rejected as ambiguous. TSV selected a tab delimiter. The tiny headerless ASCII
+fixture selected ISO-8859-9, demonstrating that byte-valid UTF-8 alone does not
+reproduce upstream charset heuristics. These results must not be normalized
+away or turned into hardcoded fixture-specific output.
+
+Before native admission, distinguish a bounded supported profile from open
+charset, delimiter and schema gaps. Explicit schema preservation for JSON must
+be tested separately; native-only schema inference must not be called parity.
+
+Observe actual CSV, JSON, gzip/bzip2, empty and ambiguous fixtures with fresh
+isolated runtime directories, exact input/config/artifact hashes, bounded
+subprocess timeouts and retained exits/stdout/stderr/guessed configurations.
+Unknown runtime prerequisites are recorded before adoption; no guessed expected
+outcome or silent normalization. Do not copy upstream implementation code.
+License permission is distinct from patent/FTO; unreviewed gaps are not cleared.
+
+## Demo Command
+
+`PYTHONDONTWRITEBYTECODE=1 python3 tests/test_guess_oracle.py && PYTHONDONTWRITEBYTECODE=1 python3 tools/guess-oracle/run.py && git diff --check`
+
+Requires pinned EMBURK_REFERENCE_JAR and Java17 JAVA_HOME. Ten fixture exit/config
+hash projections are pinned after actual review, including added explicit JSON
+columns and headerless UTF-8 seed cases; the harness fails on any drift. Those
+additional cases preserve columns and charset respectively. Initial ten-case
+evidence: /var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/emburk-t0036-guess-pn8pd7ob.
+No native dependency, code or interpretation is admitted by this reference slice.
+
+## Evidence class, stop rule and non-claims
+
+Reference-only observation. Stop native implementation on missing reference
+runtime, unreviewed dependency admission, unsafe writes or unexplained behavior.
+No full guessing/profile/parity or combined acceptance claim until executable
+evidence and independently reviewed PR integration exist.

--- a/tests/test_guess_oracle.py
+++ b/tests/test_guess_oracle.py
@@ -1,0 +1,30 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+import json
+
+spec=importlib.util.spec_from_file_location("guess_oracle",Path(__file__).parents[1]/"tools/guess-oracle/run.py")
+oracle=importlib.util.module_from_spec(spec);spec.loader.exec_module(oracle)
+
+class GuessOracleTest(unittest.TestCase):
+    def evidence(self):
+        root=Path(tempfile.mkdtemp(prefix="emburk-guess-validator-"))
+        for name,data in {"input":oracle.fixture("csv"),"seed.yml":oracle.seed(),"stdout.log":b"","stderr.log":b"","guessed.yml":b"in: {}\n","exit.txt":b"0\n"}.items(): (root/name).write_bytes(data)
+        value={"case":"csv","artifact":oracle.JAR_SHA,"exit":0,"timeout":False,"files":oracle.inventory(root)}
+        path=root/"manifest.json";path.write_text(json.dumps(value));return root,path,value
+    def test_valid(self):
+        _,path,_=self.evidence();oracle.validate(path)
+    def test_modified_input_rejected_even_with_rehashed_manifest(self):
+        root,path,value=self.evidence();(root/"input").write_bytes(b"changed");value["files"]=oracle.inventory(root);path.write_text(json.dumps(value))
+        with self.assertRaises(ValueError):oracle.validate(path)
+    def test_timeout_missing_output_and_exit_drift_rejected(self):
+        for kind in ["timeout","missing","exit"]:
+            root,path,value=self.evidence()
+            if kind=="timeout":value["timeout"]=True
+            elif kind=="missing":(root/"guessed.yml").unlink();value["files"]=oracle.inventory(root)
+            else:(root/"exit.txt").write_text("1\n");value["files"]=oracle.inventory(root)
+            path.write_text(json.dumps(value))
+            with self.assertRaises(ValueError):oracle.validate(path)
+
+if __name__=="__main__":unittest.main()

--- a/tools/guess-oracle/run.py
+++ b/tools/guess-oracle/run.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Original black-box guess fixtures with retained, bounded subprocess evidence."""
+import bz2
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+JAR_SHA = "e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47"
+CASES = ("csv", "json", "gzip", "bzip2", "empty", "ambiguous", "headerless", "tsv", "json-columns", "headerless-utf8")
+EXPECTED = {
+ "csv":"f42d8561eb44f07001e04f1645ecd8fe211f61efc78558b34db45793862dc3eb",
+ "json":"5f5b836a335e322c5129c689d2d8b2f5d265f5f83506e79e79445a77fdeb2196",
+ "gzip":"54db557ff1b45d887a968992ed2ea6b1bba87efc3fd3251bb1ac64fe79b21824",
+ "bzip2":"cfab01bb7a4b5093cad23735030ba8b537c310bbf7a75147b45a42da66502037",
+ "empty":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+ "ambiguous":"c8ffa80829a0e5a184d30cc2435f9ec2a7f8c083ca75c777a4fc2c6d8458deee",
+ "headerless":"c26073c4f7d1e70911f763841da06be7234fb475ed90706adf3f94f5ebf6dc1e",
+ "tsv":"aa043f3520e42ae777d6b335ebb3eeaa6620ac34b1edf52fd685bd7f03f63720",
+ "json-columns":"b52875c144ed5fe8865c53091a612f3bf9af897e875d7d3f48d6a4e40be07705",
+ "headerless-utf8":"e8a642dabe2109b4c4459956adecddf36019d947a912aebe0619fe518e0ada9b",
+}
+
+def sha(data):
+    return hashlib.sha256(data).hexdigest()
+
+def fixture(case):
+    case = {"json-columns":"json", "headerless-utf8":"headerless"}.get(case,case)
+    csv = b"id,name\n1,Ada\n2,Bob\n"
+    return {"csv":csv, "json":b'{"id":1,"name":"Ada"}\n{"id":2,"name":"Bob"}\n',
+            "gzip":gzip.compress(csv,mtime=0), "bzip2":bz2.compress(csv),
+            "empty":b"", "ambiguous":b"unstructured prose\nanother sentence\n",
+            "headerless":b"1,Ada\n2,Bob\n", "tsv":b"id\tname\n1\tAda\n2\tBob\n"}[case]
+
+def seed(case="csv"):
+    base = b'''in:
+  type: file
+  path_prefix: input
+out:
+  type: file
+  path_prefix: output/result
+  file_ext: csv
+  formatter:
+    type: csv
+    charset: UTF-8
+    newline: LF
+    delimiter: ','
+    quote: '"'
+    escape: '"'
+    header_line: true
+    quote_policy: MINIMAL
+exec:
+  max_threads: 1
+  min_output_tasks: 1
+'''
+    if case=="json-columns":
+        base=base.replace(b"out:\n",b"  parser:\n    columns:\n    - {name: id, type: long}\n    - {name: name, type: string}\nout:\n")
+    if case=="headerless-utf8":
+        base=base.replace(b"out:\n",b"  parser: {charset: UTF-8}\nout:\n")
+    return base
+
+def inventory(root):
+    result={}
+    for name in ("input","seed.yml","stdout.log","stderr.log","guessed.yml","exit.txt"):
+        path=root/name
+        if path.is_symlink(): raise ValueError("evidence symlink")
+        if path.exists():
+            data=path.read_bytes(); result[name]={"size":len(data),"sha256":sha(data)}
+    return result
+
+def validate(path):
+    value=json.loads(path.read_text()); root=path.parent
+    if set(value)!={"case","artifact","exit","timeout","files"} or value["case"] not in CASES or value["artifact"]!=JAR_SHA: raise ValueError("manifest contract")
+    if type(value["exit"]) is not int or value["timeout"] is not False: raise ValueError("incomplete process")
+    if (root/"input").read_bytes()!=fixture(value["case"]) or (root/"seed.yml").read_bytes()!=seed(value["case"]): raise ValueError("fixture drift")
+    if (root/"exit.txt").read_text()!=str(value["exit"])+"\n" or inventory(root)!=value["files"]: raise ValueError("evidence drift")
+    if value["exit"]==0 and not (root/"guessed.yml").is_file(): raise ValueError("missing guess")
+    return value
+
+def run():
+    jar=Path(os.environ["EMBURK_REFERENCE_JAR"])
+    if jar.is_symlink(): raise ValueError("artifact symlink")
+    data=jar.read_bytes()
+    if sha(data)!=JAR_SHA: raise ValueError("artifact checksum")
+    java=Path(os.environ["JAVA_HOME"])/"bin/java"
+    base=Path(tempfile.mkdtemp(prefix="emburk-t0036-guess-"))
+    snapshot=base/"embulk.jar"; snapshot.write_bytes(data);snapshot.chmod(0o400)
+    env={"PATH":os.defpath,"JAVA_HOME":str(java.parent.parent)}
+    version=subprocess.run([str(java),"-version"],env=env,capture_output=True,timeout=10)
+    (base/"java-version.txt").write_bytes(version.stdout+version.stderr)
+    if version.returncode or b'version "17.' not in version.stderr: raise ValueError("Java17 required")
+    outcomes=[]
+    for case in CASES:
+        root=base/case;root.mkdir();(root/"home").mkdir();(root/"tmp").mkdir();(root/"output").mkdir()
+        (root/"input").write_bytes(fixture(case));(root/"seed.yml").write_bytes(seed(case))
+        timed_out=False
+        with (root/"stdout.log").open("xb") as stdout,(root/"stderr.log").open("xb") as stderr:
+            child=subprocess.Popen([str(java),f"-Duser.home={root/'home'}",f"-Djava.io.tmpdir={root/'tmp'}","-jar",str(snapshot),"-X",f"embulk_home={root/'home'}","guess","seed.yml","-o","guessed.yml"],cwd=root,env=env,stdout=stdout,stderr=stderr)
+            try: code=child.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                child.kill();code=child.wait();timed_out=True
+        (root/"exit.txt").write_text(str(code)+"\n")
+        value={"case":case,"artifact":JAR_SHA,"exit":code,"timeout":timed_out,"files":inventory(root)}
+        manifest=root/"manifest.json";manifest.write_text(json.dumps(value,sort_keys=True)+"\n")
+        validate(manifest)
+        if code != (1 if case=="empty" else 0) or sha((root/"guessed.yml").read_bytes())!=EXPECTED[case]: raise ValueError("reviewed reference projection changed")
+        outcomes.append(value)
+        print(f"GUESS_CASE={case}|exit={code}|manifest={manifest}",flush=True)
+    (base/"summary.json").write_text(json.dumps(outcomes,sort_keys=True)+"\n")
+    print(f"GUESS_ROOT={base}")
+
+if __name__=="__main__":
+    if len(sys.argv)==3 and sys.argv[1]=="validate": validate(Path(sys.argv[2]))
+    elif len(sys.argv)==1: run()
+    else: raise SystemExit("usage: run.py [validate MANIFEST]")


### PR DESCRIPTION
T-0036/S01, Issue29, 3SP. Reference-only ten actual Embulk0.11.5 guess projections, pinned embedded module metadata, retained subprocess evidence and drift checks. Three harness tests and all ten reviewed projections passed primary and independent Demo at1d577dd. Independent evidence /private/tmp/t0036-s01-independent.MjSxrL. JSON guessing preserves explicit columns but does not infer them; headerless charset and TSV behavior remain explicit design inputs. No native implementation or full guessing claim.