### PR TITLE
T-0080: Operationalize Qwen-first implementation assistance

### DIFF
--- a/.codex/agents/emburk-compatibility-host-implementer.toml
+++ b/.codex/agents/emburk-compatibility-host-implementer.toml
@@ -10,11 +10,14 @@ other edits and accommodate concurrent non-overlapping work. Read AGENTS.md,
 the Issue packet, compatibility contract, and provenance record. Keep external
 runtimes out of the Rust core. Do not edit canonical records or convert source
 inspection into a compatibility claim. For eligible non-sensitive work, use
-tools/qwen-assistant/run.py as a non-blocking default first pass for one useful
+tools/qwen-assistant/run.py as a bounded default first pass that is not a
+delivery gate for one useful
 code explanation, error analysis, fix proposal, test suggestion, or review.
 Never send `.codex`, upstream source, credentials, or private legal or security
 material. Use only the Qwen context allowlist and pass `--no-project-context`
-unless its default files are listed. Never apply Qwen output automatically. Inspect, independently
+unless its default files are listed. Treat prompt text and standard input as
+outbound context too. Stop the attempt at the packet timeout, then continue if
+it fails. Never apply Qwen output automatically. Inspect, independently
 implement, and test any useful suggestion; report its prompt scope, duration,
 and disposition as used, revised, or rejected. Return paths, commands, evidence
 class, findings, and unresolved risks to Jitro.

--- a/.codex/agents/emburk-compatibility-host-implementer.toml
+++ b/.codex/agents/emburk-compatibility-host-implementer.toml
@@ -9,6 +9,13 @@ assigned by the Project Manager. You are not alone in the codebase: preserve
 other edits and accommodate concurrent non-overlapping work. Read AGENTS.md,
 the Issue packet, compatibility contract, and provenance record. Keep external
 runtimes out of the Rust core. Do not edit canonical records or convert source
-inspection into a compatibility claim. Return paths, commands, evidence class,
-findings, and unresolved risks to Jitro.
+inspection into a compatibility claim. For eligible non-sensitive work, use
+tools/qwen-assistant/run.py as a non-blocking default first pass for one useful
+code explanation, error analysis, fix proposal, test suggestion, or review.
+Never send `.codex`, upstream source, credentials, or private legal or security
+material. Use only the Qwen context allowlist and pass `--no-project-context`
+unless its default files are listed. Never apply Qwen output automatically. Inspect, independently
+implement, and test any useful suggestion; report its prompt scope, duration,
+and disposition as used, revised, or rejected. Return paths, commands, evidence
+class, findings, and unresolved risks to Jitro.
 """

--- a/.codex/agents/emburk-plugin-implementer.toml
+++ b/.codex/agents/emburk-plugin-implementer.toml
@@ -9,6 +9,13 @@ the Project Manager. You are not alone in the codebase: preserve other edits
 and accommodate concurrent non-overlapping work. Read AGENTS.md, the Issue
 packet, compatibility contract, and provenance record. Implement from behavior
 and specifications; do not mechanically translate upstream source, edit
-canonical records, or broaden support claims beyond evidence. Return paths,
-commands, evidence class, findings, and unresolved risks to Jitro.
+canonical records, or broaden support claims beyond evidence. For eligible
+non-sensitive work, use tools/qwen-assistant/run.py as a non-blocking default
+first pass for one useful code explanation, error analysis, fix proposal, test
+suggestion, or review. Never send `.codex`, upstream source, credentials, or
+private legal or security material. Use only the Qwen context allowlist and pass
+`--no-project-context` unless its default files are listed. Never apply Qwen output automatically.
+Inspect, independently implement, and test any useful suggestion; report its
+prompt scope, duration, and disposition as used, revised, or rejected. Return
+paths, commands, evidence class, findings, and unresolved risks to Jitro.
 """

--- a/.codex/agents/emburk-plugin-implementer.toml
+++ b/.codex/agents/emburk-plugin-implementer.toml
@@ -10,11 +10,13 @@ and accommodate concurrent non-overlapping work. Read AGENTS.md, the Issue
 packet, compatibility contract, and provenance record. Implement from behavior
 and specifications; do not mechanically translate upstream source, edit
 canonical records, or broaden support claims beyond evidence. For eligible
-non-sensitive work, use tools/qwen-assistant/run.py as a non-blocking default
-first pass for one useful code explanation, error analysis, fix proposal, test
+non-sensitive work, use tools/qwen-assistant/run.py as a bounded default first
+pass that is not a delivery gate for one useful code explanation, error analysis, fix proposal, test
 suggestion, or review. Never send `.codex`, upstream source, credentials, or
 private legal or security material. Use only the Qwen context allowlist and pass
-`--no-project-context` unless its default files are listed. Never apply Qwen output automatically.
+`--no-project-context` unless its default files are listed. Treat prompt text
+and standard input as outbound context too. Stop the attempt at the packet
+timeout, then continue if it fails. Never apply Qwen output automatically.
 Inspect, independently implement, and test any useful suggestion; report its
 prompt scope, duration, and disposition as used, revised, or rejected. Return
 paths, commands, evidence class, findings, and unresolved risks to Jitro.

--- a/.codex/agents/emburk-project-manager.toml
+++ b/.codex/agents/emburk-project-manager.toml
@@ -12,8 +12,10 @@ work. Concentrate your own reasoning on product semantics, architecture,
 boundaries, risks, acceptance, and integration. For eligible bounded low-level
 work, direct implementers to use tools/qwen-assistant/run.py as a non-blocking
 default first pass, then inspect the disposition and independent evidence.
-Define a separate Qwen context allowlist; mutation ownership does not permit
-transmission. Qwen is advisory and has no mutation or acceptance authority. Keep combined In
+Define a separate Qwen context allowlist and bounded attempt timeout; mutation
+ownership does not permit transmission. "Non-blocking" means not a delivery
+gate, not that the synchronous request cannot wait. Qwen is advisory and has no
+mutation or acceptance authority. Keep combined In
 Progress and Review WIP at two. Never accept a
 compatibility, performance, licensing, patent, security, or completion claim
 from conversation or reviewer output alone.

--- a/.codex/agents/emburk-project-manager.toml
+++ b/.codex/agents/emburk-project-manager.toml
@@ -8,7 +8,13 @@ Act only as the primary Emburk Project Manager. Own scope, T-ID and roadmap
 mapping, acceptance criteria, named file ownership, canonical record edits,
 functional requirements review, final integration, verification, and lifecycle
 conclusions. Read AGENTS.md and use the Librarian before broad or external-source
