### PR TITLE
T-0079: Close Qwen assistant delivery records

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,8 @@ Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93. T-0071/S01 is Done through PR #127
 (`fe778b2`); T-0012, T-0013, T-0021 and all other unfinished items are
-`Backlog`, except T-0079, which is `In Progress`. T-0021/S06 is integrated
-through PR #96.
+`Backlog`. T-0079 is Done through PR #130 (`7582b33`). T-0021/S06 is
+integrated through PR #96.
 T-0012/S11 is Done through PR #99 after final-head acceptance. T-0023/S01 is
 Done through PR #101 (`d0eebf8`), after primary and independent final-head Demo
 at `196d648`. S01 accepts 5 SP. T-0023/S02 is Done through PR #103 (`5d72866`)
@@ -170,7 +170,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 and T-0079 are
 | T-0074 | Research the GUI and control-plane boundary | Backlog | Icebox | 3 | T-0073 | Project Manager | Planning |
 | T-0075 | Research Terraform deployment | Backlog | Icebox | 3 | T-0072 | Project Manager | Planning |
 | T-0076 | Research adaptive optimization | Backlog | Icebox | 3 | T-0071 | Performance Reviewer | Planning |
-| T-0079 | Add a bounded Qwen development assistant | In Progress | P1 | 5 | None | Rust Core Implementer | Integration |
+| T-0079 | Add a bounded Qwen development assistant (Done through PR #130) | Done | P1 | 5 | None | Rust Core Implementer | Integration |
 
 ## Pull order
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -89,11 +89,12 @@ respectively, with JVM startup included and one reference input task. Final-head
 acceptance passed at `a70d469`; Issue #47 is closed and its 5 SP Project item is
 Done.
 
-T-0079 is In Progress on Issue #129. The selected Windows-hosted Ollama service
-answered `/api/tags` with `qwen3-coder:30b` and returned exactly `READY` from a
-non-streaming chat request after its initial model load. The repository CLI
-also returned exactly `OPENAI_READY` through the `/v1` compatibility endpoint.
-The active slice is limited to a repository-local, non-applying
+T-0079 is Done through PR #130 (`7582b33`). The selected Windows-hosted Ollama
+service answered `/api/tags` with `qwen3-coder:30b` and returned exactly
+`READY` from a non-streaming chat request after its initial model load. The
+repository CLI also returned exactly `OPENAI_READY` through the `/v1`
+compatibility endpoint.
+The accepted slice is limited to a repository-local, non-applying
 development-assistant CLI, outbound data guards, IntelliJ entry points,
 documentation, and independent Rust verification. No model answer has been
 adopted as product code or evidence.
@@ -137,7 +138,7 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0012/S13 | Done | PR #107 integrated; primary and independent final-head acceptance passed |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
-| T-0079 | In Progress | Bounded, non-applying Qwen development assistant; Issue #129 |
+| T-0079 | Done | Bounded, non-applying Qwen development assistant; PR #130 integrated |
 
 T-0025/S01 is Done through PR #117. T-0014/S02 is Done through PR #118.
 T-0033/S01 is Done through PR #119. T-0024/S01 is Done through PR #120.

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -62,3 +62,10 @@ The staged-diff review path then redacted seven fixture-like patterns and
 received a response in 77.0 seconds. Qwen hallucinated filenames and changes
 that were absent from the supplied diff and repeated safeguards already in the
 implementation. Codex rejected the findings and made no model-directed change.
+
+The exact Demo passed at implementation revision `3972350`: all 12 Qwen
+assistant tests, workspace format/check, 126 Rust tests with eight intentional
+live-oracle ignores, and diff checks passed. Strict Clippy passed separately.
+PR #130 was squash-merged as `7582b33`; Issue #129 closed and its 5 SP Project
+item moved to Done. T-0079 is complete without changing any runtime or
+compatibility claim.

--- a/docs/provenance/T-0079-qwen-assistant.md
+++ b/docs/provenance/T-0079-qwen-assistant.md
@@ -93,7 +93,9 @@ quotes, but also incorrectly stated that a Rust `&str` cannot contain a null
 byte. Rust strings can contain `U+0000`. No part of the response was adopted.
 This result proves the guarded request/response path while demonstrating why
 model text cannot be treated as correctness evidence. The final local Demo
-remains pending until the implementation revision is available.
+passed at implementation revision `3972350`: 12 assistant tests, 126 Rust
+tests with eight intentional live-oracle ignores, workspace format/check, and
+diff checks all passed. Strict workspace Clippy also passed separately.
 
 A staged-diff review redacted seven fixture-like credential patterns before
 transmission and returned in 77.0 seconds. The response hallucinated an
@@ -105,3 +107,7 @@ transport evidence, not a successful semantic review.
 This task does not replace Codex, approve or apply model output, change runtime
 behavior, establish Embulk compatibility, provide a general AI-provider API,
 or claim that outbound filtering eliminates every disclosure risk.
+
+PR #130 was squash-merged as `7582b33`. Issue #129 closed and its 5 SP private
+Project item moved to Done. Integration accepts only the bounded tooling and
+evidence described here.


### PR DESCRIPTION
## Summary

- mark T-0079 Done in the canonical backlog and current-status record
- record the fixed implementation revision, exact Demo evidence, PR #130 merge, and Issue/Project completion
- preserve the explicit runtime, compatibility, security, and model-authority non-claims

## Verification

- `python3 -m unittest tests.test_qwen_assistant` — 12 passed
- `git diff --check` — passed
- `python3 scripts/project_governance_audit.py audit` — passed, WIP 0/2, 55 items
- implementation Demo at `3972350` — 12 assistant tests and 126 Rust tests passed; 8 intentional live-oracle ignores

## Integration

Implementation PR #130 was squash-merged as `7582b33`. Issue #129 is closed and its private Project item is Done.
