### PR TITLE
test(t-0037): combined guess transfer and recovery acceptance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -112,8 +112,8 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 are `Delivery`.
 | T-0033 | Implement the JSON parser (bounded formats S01 Done) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Differential (Embulk) |
 | T-0034 | Implement gzip and bzip2 codecs | Backlog | P1 | 5 | T-0031 | Plugin Implementer | Differential (Embulk) |
 | T-0035 | Implement rename and remove-columns filters | Backlog | P1 | 3 | T-0023 | Plugin Implementer | Differential (Embulk) |
-| T-0036 | Implement format guessing (S01 Done, 3 SP; S02 active, forecast 5 SP) | In Progress | P1 | 8 | T-0032, T-0033, T-0034 | Plugin Implementer | Differential (Embulk) |
-| T-0037 | Pass File-to-File differential and resume acceptance | Backlog | P0 | 5 | T-0014, T-0025, T-0031–T-0036 | Tester | Differential (Embulk) |
+| T-0036 | Implement format guessing (S01/S02 Done, accepted 8 SP; broader gaps queued) | Backlog | P1 | 8 | T-0032, T-0033, T-0034 | Plugin Implementer | Differential (Embulk) |
+| T-0037 | Pass File-to-File differential and resume acceptance (S01 active, forecast 5 SP) | In Progress | P0 | 5 | T-0014, T-0025, T-0031–T-0036 | Tester | Differential (Embulk) |
 
 ## T-0040 — Java compatibility host
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,8 @@ plugin types become public, and the empty lifecycle coordinator stays separate.
 
 ADR-0022 admits a bounded private guess adapter using existing dependencies.
 It preserves explicit schema/charset, emits JSON syntax accepted by the YAML