-work. Keep combined In Progress and Review WIP at two. Never accept a
+work. Concentrate your own reasoning on product semantics, architecture,
+boundaries, risks, acceptance, and integration. For eligible bounded low-level
+work, direct implementers to use tools/qwen-assistant/run.py as a non-blocking
+default first pass, then inspect the disposition and independent evidence.
+Define a separate Qwen context allowlist; mutation ownership does not permit
+transmission. Qwen is advisory and has no mutation or acceptance authority. Keep combined In
+Progress and Review WIP at two. Never accept a
 compatibility, performance, licensing, patent, security, or completion claim
 from conversation or reviewer output alone.
 """

--- a/.codex/agents/emburk-rust-core-implementer.toml
+++ b/.codex/agents/emburk-rust-core-implementer.toml
@@ -7,6 +7,14 @@ developer_instructions = """
 Edit only the Rust execution-core and test files explicitly assigned by the
 Project Manager. You are not alone in the codebase: preserve other edits and
 accommodate concurrent non-overlapping work. Read AGENTS.md and the assigned
-Issue packet. Do not edit canonical project records. Return paths, exact
-commands and results, evidence class, findings, and unresolved risks to Jitro.
+Issue packet. For eligible non-sensitive work, use
+tools/qwen-assistant/run.py as a non-blocking default first pass for one useful
+code explanation, error analysis, fix proposal, test suggestion, or review.
+Never send `.codex`, upstream source, credentials, or private legal or security
+material. Use only the Qwen context allowlist and pass `--no-project-context`
+unless its default files are listed. Never apply Qwen output automatically. Inspect, independently
+implement, and test any useful suggestion; report its prompt scope, duration,
+and disposition as used, revised, or rejected. Do not edit canonical project
+records. Return paths, exact commands and results, evidence class, findings,
+and unresolved risks to Jitro.
 """

--- a/.codex/agents/emburk-rust-core-implementer.toml
+++ b/.codex/agents/emburk-rust-core-implementer.toml
@@ -8,11 +8,14 @@ Edit only the Rust execution-core and test files explicitly assigned by the
 Project Manager. You are not alone in the codebase: preserve other edits and
 accommodate concurrent non-overlapping work. Read AGENTS.md and the assigned
 Issue packet. For eligible non-sensitive work, use
-tools/qwen-assistant/run.py as a non-blocking default first pass for one useful
+tools/qwen-assistant/run.py as a bounded default first pass that is not a
+delivery gate for one useful
 code explanation, error analysis, fix proposal, test suggestion, or review.
 Never send `.codex`, upstream source, credentials, or private legal or security
 material. Use only the Qwen context allowlist and pass `--no-project-context`
-unless its default files are listed. Never apply Qwen output automatically. Inspect, independently
+unless its default files are listed. Treat prompt text and standard input as
+outbound context too. Stop the attempt at the packet timeout, then continue if
+it fails. Never apply Qwen output automatically. Inspect, independently
 implement, and test any useful suggestion; report its prompt scope, duration,
 and disposition as used, revised, or rejected. Do not edit canonical project
 records. Return paths, exact commands and results, evidence class, findings,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,8 @@ within explicitly assigned boundaries.
 - Parallel tracked-file mutation is permitted only for independently acceptable
   tasks with disjoint files, artifacts, tests, and evidence paths.
 - Each mutation packet names the real Issue, full T-ID, branch, owner, exact
-  file allowlist, dependencies, artifacts, `Demo Command`, evidence class,
-  stop rule, and non-claims.
+  mutation allowlist, optional Qwen context allowlist, dependencies, artifacts,
+  `Demo Command`, evidence class, stop rule, and non-claims.
 - Implementers do not edit canonical project records unless the Project Manager
   explicitly assigns those files.
 - Testers and reviewers remain read-only with respect to tracked files.
@@ -92,6 +92,28 @@ within explicitly assigned boundaries.
 
 See `docs/GOVERNANCE.md` for role definitions and `docs/WORKFLOW.md` for the
 full lifecycle.
+
+## Qwen-assisted implementation
+
+Codex and the Project Manager concentrate on task framing, product semantics,
+architecture, boundary and risk decisions, acceptance criteria, verification,
+and integration. For an eligible bounded implementation packet, use
+`tools/qwen-assistant/run.py` as the default first pass for at least one useful
+low-level activity such as code explanation, error triage, a patch proposal,
+test suggestions, or diff review.
+
+Qwen is an advisory model, not a repository role or an authority. Its use is
+non-blocking: continue without it when the endpoint is unavailable, slow, or
+unhelpful. Never apply its output automatically, treat it as completion
+evidence, or let it decide architecture, compatibility, licensing, patent,
+security, or acceptance questions. Inspect every suggestion, record whether it
+was used, revised, or rejected, and verify the resulting implementation with
+the task's independent checks and `Demo Command`.
+
+Send only explicitly permitted, repository-original, non-sensitive context.
+Do not send `.codex`, credentials, private security or legal material, upstream
+implementation source, build outputs, `.git`, or large files. See
+`docs/QWEN_ASSISTED_DEVELOPMENT.md` for the operating contract.
 
 ## Embulk reference and intellectual-property boundary
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@ within explicitly assigned boundaries.
   tasks with disjoint files, artifacts, tests, and evidence paths.
 - Each mutation packet names the real Issue, full T-ID, branch, owner, exact
   mutation allowlist, optional Qwen context allowlist, dependencies, artifacts,
-  `Demo Command`, evidence class, stop rule, and non-claims.
+  `Demo Command`, evidence class, Qwen attempt timeout when used, stop rule, and
+  non-claims.
 - Implementers do not edit canonical project records unless the Project Manager
   explicitly assigns those files.
 - Testers and reviewers remain read-only with respect to tracked files.
@@ -103,8 +104,9 @@ low-level activity such as code explanation, error triage, a patch proposal,
 test suggestions, or diff review.
 
 Qwen is an advisory model, not a repository role or an authority. Its use is
-non-blocking: continue without it when the endpoint is unavailable, slow, or
-unhelpful. Never apply its output automatically, treat it as completion
+delivery-non-blocking, not asynchronous: a synchronous request may wait until
+the packet's attempt timeout, after which work continues without it when the
+endpoint is unavailable, slow, or unhelpful. Never apply its output automatically, treat it as completion
 evidence, or let it decide architecture, compatibility, licensing, patent,
 security, or acceptance questions. Inspect every suggestion, record whether it
 was used, revised, or rejected, and verify the resulting implementation with
@@ -112,7 +114,10 @@ the task's independent checks and `Demo Command`.
 
 Send only explicitly permitted, repository-original, non-sensitive context.
 Do not send `.codex`, credentials, private security or legal material, upstream
-implementation source, build outputs, `.git`, or large files. See
+implementation source, build outputs, `.git`, or large files. This restriction
+also covers prompt text and standard input and is enforced by human review; the
+CLI's path and redaction guards cannot classify meaning or enforce a task's
+Qwen context allowlist. See
 `docs/QWEN_ASSISTED_DEVELOPMENT.md` for the operating contract.
 
 ## Embulk reference and intellectual-property boundary

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93. T-0071/S01 is Done through PR #127
 (`fe778b2`); T-0012, T-0013, T-0021 and all other unfinished items are
-`Backlog` except T-0080, which is In Progress. T-0079 is Done through PR #130
+`Backlog` except T-0080, which is in Review. T-0079 is Done through PR #130
 (`7582b33`). T-0021/S06 is
 integrated through PR #96.
 T-0012/S11 is Done through PR #99 after final-head acceptance. T-0023/S01 is
@@ -172,7 +172,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 and T-0079 are
 | T-0075 | Research Terraform deployment | Backlog | Icebox | 3 | T-0072 | Project Manager | Planning |
 | T-0076 | Research adaptive optimization | Backlog | Icebox | 3 | T-0071 | Performance Reviewer | Planning |
 | T-0079 | Add a bounded Qwen development assistant (Done through PR #130) | Done | P1 | 5 | None | Rust Core Implementer | Integration |
-| T-0080 | Operationalize Qwen-first implementation assistance | In Progress | P1 | 3 | T-0079 | Project Manager | Unit/Contract + Integration |
+| T-0080 | Operationalize Qwen-first implementation assistance | Review | P1 | 3 | T-0079 | Project Manager | Unit/Contract + Integration |
 
 ## Pull order
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,8 @@ Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93. T-0071/S01 is Done through PR #127
 (`fe778b2`); T-0012, T-0013, T-0021 and all other unfinished items are
-`Backlog`. T-0079 is Done through PR #130 (`7582b33`). T-0021/S06 is
+`Backlog` except T-0080, which is In Progress. T-0079 is Done through PR #130
+(`7582b33`). T-0021/S06 is
 integrated through PR #96.
 T-0012/S11 is Done through PR #99 after final-head acceptance. T-0023/S01 is
 Done through PR #101 (`d0eebf8`), after primary and independent final-head Demo
@@ -77,7 +78,7 @@ T-0010–T-0014 are `Compatibility Contract`; T-0020–T-0026 are `Core Runtime`
 T-0030–T-0037 and T-0060–T-0067 are `Native Plugins`; T-0040–T-0045 are
 `Java Host`; T-0050–T-0054 are `JRuby Host`; T-0070 is the `Delivery` epic;
 T-0071 and T-0076 are `Verification`; and T-0072–T-0075 and T-0079 are
-`Delivery`.
+`Delivery`. T-0080 is also `Delivery`.
 
 ## T-0001 — Governance and traceability
 
@@ -171,6 +172,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 and T-0079 are
 | T-0075 | Research Terraform deployment | Backlog | Icebox | 3 | T-0072 | Project Manager | Planning |
 | T-0076 | Research adaptive optimization | Backlog | Icebox | 3 | T-0071 | Performance Reviewer | Planning |
 | T-0079 | Add a bounded Qwen development assistant (Done through PR #130) | Done | P1 | 5 | None | Rust Core Implementer | Integration |
+| T-0080 | Operationalize Qwen-first implementation assistance | In Progress | P1 | 3 | T-0079 | Project Manager | Unit/Contract + Integration |
 
 ## Pull order
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,6 +44,13 @@ Qwen model through Ollama. It is advisory tooling: Codex or a human must inspect
 every answer, make any change separately, and run independent verification.
 The CLI has no command that applies a model-generated patch.
 
+The project uses this assistant as a non-blocking default first pass for
+eligible low-level implementation work so that Codex and the Project Manager
+can concentrate on requirements, architecture, boundaries, risk, acceptance,
+and integration. Read [Qwen-assisted development](QWEN_ASSISTED_DEVELOPMENT.md)
+for the responsibility split, eligibility rules, response disposition, and
+independent-evidence contract.
+
 The defaults select the project owner's Windows Ollama service:
 
 ```sh

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,8 +44,8 @@ Qwen model through Ollama. It is advisory tooling: Codex or a human must inspect
 every answer, make any change separately, and run independent verification.
 The CLI has no command that applies a model-generated patch.
 
-The project uses this assistant as a non-blocking default first pass for
-eligible low-level implementation work so that Codex and the Project Manager
+The project uses this assistant as a bounded default first pass that is not a
+delivery gate for eligible low-level implementation work so that Codex and the Project Manager
 can concentrate on requirements, architecture, boundaries, risk, acceptance,
 and integration. Read [Qwen-assisted development](QWEN_ASSISTED_DEVELOPMENT.md)
 for the responsibility split, eligibility rules, response disposition, and

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -32,6 +32,21 @@ Add a specialized role only when a recurring responsibility cannot be expressed
 through these boundaries. Role names belong in the Project `Owner Role` and
 `Support Roles` fields; GitHub assignees identify people, not authority.
 
+### Advisory development model
+
+The Windows-hosted Qwen3-Coder service is an advisory implementation tool, not
+a Project role. It owns no files or decisions and cannot supply evidence,
+approve a diff, or change lifecycle state. Codex and the Project Manager retain
+problem framing, product semantics, architecture, risk and boundary decisions,
+acceptance, verification, and integration. Eligible implementers use Qwen as a
+non-blocking default first pass for bounded code explanation, error triage,
+implementation and test proposals, and permitted diff review.
+
+Every response is inspected and classified as used, revised, or rejected. Any
+resulting repository change is produced and verified independently. The full
+information boundary and operating loop are defined in
+`docs/QWEN_ASSISTED_DEVELOPMENT.md`.
+
 ## Decision and evidence governance
 
 Create an ADR when a change accepts or supersedes an architectural invariant,

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -39,8 +39,9 @@ a Project role. It owns no files or decisions and cannot supply evidence,
 approve a diff, or change lifecycle state. Codex and the Project Manager retain
 problem framing, product semantics, architecture, risk and boundary decisions,
 acceptance, verification, and integration. Eligible implementers use Qwen as a
-non-blocking default first pass for bounded code explanation, error triage,
-implementation and test proposals, and permitted diff review.
+bounded default first pass for code explanation, error triage, implementation
+and test proposals, and permitted diff review. It is not a delivery gate; an
+individual call is synchronous and may wait until its task-defined timeout.
 
 Every response is inspected and classified as used, revised, or rejected. Any
 resulting repository change is produced and verified independently. The full

--- a/docs/QWEN_ASSISTED_DEVELOPMENT.md
+++ b/docs/QWEN_ASSISTED_DEVELOPMENT.md
@@ -78,8 +78,9 @@ unclassified material into them.
    records, integrates the pull request, and performs the final status change.
 
 Qwen is deliberately not a delivery gate. The CLI call is synchronous and may
-wait until its configured timeout; the default is currently 600 seconds. The
-packet's finite attempt timeout bounds that wait. If Qwen is unreachable,
+wait until its configured timeout; the default is currently 600 seconds. Before
+each consultation, set `EMBURK_QWEN_TIMEOUT_SECONDS` to the packet's finite
+attempt timeout so the configured request actually enforces that bound. If Qwen is unreachable,
 reaches the timeout, or produces an unusable answer, record that outcome once
 and continue with the assigned work. Repeated retries do not gate delivery or
 consume a separate Kanban item.

--- a/docs/QWEN_ASSISTED_DEVELOPMENT.md
+++ b/docs/QWEN_ASSISTED_DEVELOPMENT.md
@@ -1,0 +1,107 @@
+# Qwen-assisted development
+
+This document defines how Emburk uses the Windows-hosted Qwen3-Coder service as
+an implementation assistant while keeping Codex and the Project Manager focused
+on higher-level engineering judgment.
+
+Qwen is advisory. It is not a Project role, does not own files, does not mutate
+the repository, and cannot approve a change or supply completion evidence.
+
+## Responsibility split
+
+Codex and the Project Manager retain responsibility for:
+
+- problem framing, product semantics, and compatibility intent;
+- architecture, component boundaries, and public interfaces;
+- licensing, provenance, patent, security, and operational risk decisions;
+- task packets, file ownership, acceptance criteria, and verification plans;
+- final diff inspection, evidence assessment, integration, and status changes.
+
+Qwen is the default first-pass assistant for eligible bounded work such as:
+
+- explaining repository-original code selected by an implementer;
+- triaging a compiler, test, or runtime error;
+- proposing a local implementation or test approach within an assigned packet;
+- identifying edge cases and missing tests;
+- reviewing a permitted diff before the authoritative review.
+
+The assigned implementer remains accountable for every resulting line and must
+understand, inspect, and independently verify it.
+
+## Eligibility and information boundary
+
+A Qwen request is eligible only when its purpose is bounded and every supplied
+file appears in the task packet's separate `Qwen context allowlist`. The
+mutation allowlist grants write ownership and does not grant permission to send
+a file to the model. Send only repository-original, non-sensitive material that
+is necessary for the request.
+
+Never send:
+
+- `.codex`, `.git`, credentials, tokens, environment files, or local machine
+  configuration;
+- private security reports, legal analysis, or confidential provenance notes;
+- upstream implementation source or mechanically translated code;
+- build outputs, generated artifacts, dependency caches, or large files.
+
+The CLI enforces a conservative path and size policy, but that enforcement does
+not replace human classification. When uncertain, omit the material and ask the
+Project Manager or Librarian to resolve the boundary.
+
+The CLI normally adds `AGENTS.md` and the workspace `Cargo.toml`. The task's
+Qwen context allowlist must name those files when they are needed. Otherwise,
+pass `--no-project-context` and add only explicitly allowed `--context` or
+command-specific files.
+
+## Operating loop
+
+1. Codex or the Project Manager defines the outcome, boundaries, acceptance
+   criteria, mutation allowlist, Qwen context allowlist, evidence class, and
+   `Demo Command`.
+2. For eligible work, the implementer attempts one useful Qwen first pass with
+   `explain`, `error`, `fix`, or `review` before completing the low-level work.
+3. The implementer classifies the response as `used`, `revised`, or `rejected`
+   and records the prompt scope, elapsed time, rationale, and any material risk.
+4. The implementer manually produces the repository change. Qwen output is
+   never applied automatically.
+5. The implementer runs deterministic checks such as formatting, compilation,
+   linting, and focused tests. Qwen's answer is not evidence.
+6. Codex reviews the actual diff and evidence against the higher-level intent.
+7. The Project Manager runs or confirms the task's `Demo Command`, reconciles
+   records, integrates the pull request, and performs the final status change.
+
+Qwen is deliberately non-blocking. If it is unreachable, exceeds the configured
+timeout, or produces an unusable answer, record that outcome once and continue
+with the assigned work. Repeated retries are not a delivery gate and do not
+consume a separate Kanban item.
+
+## Decision exclusions
+
+Qwen must not decide or approve:
+
+- product scope, architecture, or an ADR;
+- Embulk compatibility or behavioral support claims;
+- licensing, patent, provenance, privacy, or security conclusions;
+- destructive commands, external publication, or repository integration;
+- test sufficiency, completion, or release readiness.
+
+These exclusions keep Codex focused on decisions whose consequences span
+components or releases while using Qwen where local implementation feedback is
+most useful.
+
+## Recording a consultation
+
+For material consultations, add a concise entry to the task log or provenance
+record. Record the command mode, file names or prompt scope, elapsed time,
+response disposition, and independent verification. Do not copy a sensitive
+prompt or a long generated response into repository records.
+
+Example:
+
+```text
+Qwen consultation: review of src/example.rs and tests/example.rs; 42 s;
+disposition: revised (kept the boundary-case idea, rejected the API change);
+verification: cargo fmt --check, cargo check, and focused tests passed.
+```
+
+See `docs/DEVELOPMENT.md` for CLI commands and environment configuration.

--- a/docs/QWEN_ASSISTED_DEVELOPMENT.md
+++ b/docs/QWEN_ASSISTED_DEVELOPMENT.md
@@ -45,19 +45,26 @@ Never send:
 - build outputs, generated artifacts, dependency caches, or large files.
 
 The CLI enforces a conservative path and size policy, but that enforcement does
-not replace human classification. When uncertain, omit the material and ask the
-Project Manager or Librarian to resolve the boundary.
+not replace human classification. The CLI does not read the Issue or enforce its
+Qwen context allowlist. `--no-project-context` only disables the two default
+files; it does not prove that added files are authorized. When uncertain, omit
+the material and ask the Project Manager or Librarian to resolve the boundary.
 
 The CLI normally adds `AGENTS.md` and the workspace `Cargo.toml`. The task's
 Qwen context allowlist must name those files when they are needed. Otherwise,
 pass `--no-project-context` and add only explicitly allowed `--context` or
 command-specific files.
 
+Prompt text and standard input, including `error` input, are outbound context
+too. They are not governed by file-path allowlisting, and secret redaction is
+heuristic rather than semantic classification. Never paste prohibited or
+unclassified material into them.
+
 ## Operating loop
 
 1. Codex or the Project Manager defines the outcome, boundaries, acceptance
    criteria, mutation allowlist, Qwen context allowlist, evidence class, and
-   `Demo Command`.
+   `Demo Command`. The packet also defines a finite Qwen attempt timeout.
 2. For eligible work, the implementer attempts one useful Qwen first pass with
    `explain`, `error`, `fix`, or `review` before completing the low-level work.
 3. The implementer classifies the response as `used`, `revised`, or `rejected`
@@ -70,9 +77,11 @@ command-specific files.
 7. The Project Manager runs or confirms the task's `Demo Command`, reconciles
    records, integrates the pull request, and performs the final status change.
 
-Qwen is deliberately non-blocking. If it is unreachable, exceeds the configured
-timeout, or produces an unusable answer, record that outcome once and continue
-with the assigned work. Repeated retries are not a delivery gate and do not
+Qwen is deliberately not a delivery gate. The CLI call is synchronous and may
+wait until its configured timeout; the default is currently 600 seconds. The
+packet's finite attempt timeout bounds that wait. If Qwen is unreachable,
+reaches the timeout, or produces an unusable answer, record that outcome once
+and continue with the assigned work. Repeated retries do not gate delivery or
 consume a separate Kanban item.
 
 ## Decision exclusions

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ Repository records are the authoritative project memory. GitHub Issues and the G
 - [GitHub Project operations](PROJECT_OPERATIONS.md)
 - [Development](DEVELOPMENT.md)
   - Includes the bounded Qwen development-assistant CLI and IntelliJ entry points.
+- [Qwen-assisted development](QWEN_ASSISTED_DEVELOPMENT.md)
+  - Defines the Codex/Qwen responsibility split, data boundary, and verification loop.
 
 ## Governance
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -99,6 +99,12 @@ development-assistant CLI, outbound data guards, IntelliJ entry points,
 documentation, and independent Rust verification. No model answer has been
 adopted as product code or evidence.
 
+T-0080 is In Progress on Issue #132. It is defining Qwen as a non-blocking
+default first pass for eligible low-level assistance while retaining
+requirements, architecture, risk, acceptance, verification, and integration
+with Codex and the Project Manager. It changes no runtime, Cargo dependency,
+compatibility behavior, or public API.
+
 T-0012/S08 is integrated through PR #82. The owner approved continuation of
 T-0012/S09 after the reference-execution explanation. Stage A at `7e46379`
 captured 114/93 events with exact selected double bits preserved; primary
@@ -139,6 +145,7 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 | T-0079 | Done | Bounded, non-applying Qwen development assistant; PR #130 integrated |
+| T-0080 | In Progress | Qwen-first low-level assistance with Codex retaining higher-level authority |
 
 T-0025/S01 is Done through PR #117. T-0014/S02 is Done through PR #118.
 T-0033/S01 is Done through PR #119. T-0024/S01 is Done through PR #120.
@@ -148,7 +155,8 @@ Other unfinished stable tasks remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
 is the coordination mirror. T-0079 is its 55th item; its lifecycle state,
 estimate, role, workstream, evidence class, and Demo Command were initialized
-on 2026-09-09. The first 52 items' lifecycle states, initial estimates, roles,
+on 2026-09-09. T-0080 is its 56th item and is In Progress with 3 SP. The first
+52 items' lifecycle states, initial estimates, roles,
 dependencies, workstreams, evidence classes, and views were reconciled to the
 repository records on 2026-09-05.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -99,8 +99,8 @@ development-assistant CLI, outbound data guards, IntelliJ entry points,
 documentation, and independent Rust verification. No model answer has been
 adopted as product code or evidence.
 
-T-0080 is In Progress on Issue #132. It is defining Qwen as a non-blocking
-default first pass for eligible low-level assistance while retaining
+T-0080 is in Review through PR #133. It defines Qwen as a non-blocking default
+first pass for eligible low-level assistance while retaining
 requirements, architecture, risk, acceptance, verification, and integration
 with Codex and the Project Manager. It changes no runtime, Cargo dependency,
 compatibility behavior, or public API.
@@ -145,7 +145,7 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 | T-0079 | Done | Bounded, non-applying Qwen development assistant; PR #130 integrated |
-| T-0080 | In Progress | Qwen-first low-level assistance with Codex retaining higher-level authority |
+| T-0080 | Review | PR #133 defines Qwen-first low-level assistance with Codex retaining higher-level authority |
 
 T-0025/S01 is Done through PR #117. T-0014/S02 is Done through PR #118.
 T-0033/S01 is Done through PR #119. T-0024/S01 is Done through PR #120.
@@ -155,7 +155,7 @@ Other unfinished stable tasks remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
 is the coordination mirror. T-0079 is its 55th item; its lifecycle state,
 estimate, role, workstream, evidence class, and Demo Command were initialized
-on 2026-09-09. T-0080 is its 56th item and is In Progress with 3 SP. The first
+on 2026-09-09. T-0080 is its 56th item and is in Review with 3 SP. The first
 52 items' lifecycle states, initial estimates, roles,
 dependencies, workstreams, evidence classes, and views were reconciled to the
 repository records on 2026-09-05.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -14,8 +14,8 @@ Status: active
    label epics `epic` and actionable items `work-item`, add it to the Project,
    and record this packet before `Ready`:
    `Authority`, `Dependencies`, `Mutation owner`, `Mutation allowlist`, optional
-   `Qwen context allowlist`, `Artifacts`, `Acceptance`, `Evidence class`, `Stop
-   rule`, and `Non-claims`.
+   `Qwen context allowlist` and Qwen attempt timeout, `Artifacts`, `Acceptance`,
+   `Evidence class`, `Stop rule`, and `Non-claims`.
 6. Create the dedicated task branch and move the item to `In Progress` only
    after all metadata is populated.
 
@@ -81,9 +81,10 @@ useful low-level first pass through `tools/qwen-assistant/run.py`: code
 explanation, error analysis, a non-applying fix proposal, test suggestions, or
 a permitted diff review.
 
-Qwen is advisory and non-blocking. If it is unavailable, slow, or unhelpful,
-record that outcome once and continue. Classify a response as used, revised, or
-rejected; never apply it automatically or treat it as evidence. Codex inspects
+Qwen is advisory and not a delivery gate. Its CLI request is synchronous, so
+the task packet sets a bounded attempt timeout. If it is unavailable, reaches
+that timeout, or is unhelpful, record that outcome once and continue. Classify
+a response as used, revised, or rejected; never apply it automatically or treat it as evidence. Codex inspects
 the actual change against the higher-level intent, and repository checks plus
 the task's `Demo Command` remain authoritative. Follow
 `docs/QWEN_ASSISTED_DEVELOPMENT.md` for data exclusions and decision boundaries.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -82,7 +82,8 @@ explanation, error analysis, a non-applying fix proposal, test suggestions, or
 a permitted diff review.
 
 Qwen is advisory and not a delivery gate. Its CLI request is synchronous, so
-the task packet sets a bounded attempt timeout. If it is unavailable, reaches
+the task packet sets a bounded attempt timeout and the caller maps it to
+`EMBURK_QWEN_TIMEOUT_SECONDS`. If it is unavailable, reaches
 that timeout, or is unhelpful, record that outcome once and continue. Classify
 a response as used, revised, or rejected; never apply it automatically or treat it as evidence. Codex inspects
 the actual change against the higher-level intent, and repository checks plus

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -13,8 +13,9 @@ Status: active
 5. Create or reuse a real open Issue for every epic and actionable work item,
    label epics `epic` and actionable items `work-item`, add it to the Project,
    and record this packet before `Ready`:
-   `Authority`, `Dependencies`, `Mutation owner`, `Allowlist`, `Artifacts`,
-   `Acceptance`, `Evidence class`, `Stop rule`, and `Non-claims`.
+   `Authority`, `Dependencies`, `Mutation owner`, `Mutation allowlist`, optional
+   `Qwen context allowlist`, `Artifacts`, `Acceptance`, `Evidence class`, `Stop
+   rule`, and `Non-claims`.
 6. Create the dedicated task branch and move the item to `In Progress` only
    after all metadata is populated.
 
@@ -70,6 +71,22 @@ test or review lane.
   unsupported cases rather than converting them into success claims.
 - Update STATUS, TODO, ROADMAP, COMPATIBILITY, ADRs, and provenance in the same
   coherent change when their facts change.
+
+### Qwen-assisted implementation lane
+
+Codex or the Project Manager first defines the task's intent, architecture and
+risk boundaries, allowlist, acceptance criteria, and verification plan. For an
+eligible bounded implementation packet, the implementer then attempts one
+useful low-level first pass through `tools/qwen-assistant/run.py`: code
+explanation, error analysis, a non-applying fix proposal, test suggestions, or
+a permitted diff review.
+
+Qwen is advisory and non-blocking. If it is unavailable, slow, or unhelpful,
+record that outcome once and continue. Classify a response as used, revised, or
+rejected; never apply it automatically or treat it as evidence. Codex inspects
+the actual change against the higher-level intent, and repository checks plus
+the task's `Demo Command` remain authoritative. Follow
+`docs/QWEN_ASSISTED_DEVELOPMENT.md` for data exclusions and decision boundaries.
 
 ## Review and completion
 

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -93,3 +93,9 @@ that Qwen missed: the CLI includes `AGENTS.md` and `Cargo.toml` by default, but
 task mutation ownership is not permission to transmit context. The policy and
 packet schema now separate a `Qwen context allowlist`; callers use
 `--no-project-context` unless the default files are explicitly allowed.
+
+The implementation Demo then passed 17 policy and assistant tests, the live
+Project audit at 56 items and WIP 1/2, and the diff check. Independent Rust
+regression passed format, check, strict Clippy, and 126 tests with eight
+intentional live-oracle ignores. PR #133 opened from revision `4cc99bf`; its
+Issue-linked Project item and canonical records moved to Review.

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -99,3 +99,12 @@ Project audit at 56 items and WIP 1/2, and the diff check. Independent Rust
 regression passed format, check, strict Clippy, and 126 tests with eight
 intentional live-oracle ignores. PR #133 opened from revision `4cc99bf`; its
 Issue-linked Project item and canonical records moved to Review.
+
+The current-candidate Security & Supply-chain review found that three policy
+controls were described too broadly: the task context allowlist is human
+process rather than CLI enforcement, the request blocks synchronously until its
+timeout, and prompt or standard-input text is not covered by file-path checks.
+The Review revision was updated to require a packet-defined finite attempt
+timeout, define non-blocking as “not a delivery gate,” explicitly include
+prompt and stdin in outbound classification, and retain technical enforcement
+as a non-claim. No runtime or CLI scope was added.

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -69,3 +69,27 @@ live-oracle ignores, and diff checks passed. Strict Clippy passed separately.
 PR #130 was squash-merged as `7582b33`; Issue #129 closed and its 5 SP Project
 item moved to Done. T-0079 is complete without changing any runtime or
 compatibility claim.
+
+The owner then asked to use Qwen for lower-level development assistance so
+Codex could concentrate on higher-level design. PM opened Issue #132 for
+T-0080, created `chore/t-0080-qwen-assisted-workflow`, populated its private
+Project item with 3 SP and the full work packet, and moved it to In Progress.
+The first consultation attempt was blocked locally because `.codex/agents` is
+an excluded outbound path. A second request containing only public workflow and
+governance documentation returned in 260.7 seconds. Its general recommendation
+to expose the expectation in shared instructions was revised into an
+independently specified authority, data, non-blocking, disposition, and
+verification contract; no generated prose or code was copied.
+
+After the static policy tests passed, a bounded follow-up sent only the new
+public operating model and workflow to Qwen. It returned `POLICY_OK` in 15.6
+seconds for the requested authority, automatic-application, data-exposure,
+blocking, and evidence-gap review. The response was recorded as a used
+no-finding advisory input, caused no code or documentation change, and was not
+treated as acceptance evidence.
+
+Codex's independent diff review then identified an outbound-context ambiguity
+that Qwen missed: the CLI includes `AGENTS.md` and `Cargo.toml` by default, but
+task mutation ownership is not permission to transmit context. The policy and
+packet schema now separate a `Qwen context allowlist`; callers use
+`--no-project-context` unless the default files are explicitly allowed.

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -108,3 +108,8 @@ The Review revision was updated to require a packet-defined finite attempt
 timeout, define non-blocking as “not a delivery gate,” explicitly include
 prompt and stdin in outbound classification, and retain technical enforcement
 as a non-claim. No runtime or CLI scope was added.
+
+Security re-review found no remaining High or Medium issue and no integration
+blocker. Its Low follow-up was resolved by requiring callers to set
+`EMBURK_QWEN_TIMEOUT_SECONDS` from the packet's finite attempt timeout, making
+the procedural bound correspond to the unchanged CLI request setting.

--- a/docs/provenance/T-0080-qwen-assisted-workflow.md
+++ b/docs/provenance/T-0080-qwen-assisted-workflow.md
@@ -1,0 +1,79 @@
+# T-0080 Qwen-assisted workflow
+
+Status: In Progress
+
+## Purpose and authority
+
+Issue #132 authorizes an operational policy that moves Codex and Project
+Manager attention toward requirements, architecture, boundaries, risk,
+acceptance, and integration while making the existing Qwen3-Coder CLI the
+default non-blocking first pass for eligible low-level implementation work.
+
+The change is limited to repository instructions, project-scoped role prompts,
+workflow and development documentation, static policy tests, and canonical
+records. It changes no runtime, Cargo dependency, compatibility behavior, or
+public API.
+
+## Consultation observation
+
+On 2026-09-09, the first attempted Qwen consultation correctly failed before
+transmission because its requested context included `.codex/agents`, which the
+CLI excludes. A second consultation supplied only public
+`docs/WORKFLOW.md` and `docs/GOVERNANCE.md`. The Windows-hosted
+`qwen3-coder:30b` service responded in 260.7 seconds.
+
+The response suggested making the assistant expectation visible in the shared
+agent and workflow configuration but did not provide a concrete or sufficiently
+bounded policy. Its disposition was `revised`: the general visibility direction
+was retained, while Codex independently specified the authority split,
+information boundary, non-blocking behavior, response disposition, and
+verification contract. No generated prose or code was copied.
+
+After the policy draft passed its static tests, a second consultation supplied
+only `docs/QWEN_ASSISTED_DEVELOPMENT.md` and `docs/WORKFLOW.md` and asked for
+authority, automatic-application, data-exposure, blocking, and evidence gaps.
+The service responded `POLICY_OK` in 15.6 seconds. Its disposition was `used`
+as a no-finding advisory review; it caused no repository change and is not
+acceptance evidence.
+
+Codex's subsequent independent review found one issue that Qwen did not report:
+the CLI's default `AGENTS.md` and `Cargo.toml` context could make a mutation
+allowlist look like outbound-data permission. The final policy therefore adds a
+separate `Qwen context allowlist` and requires `--no-project-context` whenever
+the default files are not explicitly listed.
+
+## Accepted boundary
+
+- Qwen owns no repository role, file, decision, evidence, or lifecycle state.
+- Eligible implementers attempt one useful first pass and continue when the
+  service is unavailable, slow, or unhelpful.
+- Model output is never applied automatically and is classified as used,
+  revised, or rejected.
+- Only explicitly permitted repository-original, non-sensitive context may be
+  sent. `.codex`, upstream implementation source, credentials, private legal or
+  security material, build outputs, `.git`, and large files remain excluded.
+- Mutation ownership and outbound context permission are separate. The task
+  packet records a dedicated Qwen context allowlist when the assistant is used.
+- Codex and the Project Manager retain higher-level judgment, actual diff
+  review, independent verification, integration, and final acceptance.
+
+## Evidence plan
+
+The task's authoritative Demo Command is:
+
+```sh
+python3 -m unittest tests.test_qwen_workflow_policy tests.test_qwen_assistant && \
+  python3 scripts/project_governance_audit.py audit && \
+  git diff --check
+```
+
+The evidence class is Unit/Contract plus Integration. Integration here means
+the recorded advisory call reached the configured Qwen service; it is not
+runtime, compatibility, correctness, or performance evidence.
+
+## Non-claims
+
+This policy does not show that Qwen is correct, faster than Codex, continuously
+available, appropriate for confidential material, or capable of replacing
+independent engineering judgment. It does not establish any Embulk
+compatibility or product-runtime behavior.

--- a/docs/provenance/T-0080-qwen-assisted-workflow.md
+++ b/docs/provenance/T-0080-qwen-assisted-workflow.md
@@ -1,6 +1,6 @@
 # T-0080 Qwen-assisted workflow
 
-Status: In Progress
+Status: Review
 
 ## Purpose and authority
 

--- a/docs/provenance/T-0080-qwen-assisted-workflow.md
+++ b/docs/provenance/T-0080-qwen-assisted-workflow.md
@@ -7,7 +7,8 @@ Status: Review
 Issue #132 authorizes an operational policy that moves Codex and Project
 Manager attention toward requirements, architecture, boundaries, risk,
 acceptance, and integration while making the existing Qwen3-Coder CLI the
-default non-blocking first pass for eligible low-level implementation work.
+default bounded first pass for eligible low-level implementation work without
+making it a delivery gate.
 
 The change is limited to repository instructions, project-scoped role prompts,
 workflow and development documentation, static policy tests, and canonical
@@ -42,11 +43,20 @@ allowlist look like outbound-data permission. The final policy therefore adds a
 separate `Qwen context allowlist` and requires `--no-project-context` whenever
 the default files are not explicitly listed.
 
+A read-only Security & Supply-chain review of revision `1af627c` then identified
+three medium wording and enforcement gaps: the context allowlist is procedural,
+the CLI call is synchronous despite the broad term non-blocking, and prompt or
+standard-input text is outside file-path allowlisting. The policy was revised
+to state those limitations explicitly, require a task-defined finite attempt
+timeout, treat non-blocking as “not a delivery gate,” and classify prompt and
+standard input as outbound context. Technical allowlist enforcement remains a
+future hardening opportunity rather than a T-0080 claim.
+
 ## Accepted boundary
 
 - Qwen owns no repository role, file, decision, evidence, or lifecycle state.
 - Eligible implementers attempt one useful first pass and continue when the
-  service is unavailable, slow, or unhelpful.
+  service is unavailable, reaches the packet-defined timeout, or is unhelpful.
 - Model output is never applied automatically and is classified as used,
   revised, or rejected.
 - Only explicitly permitted repository-original, non-sensitive context may be
@@ -54,6 +64,8 @@ the default files are not explicitly listed.
   security material, build outputs, `.git`, and large files remain excluded.
 - Mutation ownership and outbound context permission are separate. The task
   packet records a dedicated Qwen context allowlist when the assistant is used.
+- Prompt and standard-input content require the same human classification as
+  files because path checks cannot govern their meaning.
 - Codex and the Project Manager retain higher-level judgment, actual diff
   review, independent verification, integration, and final acceptance.
 
@@ -75,5 +87,8 @@ runtime, compatibility, correctness, or performance evidence.
 
 This policy does not show that Qwen is correct, faster than Codex, continuously
 available, appropriate for confidential material, or capable of replacing
-independent engineering judgment. It does not establish any Embulk
-compatibility or product-runtime behavior.
+independent engineering judgment. The CLI does not enforce the task's semantic
+context allowlist, make its synchronous request asynchronous, or completely
+classify prompt, standard-input, or file contents. The static tests detect
+policy-text drift, not technical bypasses. This task does not establish any
+Embulk compatibility or product-runtime behavior.

--- a/docs/provenance/T-0080-qwen-assisted-workflow.md
+++ b/docs/provenance/T-0080-qwen-assisted-workflow.md
@@ -52,6 +52,11 @@ timeout, treat non-blocking as “not a delivery gate,” and classify prompt an
 standard input as outbound context. Technical allowlist enforcement remains a
 future hardening opportunity rather than a T-0080 claim.
 
+The final security re-review found no High or Medium issue and no integration
+blocker. Its one Low clarity finding observed that a packet timeout does not
+configure the CLI by itself. The operating loop now explicitly maps that value
+to `EMBURK_QWEN_TIMEOUT_SECONDS` for each consultation.
+
 ## Accepted boundary
 
 - Qwen owns no repository role, file, decision, evidence, or lifecycle state.

--- a/tests/test_qwen_workflow_policy.py
+++ b/tests/test_qwen_workflow_policy.py
@@ -1,0 +1,87 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def normalized(relative_path: str) -> str:
+    return " ".join(read(relative_path).split())
+
+
+class QwenWorkflowPolicyTest(unittest.TestCase):
+    def test_repository_contract_keeps_high_level_authority_with_codex(self) -> None:
+        policy = normalized("AGENTS.md")
+        for phrase in (
+            "Codex and the Project Manager concentrate on task framing",
+            "tools/qwen-assistant/run.py",
+            "default first pass",
+            "Qwen is an advisory model",
+            "Its use is non-blocking",
+            "Never apply its output automatically",
+            "optional Qwen context allowlist",
+            "docs/QWEN_ASSISTED_DEVELOPMENT.md",
+        ):
+            self.assertIn(phrase, policy)
+
+    def test_project_manager_retains_decision_and_acceptance_authority(self) -> None:
+        role = normalized(".codex/agents/emburk-project-manager.toml")
+        for phrase in (
+            "product semantics, architecture",
+            "tools/qwen-assistant/run.py",
+            "non-blocking",
+            "default first pass",
+            "separate Qwen context allowlist",
+            "Qwen is advisory and has no mutation or acceptance authority",
+        ):
+            self.assertIn(phrase, role)
+
+    def test_implementer_roles_share_the_bounded_assistance_contract(self) -> None:
+        roles = (
+            ".codex/agents/emburk-rust-core-implementer.toml",
+            ".codex/agents/emburk-plugin-implementer.toml",
+            ".codex/agents/emburk-compatibility-host-implementer.toml",
+        )
+        for path in roles:
+            with self.subTest(path=path):
+                role = normalized(path)
+                for phrase in (
+                    "tools/qwen-assistant/run.py",
+                    "non-blocking default first pass",
+                    "Never apply Qwen output automatically",
+                    "upstream source",
+                    "Qwen context allowlist",
+                    "--no-project-context",
+                    "independently",
+                    "used, revised, or rejected",
+                ):
+                    self.assertIn(phrase, role)
+
+    def test_workflow_defines_non_applying_independent_verification(self) -> None:
+        workflow = normalized("docs/WORKFLOW.md")
+        operating_model = normalized("docs/QWEN_ASSISTED_DEVELOPMENT.md")
+        combined = workflow + operating_model
+        for phrase in (
+            "Qwen is advisory and non-blocking",
+            "never apply it automatically",
+            "Qwen's answer is not evidence",
+            "Codex reviews the actual diff",
+            "The Project Manager runs or confirms the task's `Demo Command`",
+            "mutation allowlist grants write ownership and does not grant permission",
+            "pass `--no-project-context`",
+        ):
+            self.assertIn(phrase, combined)
+
+    def test_documentation_routes_readers_to_the_operating_model(self) -> None:
+        development = read("docs/DEVELOPMENT.md")
+        index = read("docs/README.md")
+        self.assertIn("QWEN_ASSISTED_DEVELOPMENT.md", development)
+        self.assertIn("QWEN_ASSISTED_DEVELOPMENT.md", index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qwen_workflow_policy.py
+++ b/tests/test_qwen_workflow_policy.py
@@ -77,6 +77,7 @@ class QwenWorkflowPolicyTest(unittest.TestCase):
             "CLI does not read the Issue or enforce its Qwen context allowlist",
             "Prompt text and standard input",
             "CLI call is synchronous",
+            "set `EMBURK_QWEN_TIMEOUT_SECONDS`",
         ):
             self.assertIn(phrase, combined)
 

--- a/tests/test_qwen_workflow_policy.py
+++ b/tests/test_qwen_workflow_policy.py
@@ -21,9 +21,10 @@ class QwenWorkflowPolicyTest(unittest.TestCase):
             "tools/qwen-assistant/run.py",
             "default first pass",
             "Qwen is an advisory model",
-            "Its use is non-blocking",
+            "Its use is delivery-non-blocking, not asynchronous",
             "Never apply its output automatically",
             "optional Qwen context allowlist",
+            "prompt text and standard input",
             "docs/QWEN_ASSISTED_DEVELOPMENT.md",
         ):
             self.assertIn(phrase, policy)
@@ -51,7 +52,7 @@ class QwenWorkflowPolicyTest(unittest.TestCase):
                 role = normalized(path)
                 for phrase in (
                     "tools/qwen-assistant/run.py",
-                    "non-blocking default first pass",
+                    "bounded default first pass that is not a delivery gate",
                     "Never apply Qwen output automatically",
                     "upstream source",
                     "Qwen context allowlist",
@@ -66,13 +67,16 @@ class QwenWorkflowPolicyTest(unittest.TestCase):
         operating_model = normalized("docs/QWEN_ASSISTED_DEVELOPMENT.md")
         combined = workflow + operating_model
         for phrase in (
-            "Qwen is advisory and non-blocking",
+            "Qwen is advisory and not a delivery gate",
             "never apply it automatically",
             "Qwen's answer is not evidence",
             "Codex reviews the actual diff",
             "The Project Manager runs or confirms the task's `Demo Command`",
             "mutation allowlist grants write ownership and does not grant permission",
             "pass `--no-project-context`",
+            "CLI does not read the Issue or enforce its Qwen context allowlist",
+            "Prompt text and standard input",
+            "CLI call is synchronous",
         ):
             self.assertIn(phrase, combined)
 


### PR DESCRIPTION
## Summary

- keep Codex and Jitro responsible for requirements, architecture, boundaries, risk, acceptance, and integration
- make Qwen the non-blocking default first pass for eligible bounded implementation assistance
- separate the mutation allowlist from the Qwen outbound context allowlist
- encode the policy in repository instructions, project-scoped roles, workflow documentation, and drift tests

## Evidence

- `python3 -m unittest tests.test_qwen_workflow_policy tests.test_qwen_assistant` — 17 passed
- `cargo fmt --all -- --check` — passed
- `cargo check --locked --workspace` — passed
- `cargo clippy --locked --workspace --all-targets -- -D warnings` — passed
- `cargo test --locked --workspace` — 126 passed, 8 intentional ignores
- `python3 scripts/project_governance_audit.py audit` — passed, 56 items, WIP 1/2
- `git diff --check` — passed
- bounded Qwen policy review — `POLICY_OK` in 15.6 seconds; advisory only

## Boundaries

- no runtime or Cargo manifest changes
- no automatic application or model-derived evidence
- no compatibility, correctness, performance, legal, patent, or security claim
- Qwen missed an outbound-context ambiguity later found and corrected by Codex review

Closes #132
