### PR TITLE
T-0080: Record Qwen workflow integration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,9 +12,10 @@ Current queue state: `T-0002`, `T-0003`, `T-0004`, and `T-0011` are `Done`;
 integrated through PR #91 following fresh reference-probe acceptance runs.
 T-0012/S10 is integrated through PR #93. T-0071/S01 is Done through PR #127
 (`fe778b2`); T-0012, T-0013, T-0021 and all other unfinished items are
-`Backlog` except T-0080, which is in Review. T-0079 is Done through PR #130
+`Backlog`. T-0079 is Done through PR #130
 (`7582b33`). T-0021/S06 is
 integrated through PR #96.
+T-0080 is Done through PR #133 (`34f6ee6`).
 T-0012/S11 is Done through PR #99 after final-head acceptance. T-0023/S01 is
 Done through PR #101 (`d0eebf8`), after primary and independent final-head Demo
 at `196d648`. S01 accepts 5 SP. T-0023/S02 is Done through PR #103 (`5d72866`)
@@ -172,7 +173,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 and T-0079 are
 | T-0075 | Research Terraform deployment | Backlog | Icebox | 3 | T-0072 | Project Manager | Planning |
 | T-0076 | Research adaptive optimization | Backlog | Icebox | 3 | T-0071 | Performance Reviewer | Planning |
 | T-0079 | Add a bounded Qwen development assistant (Done through PR #130) | Done | P1 | 5 | None | Rust Core Implementer | Integration |
-| T-0080 | Operationalize Qwen-first implementation assistance | Review | P1 | 3 | T-0079 | Project Manager | Unit/Contract + Integration |
+| T-0080 | Operationalize Qwen-first implementation assistance (Done through PR #133) | Done | P1 | 3 | T-0079 | Project Manager | Unit/Contract + Integration |
 
 ## Pull order
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -99,8 +99,8 @@ development-assistant CLI, outbound data guards, IntelliJ entry points,
 documentation, and independent Rust verification. No model answer has been
 adopted as product code or evidence.
 
-T-0080 is in Review through PR #133. It defines Qwen as a non-blocking default
-first pass for eligible low-level assistance while retaining
+T-0080 is Done through PR #133 (`34f6ee6`). It defines Qwen as a bounded
+first pass for eligible low-level assistance that does not gate delivery, while retaining
 requirements, architecture, risk, acceptance, verification, and integration
 with Codex and the Project Manager. It changes no runtime, Cargo dependency,
 compatibility behavior, or public API.
@@ -145,7 +145,7 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 | T-0079 | Done | Bounded, non-applying Qwen development assistant; PR #130 integrated |
-| T-0080 | Review | PR #133 defines Qwen-first low-level assistance with Codex retaining higher-level authority |
+| T-0080 | Done | Qwen-first low-level assistance with Codex retaining higher-level authority; PR #133 integrated |
 
 T-0025/S01 is Done through PR #117. T-0014/S02 is Done through PR #118.
 T-0033/S01 is Done through PR #119. T-0024/S01 is Done through PR #120.
@@ -155,7 +155,7 @@ Other unfinished stable tasks remain `Backlog`. Parent epics are
 unpointed. The private [Emburk Delivery Project](https://github.com/users/bhind/projects/2)
 is the coordination mirror. T-0079 is its 55th item; its lifecycle state,
 estimate, role, workstream, evidence class, and Demo Command were initialized
-on 2026-09-09. T-0080 is its 56th item and is in Review with 3 SP. The first
+on 2026-09-09. T-0080 is its 56th item and is Done with 3 SP. The first
 52 items' lifecycle states, initial estimates, roles,
 dependencies, workstreams, evidence classes, and views were reconciled to the
 repository records on 2026-09-05.

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -113,3 +113,12 @@ Security re-review found no remaining High or Medium issue and no integration
 blocker. Its Low follow-up was resolved by requiring callers to set
 `EMBURK_QWEN_TIMEOUT_SECONDS` from the packet's finite attempt timeout, making
 the procedural bound correspond to the unchanged CLI request setting.
+
+At final candidate `3e9b4b7`, the exact Demo passed 17 policy and assistant
+tests, the Project audit at 56 items and WIP 1/2, and the diff check. Vreji and
+Security & Supply-chain final-candidate reviews reported no integration blocker
+and no remaining severity finding. The repository has no PR quality-check
+workflow; this absence and the complete local/reviewer evidence were recorded
+on PR #133. The clean pull request squash-merged as `34f6ee6`, Issue #132
+closed, and its 3 SP Project item moved to Done. T-0080 changes no runtime,
+Cargo manifest, dependency, public API, or compatibility claim.

--- a/docs/provenance/T-0080-qwen-assisted-workflow.md
+++ b/docs/provenance/T-0080-qwen-assisted-workflow.md
@@ -1,6 +1,6 @@
 # T-0080 Qwen-assisted workflow
 
-Status: Review
+Status: Done through PR #133 (`34f6ee6`)
 
 ## Purpose and authority
 
@@ -87,6 +87,22 @@ python3 -m unittest tests.test_qwen_workflow_policy tests.test_qwen_assistant &&
 The evidence class is Unit/Contract plus Integration. Integration here means
 the recorded advisory call reached the configured Qwen service; it is not
 runtime, compatibility, correctness, or performance evidence.
+
+## Accepted evidence
+
+At reviewed revision `3e9b4b7`, the exact Demo passed 17 Qwen assistant and
+policy tests, the live private Project audit at 56 items and WIP 1/2, and the
+diff check. Rust regression in the same pull request passed format, check,
+strict Clippy, and 126 tests with eight intentional live-oracle ignores; later
+commits changed policy text and its static tests only, and final-head acceptance
+reran format and check.
+
+Vreji's read-only provenance/IP/privacy review and the Security & Supply-chain
+review both passed the exact final candidate with no integration blocker. The
+repository has no PR quality-check workflow, so no GitHub status check existed;
+the repository-defined local Demo and reviewer evidence were attached to PR
+#133. The pull request squash-merged as `34f6ee6`, Issue #132 closed, and its
+3 SP Project item moved to Done.
 
 ## Non-claims
 


### PR DESCRIPTION
## Summary

- record PR #133 integration as `34f6ee6`
- reconcile T-0080 to Done in TODO, STATUS, provenance, and the project log
- retain final acceptance, Vreji, security, residual-risk, and no-configured-CI evidence

## Evidence

- `python3 -m unittest tests.test_qwen_workflow_policy tests.test_qwen_assistant` — 17 passed
- `python3 scripts/project_governance_audit.py audit` — passed, 56 items, WIP 0/2
- `git diff --check` — passed
- Issue #132 — closed
- private Project item — Done, 3 SP

## Boundary

Documentation-only integration closeout. No runtime, Cargo manifest, dependency, public API, or compatibility change.
