### PR TITLE
feat(t-0036): bounded seed-preserving native guess

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -112,7 +112,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0033 | Implement the JSON parser (bounded formats S01 Done) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |
 | T-0035 | Implement rename and remove-columns filters | Backlog | P1 | 3 | T-0023 | Plugin Implementer | Differential (Embulk) |
-| T-0036 | Implement format guessing (S01 reference observations active, forecast 3 SP) | In Progress | P1 | 5 | T-0032, T-0033, T-0034 | Plugin Implementer | Differential (Embulk) |
+| T-0036 | Implement format guessing (S01 Done, 3 SP; S02 active, forecast 5 SP) | In Progress | P1 | 8 | T-0032, T-0033, T-0034 | Plugin Implementer | Differential (Embulk) |
 | T-0037 | Pass File-to-File differential and resume acceptance | Backlog | P0 | 5 | T-0014, T-0025, T-0031–T-0036 | Tester | Differential (Embulk) |
 
 ## T-0040 — Java compatibility host

--- a/crates/emburk-cli/src/main.rs
+++ b/crates/emburk-cli/src/main.rs
@@ -3,7 +3,7 @@
 use std::{
     env,
     fs::{self, File, OpenOptions},
-    io::{self, BufReader},
+    io::{self, BufReader, Write},
     path::Path,
     sync::{
         Arc,
@@ -24,12 +24,25 @@ fn main() {
         )
     {
         println!(
-            "Usage: emburk run CONFIG [--state STATE_DIR]\n       emburk resume CONFIG STATE_DIR\n       emburk transfer-lines INPUT OUTPUT\n       emburk transfer-lines-stdout INPUT\n       emburk transfer-lines-null INPUT"
+            "Usage: emburk guess SEED [-o CONFIG]\n       emburk run CONFIG [--state STATE_DIR]\n       emburk resume CONFIG STATE_DIR\n       emburk transfer-lines INPUT OUTPUT\n       emburk transfer-lines-stdout INPUT\n       emburk transfer-lines-null INPUT"
         );
         return;
     }
     let cancelled = Arc::new(AtomicBool::new(false));
     let (command, result) = match arguments.as_slice() {
+        [_, command, seed] if command == "guess" => (
+            "guess",
+            emburk_core::guess_config(Path::new(seed)).and_then(|bytes| {
+                io::stdout()
+                    .lock()
+                    .write_all(&bytes)
+                    .map_err(|e| e.to_string())
+            }),
+        ),
+        [_, command, seed, flag, output] if command == "guess" && flag == "-o" => (
+            "guess",
+            emburk_core::guess_config_to_file(Path::new(seed), Path::new(output)),
+        ),
         #[cfg(unix)]
         [_, command, config, flag, directory] if command == "run" && flag == "--state" => (
             "run",

--- a/crates/emburk-cli/tests/guess.rs
+++ b/crates/emburk-cli/tests/guess.rs
@@ -1,0 +1,103 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::Command,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+static NEXT: AtomicUsize = AtomicUsize::new(0);
+fn root() -> PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "emburk-guess-cli-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir(&p).unwrap();
+    fs::create_dir(p.join("output")).unwrap();
+    p
+}
+fn seed(parser: &str) -> String {
+    format!(
+        "in:\n  type: file\n  path_prefix: input\n{parser}out:\n  type: file\n  path_prefix: output/result\n  file_ext: csv\n  formatter:\n    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    header_line: true\n    quote_policy: MINIMAL\nexec:\n  max_threads: 1\n  min_output_tasks: 1\n"
+    )
+}
+fn run(root: &PathBuf, args: &[&str], success: bool) {
+    let o = Command::new(env!("CARGO_BIN_EXE_emburk"))
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert_eq!(
+        o.status.success(),
+        success,
+        "{}",
+        String::from_utf8_lossy(&o.stderr)
+    );
+}
+#[test]
+fn generated_csv_and_explicit_json_schema_execute() {
+    for (data, parser, expected) in [
+        (
+            "account,label\n71,\n-3,Delta\n",
+            "  parser:\n    columns:\n    - {name: account, type: long}\n    - {name: label, type: string}\n",
+            "account,label\n71,\n-3,Delta\n",
+        ),
+        (
+            "account,label\n71,Delta\n-3,Echo\n",
+            "",
+            "account,label\n71,Delta\n-3,Echo\n",
+        ),
+        (
+            "{\"account\":71,\"label\":\"Delta\"}\n",
+            "  parser:\n    columns:\n    - {name: account, type: long}\n    - {name: label, type: string}\n",
+            "account,label\n71,Delta\n",
+        ),
+    ] {
+        let p = root();
+        fs::write(p.join("input"), data).unwrap();
+        let seed = seed(parser);
+        fs::write(p.join("seed.yml"), &seed).unwrap();
+        run(&p, &["guess", "seed.yml", "-o", "config.yml"], true);
+        run(&p, &["run", "config.yml"], true);
+        assert_eq!(
+            fs::read_to_string(p.join("output/result000.00.csv")).unwrap(),
+            expected
+        );
+        assert_eq!(fs::read_to_string(p.join("seed.yml")).unwrap(), seed);
+    }
+}
+#[test]
+fn rejection_and_output_no_clobber() {
+    for data in ["", "id\tname\n1\tAda\n", "1,Ada\n2,Bob\n"] {
+        let p = root();
+        fs::write(p.join("input"), data).unwrap();
+        fs::write(p.join("seed.yml"), seed("")).unwrap();
+        run(&p, &["guess", "seed.yml", "-o", "config.yml"], false);
+        assert!(!p.join("config.yml").exists());
+    }
+    let p = root();
+    fs::write(p.join("input"), "id,name\n1,Ada\n").unwrap();
+    fs::write(p.join("seed.yml"), seed("")).unwrap();
+    fs::write(p.join("config.yml"), "sentinel").unwrap();
+    run(&p, &["guess", "seed.yml", "-o", "config.yml"], false);
+    assert_eq!(
+        fs::read_to_string(p.join("config.yml")).unwrap(),
+        "sentinel"
+    );
+}
+#[test]
+fn oversize_explicit_conflicts_and_json_missing_schema_are_not_silently_fixed() {
+    let p = root();
+    fs::write(p.join("seed.yml"), seed("")).unwrap();
+    fs::write(p.join("input"), vec![b'x'; 32769]).unwrap();
+    run(&p, &["guess", "seed.yml", "-o", "config.yml"], false);
+    fs::write(p.join("input"), "{\"id\":1}\n").unwrap();
+    run(&p, &["guess", "seed.yml", "-o", "config.yml"], true);
+    run(&p, &["run", "config.yml"], false);
+    assert!(fs::read_dir(p.join("output")).unwrap().next().is_none());
+    fs::write(
+        p.join("seed.yml"),
+        seed("  parser: {charset: ISO-8859-9}\n"),
+    )
+    .unwrap();
+    run(&p, &["guess", "seed.yml"], false);
+}

--- a/crates/emburk-core/src/configured_csv.rs
+++ b/crates/emburk-core/src/configured_csv.rs
@@ -91,7 +91,12 @@ fn compile(root: Node) -> Result<Profile, String> {
         _ => return Err("unsupported parser type".into()),
     };
     let skip = if json {
-        exact(parser, &["type", "columns"])?;
+        exact(parser, &["type", "columns", "charset", "newline"])?;
+        for (key, value) in [("charset", "UTF-8"), ("newline", "LF")] {
+            if !values(parser, key).is_empty() {
+                require(parser, key, value)?;
+            }
+        }
         0
     } else {
         exact(
@@ -105,8 +110,20 @@ fn compile(root: Node) -> Result<Profile, String> {
                 "escape",
                 "skip_header_lines",
                 "columns",
+                "trim_if_not_quoted",
+                "allow_extra_columns",
+                "allow_optional_columns",
             ],
         )?;
+        for key in [
+            "trim_if_not_quoted",
+            "allow_extra_columns",
+            "allow_optional_columns",
+        ] {
+            if !values(parser, key).is_empty() {
+                require(parser, key, "false")?;
+            }
+        }
         for (k, v) in [
             ("type", "csv"),
             ("charset", "UTF-8"),

--- a/crates/emburk-core/src/guess.rs
+++ b/crates/emburk-core/src/guess.rs
@@ -1,0 +1,353 @@
+//! Private bounded guess profile, based on observed behavior, not upstream code.
+use crate::{
+    csv_stream, native_formats,
+    yaml_profile::{self, Node},
+};
+use serde_json::{Map, Value};
+use std::{
+    collections::BTreeSet,
+    fs::{self, File},
+    io::{BufReader, Cursor, Read, Write},
+    path::Path,
+};
+const RAW: usize = 1024 * 1024;
+const DECODED: usize = 32768;
+type Result<T> = std::result::Result<T, String>;
+pub fn guess_config_to_file(seed: &Path, output: &Path) -> Result<()> {
+    let bytes = guess_config(seed)?;
+    crate::publication::write_atomic(output, &std::sync::atomic::AtomicBool::new(false), |file| {
+        file.write_all(&bytes).map_err(|e| e.to_string())
+    })
+    .map_err(|e| e.to_string())
+}
+pub fn guess_config(path: &Path) -> Result<Vec<u8>> {
+    let mut root = object(yaml_profile::load(path)?.compile_node()?)?;
+    let mut input = root
+        .get("in")
+        .and_then(Value::as_object)
+        .ok_or("seed needs input mapping")?
+        .clone();
+    if input.get("type").and_then(Value::as_str) != Some("file") {
+        return Err("input type must be file".into());
+    }
+    if input
+        .keys()
+        .any(|k| !matches!(k.as_str(), "type" | "path_prefix" | "parser" | "decoders"))
+    {
+        return Err("unsupported input option".into());
+    }
+    let explicit = match input.get("parser") {
+        None => Map::new(),
+        Some(Value::Object(m)) => m.clone(),
+        _ => return Err("parser must be mapping".into()),
+    };
+    if explicit
+        .keys()
+        .any(|k| !matches!(k.as_str(), "charset" | "columns"))
+    {
+        return Err("explicit parser option not supported by guess".into());
+    }
+    if explicit.get("charset").is_some_and(|v| v != "UTF-8") {
+        return Err("only explicit UTF-8 is supported".into());
+    }
+    let prefix = Path::new(
+        input
+            .get("path_prefix")
+            .and_then(Value::as_str)
+            .ok_or("missing path_prefix")?,
+    );
+    let parent = prefix
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    let name = prefix.file_name().ok_or("missing input filename")?;
+    let mut selected = None;
+    for entry in fs::read_dir(parent).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        if entry
+            .file_name()
+            .as_encoded_bytes()
+            .starts_with(name.as_encoded_bytes())
+        {
+            let kind = entry.file_type().map_err(|e| e.to_string())?;
+            if kind.is_symlink() {
+                return Err("input symlink unsupported".into());
+            }
+            if kind.is_file() && selected.replace(entry.path()).is_some() {
+                return Err("multiple input files matched".into());
+            }
+        }
+    }
+    let mut raw = Vec::new();
+    File::open(selected.ok_or("no input matched")?)
+        .map_err(|e| e.to_string())?
+        .take((RAW + 1) as u64)
+        .read_to_end(&mut raw)
+        .map_err(|e| e.to_string())?;
+    if raw.len() > RAW {
+        return Err("raw sample exceeds 1 MiB".into());
+    }
+    let codec = if raw.starts_with(&[0x1f, 0x8b]) {
+        Some("gzip")
+    } else if raw.starts_with(b"BZh") {
+        Some("bzip2")
+    } else {
+        None
+    };
+    if let Some(decoders) = input.get("decoders") {
+        let expected = codec.map(|c| {
+            Value::Array(vec![Value::Object(Map::from_iter([(
+                "type".into(),
+                Value::String(c.into()),
+            )]))])
+        });
+        if expected.as_ref() != Some(decoders) {
+            return Err("explicit decoder does not match supported input".into());
+        }
+    } else if let Some(codec) = codec {
+        input.insert("decoders".into(), serde_json::json!([{"type":codec}]));
+    }
+    let cursor = Cursor::new(raw);
+    let reader: Box<dyn Read> = match codec {
+        Some("gzip") => Box::new(flate2::read::MultiGzDecoder::new(cursor)),
+        Some("bzip2") => Box::new(bzip2::read::MultiBzDecoder::new(cursor)),
+        _ => Box::new(cursor),
+    };
+    let mut data = Vec::new();
+    reader
+        .take((DECODED + 1) as u64)
+        .read_to_end(&mut data)
+        .map_err(|e| e.to_string())?;
+    if data.len() > DECODED {
+        return Err("decoded whole-file sample exceeds 32768 bytes".into());
+    }
+    let text = std::str::from_utf8(&data).map_err(|_| "only UTF-8 samples are supported")?;
+    if text.is_empty() {
+        return Err("cannot guess empty input".into());
+    }
+    if text.contains('\r') {
+        return Err("only LF samples are supported".into());
+    }
+    let mut parser = if text.trim_start().starts_with('{') {
+        let mut reader = BufReader::new(data.as_slice());
+        let mut count = 0;
+        while native_formats::read_json(&mut reader)
+            .map_err(|e| e.to_string())?
+            .is_some()
+        {
+            count += 1;
+        }
+        if count == 0 {
+            return Err("no JSON objects".into());
+        }
+        Map::from_iter([
+            ("type".into(), Value::String("json".into())),
+            ("charset".into(), Value::String("UTF-8".into())),
+            ("newline".into(), Value::String("LF".into())),
+        ])
+    } else {
+        csv_schema(
+            text,
+            explicit.contains_key("charset"),
+            explicit.get("columns"),
+        )?
+    };
+    // Explicit schema/charset remains authoritative, even when the resulting
+    // configuration requires further validation by the transfer consumer.
+    parser.extend(explicit);
+    input.insert("parser".into(), Value::Object(parser));
+    root.insert("in".into(), Value::Object(input));
+    let mut output = serde_json::to_vec_pretty(&Value::Object(root)).map_err(|e| e.to_string())?;
+    output.push(b'\n');
+    if output.len() > 65536 {
+        return Err("guessed config exceeds 64 KiB".into());
+    }
+    Ok(output)
+}
+fn object(node: Node) -> Result<Map<String, Value>> {
+    let Node::Map(items) = node else {
+        return Err("expected mapping".into());
+    };
+    let mut map = Map::new();
+    for (key, value) in items {
+        if map.insert(key, convert(value)?).is_some() {
+            return Err("duplicate seed key".into());
+        }
+    }
+    Ok(map)
+}
+fn convert(node: Node) -> Result<Value> {
+    Ok(match node {
+        Node::Scalar(s) => Value::String(s),
+        Node::Map(_) => Value::Object(object(node)?),
+        Node::Seq(items) => Value::Array(items.into_iter().map(convert).collect::<Result<_>>()?),
+    })
+}
+#[cfg(test)]
+fn csv(text: &str, explicit_utf8: bool) -> Result<Map<String, Value>> {
+    csv_schema(text, explicit_utf8, None)
+}
+fn csv_schema(
+    text: &str,
+    explicit_utf8: bool,
+    explicit_columns: Option<&Value>,
+) -> Result<Map<String, Value>> {
+    if text.contains('\t') || text.contains(';') || text.contains('|') {
+        return Err("unsupported possible delimiter".into());
+    }
+    let mut reader = BufReader::new(text.as_bytes());
+    let mut rows = Vec::new();
+    while let Some(row) = csv_stream::read_record(&mut reader).map_err(|e| e.to_string())? {
+        rows.push(row);
+    }
+    if rows.is_empty() {
+        return Err("no CSV rows".into());
+    }
+    let width = rows[0].len();
+    if width == 0 || width > 256 || rows.iter().any(|r| r.len() != width) {
+        return Err("inconsistent CSV rows".into());
+    }
+    let unique = rows[0]
+        .iter()
+        .map(|(v, _)| v)
+        .collect::<BTreeSet<_>>()
+        .len()
+        == width;
+    let header = rows.len() > 1
+        && unique
+        && rows[0].iter().all(|(v, _)| ident(v))
+        && rows[1..]
+            .iter()
+            .flatten()
+            .any(|(v, _)| v.parse::<i64>().is_ok());
+    let numeric = rows.iter().flatten().any(|(v, _)| v.parse::<i64>().is_ok());
+    if !header && numeric && !explicit_utf8 {
+        return Err("headerless numeric input requires explicit charset: UTF-8; automatic charset inference is unverified".into());
+    }
+    let names: Vec<String> = if header {
+        rows[0].iter().map(|(v, _)| v.clone()).collect()
+    } else {
+        (0..width).map(|i| format!("c{i}")).collect()
+    };
+    let mut columns = Vec::new();
+    for (index, name) in names.into_iter().enumerate() {
+        if explicit_columns.is_some() {
+            break;
+        }
+        let values = rows[usize::from(header)..]
+            .iter()
+            .map(|r| r[index].0.as_str())
+            .collect::<Vec<_>>();
+        if values.iter().any(|v| v.is_empty()) {
+            return Err("empty-field type inference is unsupported".into());
+        }
+        let longs = values.iter().filter(|v| v.parse::<i64>().is_ok()).count();
+        if longs != 0 && longs != values.len() {
+            return Err("mixed numeric type inference is unsupported".into());
+        }
+        if longs == 0
+            && values
+                .iter()
+                .any(|v| v.parse::<f64>().is_ok() || matches!(*v, "true" | "false"))
+        {
+            return Err("non-long scalar inference is unsupported".into());
+        }
+        columns.push(
+            serde_json::json!({"name":name,"type":if longs==values.len(){"long"}else{"string"}}),
+        );
+    }
+    let mut parser = Map::new();
+    for (key, value) in [
+        ("type", "csv"),
+        ("charset", "UTF-8"),
+        ("newline", "LF"),
+        ("delimiter", ","),
+        ("quote", "\""),
+        ("escape", "\""),
+        ("trim_if_not_quoted", "false"),
+        ("allow_extra_columns", "false"),
+        ("allow_optional_columns", "false"),
+    ] {
+        parser.insert(key.into(), Value::String(value.into()));
+    }
+    parser.insert(
+        "skip_header_lines".into(),
+        Value::String(usize::from(header).to_string()),
+    );
+    parser.insert(
+        "columns".into(),
+        explicit_columns.cloned().unwrap_or(Value::Array(columns)),
+    );
+    Ok(parser)
+}
+fn ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    matches!(chars.next(),Some(c)if c.is_ascii_alphabetic()||c=='_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn file_guess(bytes: &[u8]) -> Result<Value> {
+        static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "emburk-guess-unit-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        fs::create_dir(&root).unwrap();
+        fs::write(root.join("input"), bytes).unwrap();
+        fs::write(root.join("seed.yml"),serde_json::to_vec(&serde_json::json!({"in":{"type":"file","path_prefix":root.join("input").to_str().unwrap()}})).unwrap()).unwrap();
+        serde_json::from_slice(&guess_config(&root.join("seed.yml"))?).map_err(|e| e.to_string())
+    }
+    #[test]
+    fn compressed_samples_and_expansion_limits() {
+        let plain = b"account,label\n71,Delta\n-3,Echo\n";
+        let mut gzip = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        gzip.write_all(plain).unwrap();
+        let bytes = gzip.finish().unwrap();
+        assert_eq!(
+            file_guess(&bytes).unwrap()["in"]["decoders"][0]["type"],
+            "gzip"
+        );
+        let mut bzip = bzip2::write::BzEncoder::new(Vec::new(), bzip2::Compression::best());
+        bzip.write_all(plain).unwrap();
+        assert_eq!(
+            file_guess(&bzip.finish().unwrap()).unwrap()["in"]["decoders"][0]["type"],
+            "bzip2"
+        );
+        let mut gzip = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        gzip.write_all(&vec![b'x'; DECODED + 1]).unwrap();
+        assert!(file_guess(&gzip.finish().unwrap()).is_err());
+        assert!(file_guess(&vec![b'x'; RAW + 1]).is_err());
+        assert!(file_guess(&bytes[..bytes.len() - 2]).is_err());
+    }
+    #[test]
+    fn arbitrary_names_and_values() {
+        let p = csv("account,label\n71,Delta\n-3,Echo\n", false).unwrap();
+        assert_eq!(p["columns"][0]["name"], "account");
+        assert_eq!(p["columns"][0]["type"], "long");
+        assert_eq!(p["skip_header_lines"], "1");
+    }
+    #[test]
+    fn headerless_needs_explicit_charset() {
+        assert!(csv("1,Delta\n2,Echo\n", false).is_err());
+        assert_eq!(
+            csv("1,Delta\n2,Echo\n", true).unwrap()["columns"][0]["name"],
+            "c0"
+        );
+    }
+    #[test]
+    fn unsupported_inference_is_explicit() {
+        for input in [
+            "",
+            "a\tb\n1\tx\n",
+            "a,b\n1,x\n2\n",
+            "a,b\n1,x\ny,z\n",
+            "a,b\n1,\n",
+            "a,b\n1,3.2\n",
+        ] {
+            assert!(csv(input, false).is_err(), "{input:?}");
+        }
+    }
+}

--- a/crates/emburk-core/src/lib.rs
+++ b/crates/emburk-core/src/lib.rs
@@ -49,6 +49,9 @@ mod text_transfer;
 
 mod bounded_parallel;
 mod configured_csv;
+mod guess;
+#[doc(hidden)]
+pub use guess::{guess_config, guess_config_to_file};
 mod csv_stream;
 mod native_formats;
 mod publication;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,10 @@ plugin types become public, and the empty lifecycle coordinator stays separate.
 
 ## Principles
 
+ADR-0022 admits a bounded private guess adapter using existing dependencies.
+It preserves explicit schema/charset, emits JSON syntax accepted by the YAML
+adapter and does not infer JSON columns. S02 final acceptance is pending.
+
 ADR-0019 admits the selected native_formats adapter for bounded JSON framing,
 streaming codecs and ordered schema projections inside the configured consumer.
 Dependencies remain private and codec finalization precedes publication.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -2,6 +2,11 @@
 
 Compatibility is an evidence record, not a general promise.
 
+T-0036/S01 (#123) records ten actual guess projections. The S02 native profile
+is under acceptance: UTF-8/LF/comma, JSON objects, gzip/bzip2 and explicit seed
+preservation. Unseeded headerless charset detection and TSV remain unsupported
+gaps; JSON schema is not inferred. General guess parity is not accepted.
+
 T-0022/S01's isolated parser experiment is not production adoption or YAML
 compatibility. Ordered syntax observations are evaluated before configuration
 policy is selected; production adoption was separately admitted by ADR-0017.

--- a/docs/NATIVE_PIPELINE.md
+++ b/docs/NATIVE_PIPELINE.md
@@ -119,6 +119,22 @@ Ordinary `run` does not checkpoint. The earlier `transfer-lines`
 commands remain experimental and do not inherit the configured publication
 contract.
 
+## Bounded guess (acceptance pending)
+
+`emburk guess seed.yml -o config.yml` fills missing input parser/decoder fields
+while retaining the output and execution configuration. Without `-o`, the
+result goes to stdout. Output uses JSON syntax, which is valid YAML; an existing
+destination is never overwritten. Provide a file input type/path_prefix and
+the desired output settings in the seed.
+
+The initial whole-file profile rejects raw inputs over 1 MiB or decoded inputs
+over 32 KiB. It supports selected UTF-8/LF/comma CSV and JSON object inputs,
+with one gzip/bzip2 layer. JSON guessing preserves explicit columns but does
+not invent them; supply parser.columns to execute the current CSV output.
+Headerless numeric CSV needs an explicit parser.charset of UTF-8. TSV, general
+charset/type inference and large-input sampling remain unsupported. Explicit
+parser fields other than charset/columns are rejected, not silently replaced.
+
 ## Evidence boundary
 
 Eight selected CSV cases and five JSON/codec/filter cases are compared with

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,10 @@ including format guessing, general plugin profiles and Embulk resume parity.
 
 ## Phase 0: Governance and Compatibility Contract
 
+The next owner-authorized chain is T-0036/S01 reference guessing (integrated
+through #123), T-0036/S02 bounded native guessing, then T-0037/S01 combined
+guess/transfer/recovery acceptance. It does not complete broader parent gates.
+
 - Establish canonical project records, roles, workflow, provenance, and release-compliance gates.
 - Pin the Embulk core and selected plugin references.
 - Specify configuration, schema, value, lifecycle, transaction, cleanup, and resume behavior.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -64,10 +64,10 @@ explicit bounded native profile; broader parent compatibility gates remain open.
 
 ## Delivery queue
 
-T-0036/S01 is In Progress for actual guess observations, followed by bounded
-native guessing and T-0037 integrated acceptance under owner authorization.
-The first eight probes expose JSON-without-columns and charset/delimiter gaps;
-native guessing is not yet implemented or accepted.
+T-0036/S01 is Done through PR #123: three harness tests and ten reviewed actual
+guess projections passed independently at 1d577dd. T-0036/S02 is In Progress
+for bounded native guessing; T-0037 integrated acceptance follows. JSON schema
+inference and general charset/delimiter behavior remain explicit open gaps.
 
 T-0012/S08 is integrated through PR #82. The owner approved continuation of
 T-0012/S09 after the reference-execution explanation. Stage A at `7e46379`

--- a/docs/decisions/ADR-0022-bounded-guess-profile.md
+++ b/docs/decisions/ADR-0022-bounded-guess-profile.md
@@ -1,0 +1,21 @@
+# ADR-0022: Bounded native guess profile
+
+Status: Accepted for T-0036/S02 implementation; final acceptance pending.
+Date: 2026-09-06.
+
+Guess completes missing seed fields and preserves explicit choices. The initial
+native profile uses the existing YAML/CSV/JSON/codec adapters, bounded whole-file
+samples, and no new dependencies. JSON syntax is emitted as valid YAML; textual
+serialization equality is not required for configuration semantics.
+
+Actual S01 observations show that JSON guessing does not infer columns and
+charset detection is not equivalent to UTF-8 validation. Therefore native JSON
+column invention and fixture-specific charset guesses are rejected approaches.
+Unsupported TSV/charset/header/type cases remain open compatibility gaps, not
+silently accepted exceptions. A JSON guess may still require explicit columns
+before the selected CSV-output pipeline can execute it.
+
+No-clobber publication protects explicitly requested configuration output. The
+packet defines exact bounds, admitted behavior and acceptance commands. Combined
+guess/transfer/interruption/resume acceptance is a separate T-0037 slice and
+must classify reference gaps honestly.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,3 +25,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0019](ADR-0019-bounded-native-formats.md) | Bounded native formats and projections | Accepted through PR #119 |
 | [ADR-0020](ADR-0020-bounded-format-workers.md) | Bounded ordered formatting workers | Accepted through PR #120 |
 | [ADR-0021](ADR-0021-validated-native-spool-resume.md) | Validated native spool resume | Accepted through PR #121 |
+| [ADR-0022](ADR-0022-bounded-guess-profile.md) | Bounded seed-preserving guess profile | Accepted for implementation |

--- a/docs/provenance/T-0036-bounded-guess.md
+++ b/docs/provenance/T-0036-bounded-guess.md
@@ -1,0 +1,63 @@
+# T-0036/S02 bounded native guessing
+
+Issue #29. In Progress; forecast 5 SP. S01 accepted 3 SP through PR #123
+(cdb0fdc), after primary/independent three tests and ten reviewed projections at
+1d577dd. Parent Current becomes 8, Initial remains 5. S03/T-0037 acceptance
+remains separate; this packet does not complete full guessing compatibility.
+
+## Branch and allowlist
+
+Branch feat/t-0036-bounded-guess. Plugin Implementer owns only
+crates/emburk-core/src/guess.rs and its inline unit tests. After that returns,
+PM serially owns integration/fixes in that file, lib.rs, configured_csv.rs,
+crates/emburk-cli/src/main.rs and tests/guess.rs. PM owns this packet, prior
+S01 closeout, STATUS/TODO/ROADMAP/COMPATIBILITY/ARCHITECTURE, ADR-0022 and indexes,
+and the native guide. No concurrent source writers or new dependencies.
+The implementer returned an unregistered incomplete module; PM took serial
+source ownership, replaced the unbounded raw read, implemented actual seed
+preservation/codec output, and added compiled unit/CLI tests before acceptance.
+
+## Accepted bounded design
+
+Original behavioral implementation informed only by S01 observations and public
+documentation, not upstream source translation. Use already admitted YAML,
+JSON, CSV and codec adapters. Emit JSON syntax (valid YAML) with preserved seed
+fields; compare semantic keys/scalars rather than YAML formatting. Never
+replace explicit configuration values or invent JSON columns. An incomplete
+JSON configuration stays incomplete and cannot silently run with guessed types.
+
+Initially admit UTF-8/LF/comma CSV, JSON objects, and one gzip/bzip2 layer.
+Read at most 1 MiB raw compressed bytes and 32 KiB decoded sample, rejecting
+larger files in this initial whole-sample profile rather than pretending partial
+EOF proves the schema. Configuration/output remain <=64 KiB, <=256 columns;
+sampling of larger inputs is future work. CSV headers are unique identifier
+names with numeric evidence below; headerless numeric columns require explicit
+UTF-8 in the seed because the observed charset heuristic differs. Single-column
+prose is a string c0. Infer only uniform signed64/string columns; reject
+unsupported delimiters, inconsistent rows and uncertain numeric coercions.
+
+TSV and unseeded headerless charset guessing remain explicit unsupported gaps,
+not accepted deviations or matching comparisons. UTF-8 byte validity alone is
+not a claim to reproduce upstream ICU charset detection. Keep these reference
+cases in the gap inventory. Broader header/type/charset behavior is unverified.
+
+CLI: guess SEED [-o CONFIG]. Write stdout only without -o; with -o use existing
+no-clobber publication, never overwrite a destination or mutate input/seed.
+Configured CSV accepts only observed false trim/extra/optional policies; JSON
+accepts only explicit UTF-8/LF. True policies and other encodings stay rejected.
+
+## Demo Command
+
+`cargo fmt --all -- --check && cargo clippy --locked --workspace --all-targets -- -D warnings && cargo test --locked --workspace && git diff --check`
+
+Use the existing offline Cargo cache if needed. Tests include arbitrary names,
+compression, explicit configuration preservation, empty/invalid/oversized input,
+no-clobber output and executing generated supported configurations. Final
+cross-runtime guess/transfer/resume comparisons belong to T-0037/S01.
+
+## Evidence class, stop rule and non-claims
+
+Unit/Contract and native Integration. Stop on unbounded read, seed loss,
+unsafe write, dependency/provenance gap or mismatch hidden as a normalization.
+No full guess/plugin or charset/type inference parity, no automatic JSON schema,
+no large-input sampling claim. S01 artifact/license/IP non-claims remain.

--- a/docs/provenance/T-0036-guess-observations.md
+++ b/docs/provenance/T-0036-guess-observations.md
@@ -1,6 +1,6 @@
 # T-0036/S01 guess reference observations
 
-Issue: [#29](https://github.com/bhind/emburk/issues/29). In Progress; forecast 3 SP.
+Issue: [#29](https://github.com/bhind/emburk/issues/29). Done via PR #123; accepted 3 SP.
 Owner authorized observation, bounded native guess, then integrated acceptance.
 The prior seven-stage slice is integrated through PR #122. Broader parser,
 codec and recovery parent contracts remain open; prerequisites here are only
@@ -84,6 +84,15 @@ evidence: /var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/emburk-t0036-guess-pn
 No native dependency, code or interpretation is admitted by this reference slice.
 
 ## Evidence class, stop rule and non-claims
+
+Primary and independent exact Demo passed at 1d577dddb2209240fa96c1457fb2f3c669fbe30a.
+Three harness tests and ten pinned guess projections matched. Primary retained
+root: /var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/emburk-t0036-guess-0525q9a5.
+Independent /private/tmp/t0036-s01-independent.MjSxrL stdout SHA256
+52807f02e310b614a169fbf2453775da9cb2812a948f31621035f254d1ec8439;
+stderr 69796c8069b47be836df270a88b29823ad41a084acbab76d06c1d4ae5f567053;
+exit 0, SHA256 9a271f2a916b0b6ee6cecb2426f0b3206ef074578be55d9bc94f6f3fe3ab86aa.
+Independent revision/status unchanged. Merge cdb0fdcbcbe8c6ef13dcd2a13d6b1fb0327860c5.
 
 Reference-only observation. Stop native implementation on missing reference
 runtime, unreviewed dependency admission, unsafe writes or unexplained behavior.


### PR DESCRIPTION
T-0036/S02, Issue29, forecast5SP. Adds guess SEED [-o CONFIG], bounded raw/decoded reads, CSV/JSON and gzip/bzip2, explicit schema preservation, no-clobber config output, and observed parser options for generated configs. Initial whole-file limit32KiB decoded/1MiB raw; TSV, general charset/type inference and large input sampling remain unsupported. No automatic JSON columns. Primary exact Demo at421500e passed125tests with8existingignores; independent acceptance running. Explicit CSV schema inference bug found in review is fixed and regression-tested. T0037 combined differential/recovery acceptance follows; no full parent Done.