-adapter and does not infer JSON columns. S02 final acceptance is pending.
+adapter and does not infer JSON columns. S02 integrated through PR #124;
+combined reference/transfer/recovery evidence is tracked by T-0037/S01.
 
 ADR-0019 admits the selected native_formats adapter for bounded JSON framing,
 streaming codecs and ordered schema projections inside the configured consumer.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -3,7 +3,7 @@
 Compatibility is an evidence record, not a general promise.
 
 T-0036/S01 (#123) records ten actual guess projections. The S02 native profile
-is under acceptance: UTF-8/LF/comma, JSON objects, gzip/bzip2 and explicit seed
+integrated through PR #124: UTF-8/LF/comma, JSON objects, gzip/bzip2 and explicit seed
 preservation. Unseeded headerless charset detection and TSV remain unsupported
 gaps; JSON schema is not inferred. General guess parity is not accepted.
 

--- a/docs/NATIVE_PIPELINE.md
+++ b/docs/NATIVE_PIPELINE.md
@@ -119,7 +119,7 @@ Ordinary `run` does not checkpoint. The earlier `transfer-lines`
 commands remain experimental and do not inherit the configured publication
 contract.
 
-## Bounded guess (acceptance pending)
+## Bounded guess
 
 `emburk guess seed.yml -o config.yml` fills missing input parser/decoder fields
 while retaining the output and execution configuration. Without `-o`, the

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -65,8 +65,9 @@ explicit bounded native profile; broader parent compatibility gates remain open.
 ## Delivery queue
 
 T-0036/S01 is Done through PR #123: three harness tests and ten reviewed actual
-guess projections passed independently at 1d577dd. T-0036/S02 is In Progress
-for bounded native guessing; T-0037 integrated acceptance follows. JSON schema
+guess projections passed independently at 1d577dd. T-0036/S02 is Done through
+PR #124, after 125 tests passed independently at 421500e. T-0037/S01 integrated
+guess/transfer/native-recovery acceptance is In Progress. JSON schema
 inference and general charset/delimiter behavior remain explicit open gaps.
 
 T-0012/S08 is integrated through PR #82. The owner approved continuation of

--- a/docs/decisions/ADR-0022-bounded-guess-profile.md
+++ b/docs/decisions/ADR-0022-bounded-guess-profile.md
@@ -1,6 +1,6 @@
 # ADR-0022: Bounded native guess profile
 
-Status: Accepted for T-0036/S02 implementation; final acceptance pending.
+Status: Accepted and integrated through PR #124 (T-0036/S02).
 Date: 2026-09-06.
 
 Guess completes missing seed fields and preserves explicit choices. The initial

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,4 +25,4 @@ Architecture Decision Records capture durable decisions that affect product cont
 | [ADR-0019](ADR-0019-bounded-native-formats.md) | Bounded native formats and projections | Accepted through PR #119 |
 | [ADR-0020](ADR-0020-bounded-format-workers.md) | Bounded ordered formatting workers | Accepted through PR #120 |
 | [ADR-0021](ADR-0021-validated-native-spool-resume.md) | Validated native spool resume | Accepted through PR #121 |
-| [ADR-0022](ADR-0022-bounded-guess-profile.md) | Bounded seed-preserving guess profile | Accepted for implementation |
+| [ADR-0022](ADR-0022-bounded-guess-profile.md) | Bounded seed-preserving guess profile | Accepted through PR #124 |

--- a/docs/provenance/T-0036-bounded-guess.md
+++ b/docs/provenance/T-0036-bounded-guess.md
@@ -1,6 +1,6 @@
 # T-0036/S02 bounded native guessing
 
-Issue #29. In Progress; forecast 5 SP. S01 accepted 3 SP through PR #123
+Issue #29. Done through PR #124; accepted 5 SP. S01 accepted 3 SP through PR #123
 (cdb0fdc), after primary/independent three tests and ten reviewed projections at
 1d577dd. Parent Current becomes 8, Initial remains 5. S03/T-0037 acceptance
 remains separate; this packet does not complete full guessing compatibility.
@@ -56,6 +56,19 @@ no-clobber output and executing generated supported configurations. Final
 cross-runtime guess/transfer/resume comparisons belong to T-0037/S01.
 
 ## Evidence class, stop rule and non-claims
+
+Integrated as 54d2cc1abd8b849063859e9f57eaf0ea6b6a4bc9 after exact primary and
+independent Demo at 421500e5b46ff38a00bc8186956acb0d70d71e62: 125 tests passed,
+eight existing intentional ignores. Primary /private/tmp/t0036-s02-primary.Zjyjsw
+stdout SHA256 c2ededb2c3d50599c3318d78d1e6b89375d882c28ef51eb6fbb84e34c05585cd;
+stderr 79aa25dbb413f70aaa50cea73145107fdbe4f336e4a5d03f92f6eac204e8b910.
+Independent /private/tmp/t0036-s02-independent.ARslvI stdout SHA256
+e31c833095e60be3b8fb6388b049f0d6c2a9a20a781488e1b1b72bbb746e8064;
+stderr b2470955a79f16e6a9f67d2cf07186878f26a99f64f1d60f63c9bba27cc156a5.
+Both exits 0; independent revision/status unchanged. Review found explicit
+CSV schema was overlaid after unwanted inference; fixed and regression-tested
+before the accepted revision. Parent #29 remains Backlog, accepted total 8 SP,
+Current8/Initial5, broader guessing unaccepted.
 
 Unit/Contract and native Integration. Stop on unbounded read, seed loss,
 unsafe write, dependency/provenance gap or mismatch hidden as a normalization.

--- a/docs/provenance/T-0037-guess-transfer-resume.md
+++ b/docs/provenance/T-0037-guess-transfer-resume.md
@@ -1,0 +1,64 @@
+# T-0037/S01 guess/transfer/native-resume acceptance
+
+Issue #30. In Progress; forecast 5 SP. Depends on independently accepted
+T-0036/S01 (#123), S02 (#124, 54d2cc1), configured format/publication/worker/
+resume slices (#116–#121). Broader parent tasks are not presumed complete.
+
+## Branch and allowlist
+
+Branch test/t-0037-guess-transfer-resume. PM owns tests/t0037_guess_pipeline.py,
+tests/t0037_guess_pipeline_test.sh, this packet, prior S02 closeout and canonical
+STATUS/TODO/ROADMAP/COMPATIBILITY/ARCHITECTURE, native guide and ADR-0022/index.
+No Rust implementation or dependency changes. Independent reviewers are
+read-only. Maximum one active implementation/acceptance Project lane.
+
+## Acceptance matrix
+
+Re-run all ten pinned reference guess fixtures. Compare all keys, scalar text
+and ordered arrays of seven supported successful generated configurations;
+compare empty-input rejection separately. Retain two unsupported reference
+cases (TSV and unseeded headerless charset) as gaps, not successful matches.
+Use installed Ruby 2.6.10/Psych 3.1.0 only to parse both YAML documents to raw
+scalar trees; preserve keys and array order, reject aliases/duplicates. No
+schema/value coercion or broad YAML equivalence claim. Runtime API usage only;
+no Ruby/Psych source or library is redistributed/adopted by the Rust binary.
+
+Run six complete generated profiles through both actual Embulk and native
+transfer and compare full output filenames/bytes. Unseeded JSON has no columns
+and is not included as a runnable profile; no schema is silently inserted.
+For CSV, explicit-schema JSON, gzip and bzip2, first guess from a small sample,
+then create a larger same-schema job input BEFORE either execution. Record
+both input versions. Interrupt the actual native stateful job after a durable
+checkpoint, resume it, and compare final output with actual reference normal
+execution. Repeat resume and verify no target replacement. This compares final
+data after native recovery, NOT Embulk resume-file/lifecycle/transaction parity.
+
+Retain all commands/logs/exits/input/config/output hashes and exact native
+revision/binary/reference identities. Explicitly fail on mismatch or timeout;
+keep incomplete summary on failure. Forced mismatch is a required negative
+control. Existing CSV/formats comparisons and runtime tests remain unchanged.
+
+## Demo Command
+
+`cargo fmt --all -- --check && cargo clippy --locked --workspace --all-targets -- -D warnings && cargo test --locked --workspace && bash tests/t0032_configured_csv_differential_test.sh && bash tests/t0033_native_formats_differential_test.sh && bash tests/t0037_guess_pipeline_test.sh && git diff --check`
+
+Requires pinned reference JAR/Java17, installed Ruby/Psych and offline Cargo
+cache where necessary. Reference packet S01 records exact artifacts/licenses.
+
+## Evidence class, stop rule and non-claims
+
+Pre-acceptance controls: forced configuration mismatch under PYTHONOPTIMIZE
+returned 1 with incomplete summary in
+/var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/emburk-t0037-pipeline-f19397by.
+Forced timeout returned 1; owned child exit -9 and timeout=true were retained
+in /var/folders/mh/pwg8ncpd23g7bp63xgnh461r0000gn/T/emburk-t0037-pipeline-havrgy_6.
+Read-only PID probe confirmed that child was reaped. Review findings about
+missing failure records and vacuous rejection classification were fixed before
+acceptance: owned process groups are reaped, records are written in finally,
+rejected configurations must be absent with the intended diagnostic, and
+sample/job schema and expected output filenames are checked explicitly.
+
+Selected Differential plus native recovery Integration. Stop on unexplained
+mismatch, hidden gap, source drift, unsafe output or orphaned subprocess.
+No full T-0037 parent completion, generic guess/schema/charset support,
+Embulk recovery parity, benchmark, production or legal-clearance claim.

--- a/tests/t0037_guess_pipeline.py
+++ b/tests/t0037_guess_pipeline.py
@@ -1,0 +1,157 @@
+"""Selected real guess/transfer comparisons and native checkpoint recovery."""
+import bz2
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO=Path(__file__).resolve().parents[1]
+BINARY=REPO/"target/debug/emburk"
+BASE=Path(tempfile.mkdtemp(prefix="emburk-t0037-pipeline-"))
+RESULT={"complete":False,"cases":[],"recovery":[]}
+
+def require(ok,message):
+    if not ok: raise ValueError(message)
+def digest(path):return hashlib.sha256(path.read_bytes()).hexdigest()
+def record(root):
+    result={}
+    for path in sorted(root.rglob("*")):
+        require(not path.is_symlink(),"evidence symlink")
+        if path.is_file():result[str(path.relative_to(root))]={"size":path.stat().st_size,"sha256":digest(path)}
+    return result
+def kill_owned(child):
+    if child.poll() is None:
+        try:os.killpg(child.pid,signal.SIGKILL)
+        except ProcessLookupError:pass
+    return child.wait()
+def process(command,root,label,env=None,expected=0,timeout=180):
+    with (root/(label+".stdout")).open("xb") as stdout,(root/(label+".stderr")).open("xb") as stderr:
+        child=subprocess.Popen(command,cwd=root,env=env,stdout=stdout,stderr=stderr,start_new_session=True)
+        timed_out=False;code=None
+        try:code=child.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            timed_out=True;code=kill_owned(child);raise
+        finally:
+            if code is None:code=kill_owned(child)
+            (root/(label+".process.json")).write_text(json.dumps({"command":list(map(str,command)),"pid":child.pid,"exit":code,"timeout":timed_out})+"\n")
+    require(code==expected,f"unexpected exit {label}: {code}")
+    return (root/(label+".stdout")).read_bytes()
+
+RUBY=r'''
+require 'psych'; require 'json'
+def tree(n)
+ case n
+ when Psych::Nodes::Document then tree(n.children.fetch(0))
+ when Psych::Nodes::Scalar then n.value
+ when Psych::Nodes::Sequence then n.children.map{|c|tree(c)}
+ when Psych::Nodes::Mapping
+  h={};n.children.each_slice(2){|k,v| key=tree(k);raise 'duplicate key' if h.key?(key);h[key]=tree(v)};h
+ else raise 'unsupported YAML node'
+ end
+end
+puts JSON.generate(tree(Psych.parse(File.read(ARGV.fetch(0)))))
+'''
+def semantic(path,root,label):
+    return json.loads(process(["ruby","-e",RUBY,str(path)],root,label))
+def java_command(root,jar):
+    (root/"home").mkdir();(root/"tmp").mkdir()
+    java=str(Path(os.environ["JAVA_HOME"])/"bin/java")
+    return [java,f"-Duser.home={root/'home'}",f"-Djava.io.tmpdir={root/'tmp'}","-jar",str(jar),"-X",f"embulk_home={root/'home'}","run","config.yml"]
+def outputs(root):
+    return {str(p.relative_to(root/"output")):p.read_bytes() for p in sorted((root/"output").rglob("*")) if p.is_file()}
+def isolated(name,input_bytes,config):
+    root=BASE/name;root.mkdir();(root/"output").mkdir();(root/"input").write_bytes(input_bytes);(root/"config.yml").write_bytes(config);return root
+def interrupt(root):
+    command=[str(BINARY),"run","config.yml","--state","state"]
+    with (root/"interrupted.stdout").open("xb") as stdout,(root/"interrupted.stderr").open("xb") as stderr:
+        child=subprocess.Popen(command,cwd=root,stdout=stdout,stderr=stderr,start_new_session=True)
+        code=None;timed_out=False
+        try:
+            deadline=time.monotonic()+30
+            while not (root/"state/00000000000000000001.json").exists():
+                require(child.poll() is None,"job ended before checkpoint interruption")
+                require(time.monotonic()<deadline,"checkpoint timeout")
+                time.sleep(.002)
+            child.send_signal(signal.SIGINT);code=child.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            timed_out=True;raise
+        finally:
+            if code is None:code=kill_owned(child)
+            (root/"interrupted.process.json").write_text(json.dumps({"command":command,"pid":child.pid,"exit":code,"timeout":timed_out})+"\n")
+    require(code==130,"SIGINT exit must be 130")
+    require(not outputs(root),"interrupted job published output")
+
+def main():
+    RESULT["revision"]=subprocess.check_output(["git","rev-parse","HEAD"],cwd=REPO,text=True).strip()
+    RESULT["binary_sha256"]=digest(BINARY)
+    if os.environ.get("EMBURK_TEST_PIPELINE_TIMEOUT"):
+        process([sys.executable,"-c","import time;time.sleep(30)"],BASE,"forced-timeout",timeout=.1)
+    RESULT["ruby"]=process(["ruby","-rpsych","-e","puts RUBY_VERSION;puts Psych::VERSION"],BASE,"ruby-version").decode()
+    raw=process([sys.executable,"-B",str(REPO/"tools/guess-oracle/run.py")],BASE,"guess-reference",os.environ.copy())
+    roots=[line.split("=",1)[1] for line in raw.decode().splitlines() if line.startswith("GUESS_ROOT=")]
+    require(len(roots)==1,"missing reference root");reference=Path(roots[0]);jar=reference/"embulk.jar"
+    RESULT["reference_root"]=str(reference);RESULT["reference_sha256"]=digest(jar)
+    env={"PATH":os.defpath,"JAVA_HOME":os.environ["JAVA_HOME"]}
+    for case in ["csv","json","gzip","bzip2","empty","ambiguous","headerless","tsv","json-columns","headerless-utf8"]:
+        observed=reference/case
+        native=BASE/("guess-"+case);native.mkdir();shutil.copyfile(observed/"input",native/"input");shutil.copyfile(observed/"seed.yml",native/"seed.yml")
+        gap=case in {"headerless","tsv"};rejected=gap or case=="empty"
+        process([str(BINARY),"guess","seed.yml","-o","config.yml"],native,"guess",expected=1 if rejected else 0)
+        entry={"case":case,"class":"unsupported-gap" if gap else "matched-rejection" if rejected else "matched-config"}
+        if rejected:
+            require(not (native/"config.yml").exists(),"rejected guess created configuration")
+            reason={"empty":"cannot guess empty input","headerless":"headerless numeric input requires explicit charset","tsv":"unsupported possible delimiter"}[case]
+            require(reason in (native/"guess.stderr").read_text(),"unexpected rejection class: "+case)
+            entry["native_reason"]=reason
+            entry["reference_exit"]=1 if case=="empty" else 0
+        if not rejected:
+            expected=semantic(observed/"guessed.yml",native,"reference-tree");actual=semantic(native/"config.yml",native,"native-tree")
+            if os.environ.get("EMBURK_TEST_PIPELINE_MISMATCH"):actual["in"]["parser"]["type"]="forced-mismatch"
+            require(actual==expected,"guessed scalar tree mismatch: "+case)
+            if case!="json":
+                r=isolated("run-reference-"+case,(observed/"input").read_bytes(),(observed/"guessed.yml").read_bytes())
+                n=isolated("run-native-"+case,(observed/"input").read_bytes(),(native/"config.yml").read_bytes())
+                process(java_command(r,jar),r,"run",env);process([str(BINARY),"run","config.yml"],n,"run")
+                require(set(outputs(r))=={"result000.00.csv"},"missing expected reference output")
+                require(outputs(r)==outputs(n),"transfer bytes mismatch: "+case);entry["transfer"]="matched"
+            else:entry["transfer"]="not-claimed: explicit columns required"
+        RESULT["cases"].append(entry);print("PIPELINE_CASE="+json.dumps(entry),flush=True)
+    for case in ["csv","json-columns","gzip","bzip2"]:
+        observed=reference/case
+        if case=="json-columns": data=b'{"id":1,"name":"sample payload"}\n'*65536
+        else:data=b"id,name\n"+b"1,sample payload\n"*65536
+        if case=="gzip":data=gzip.compress(data,mtime=0)
+        if case=="bzip2":data=bz2.compress(data)
+        sample=(observed/"input").read_bytes()
+        decoded_sample=gzip.decompress(sample) if case=="gzip" else bz2.decompress(sample) if case=="bzip2" else sample
+        decoded_job=gzip.decompress(data) if case=="gzip" else bz2.decompress(data) if case=="bzip2" else data
+        if case=="json-columns":require(set(json.loads(decoded_sample.splitlines()[0]))==set(json.loads(decoded_job.splitlines()[0]))=={"id","name"},"sample/job JSON schema drift")
+        else:require(decoded_sample.splitlines()[0]==decoded_job.splitlines()[0]==b"id,name","sample/job CSV schema drift")
+        r=isolated("recovery-reference-"+case,data,(observed/"guessed.yml").read_bytes())
+        n=isolated("recovery-native-"+case,data,(BASE/("guess-"+case)/"config.yml").read_bytes())
+        (n/"guess-sample.bin").write_bytes((observed/"input").read_bytes())
+        process(java_command(r,jar),r,"run",env);interrupt(n)
+        process([str(BINARY),"resume","config.yml","state"],n,"resume")
+        require(set(outputs(r))=={"result000.00.csv"},"missing recovery reference output")
+        require(outputs(r)==outputs(n),"recovered bytes mismatch: "+case)
+        identities={str(p):p.stat().st_ino for p in (n/"output").iterdir()}
+        process([str(BINARY),"resume","config.yml","state"],n,"repeat-resume")
+        require(identities=={str(p):p.stat().st_ino for p in (n/"output").iterdir()},"repeat resume replaced target")
+        require(outputs(r)==outputs(n),"repeat resume changed output content")
+        RESULT["recovery"].append({"case":case,"result":"matched-reference-final-data","sample_sha256":digest(n/"guess-sample.bin"),"job_sha256":digest(n/"input")})
+        print("PIPELINE_RECOVERY="+case,flush=True)
+    require(digest(BINARY)==RESULT["binary_sha256"],"native binary changed during acceptance")
+    RESULT["complete"]=True
+
+try:main()
+finally:
+    RESULT["files"]=record(BASE)
+    (BASE/"summary.json").write_text(json.dumps(RESULT,sort_keys=True)+"\n")
+    print("PIPELINE_ROOT="+str(BASE),flush=True)

--- a/tests/t0037_guess_pipeline_test.sh
+++ b/tests/t0037_guess_pipeline_test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cargo build --locked -p emburk-cli
+PYTHONDONTWRITEBYTECODE=1 python3 tests/t0037_guess_pipeline.py


### PR DESCRIPTION
T-0037/S01 Issue30 forecast5SP. Adds retained actual reference guess/transfer comparisons and native SIGINT/resume final-data comparison. Seven guessed configurations, empty rejection, two explicit unsupported gaps, six generated-config transfers and four recovery profiles; no full parent/Embulk resume-file parity claim. Process timeout/mismatch controls are fail-closed and retain incomplete evidence; explicit error classes and output absence prevent vacuous rejection passes. No Rust/dependency changes. Primary and independent exact full Demo at ec69eb6 are running; merge only after completion. Packet docs/provenance/T-0037-guess-transfer-resume.md.