### PR TITLE
T-0026/S01: Add deterministic native run-result sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ version = "0.1.0"
 dependencies = [
  "ctrlc",
  "emburk-core",
+ "serde_json",
 ]
 
 [[package]]

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,8 @@ T-0012/S10 is integrated through PR #93. T-0071/S01 is Done through PR #127
 (`7582b33`). T-0021/S06 is
 integrated through PR #96.
 T-0080 is Done through PR #133 (`34f6ee6`).
+T-0026/S01 is In Progress on Issue #135 and
+`feat/t-0026-run-result-sidecar`.
 T-0012/S11 is Done through PR #99 after final-head acceptance. T-0023/S01 is
 Done through PR #101 (`d0eebf8`), after primary and independent final-head Demo
 at `196d648`. S01 accepts 5 SP. T-0023/S02 is Done through PR #103 (`5d72866`)
@@ -112,7 +114,13 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 and T-0079 are
 | T-0023 | Implement logical schema and Arrow-compatible batches (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 21 | T-0012, T-0021 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation (S01 Done) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0025 | Implement atomic transaction and resume state (S01/S02 Done; broader contracts queued) | Backlog | P1 | 13 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
-| T-0026 | Implement structured errors and observability | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |
+| T-0026 | Implement structured errors and observability (S01 In Progress) | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |
+
+T-0026/S01 (3 SP within the parent) adds only an opt-in native v1 result
+sidecar for ordinary configured `run`. The report has fixed success, failure,
+and cancellation outcomes while the existing core execution and publication
+semantics remain unchanged. It is not an Embulk report/error compatibility
+claim or completion of T-0026.
 
 ## T-0030 — Native File-to-File ETL
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ T-0012/S10 is integrated through PR #93. T-0071/S01 is Done through PR #127
 (`7582b33`). T-0021/S06 is
 integrated through PR #96.
 T-0080 is Done through PR #133 (`34f6ee6`).
-T-0026/S01 is In Progress on Issue #135 and
+T-0026/S01 is in Review on PR #136 from
 `feat/t-0026-run-result-sidecar`.
 T-0012/S11 is Done through PR #99 after final-head acceptance. T-0023/S01 is
 Done through PR #101 (`d0eebf8`), after primary and independent final-head Demo
@@ -114,7 +114,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 and T-0079 are
 | T-0023 | Implement logical schema and Arrow-compatible batches (S01/S02 Done; remaining contracts queued) | Backlog | P1 | 21 | T-0012, T-0021 | Compatibility Host Implementer | Differential (Embulk) |
 | T-0024 | Implement bounded scheduling, backpressure, and cancellation (S01 Done) | Backlog | P1 | 8 | T-0023 | Rust Core Implementer | Unit/Contract |
 | T-0025 | Implement atomic transaction and resume state (S01/S02 Done; broader contracts queued) | Backlog | P1 | 13 | T-0013, T-0024 | Rust Core Implementer | Unit/Contract |
-| T-0026 | Implement structured errors and observability (S01 In Progress) | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |
+| T-0026 | Implement structured errors and observability (S01 in Review) | Backlog | P1 | 5 | T-0021 | Rust Core Implementer | Unit/Contract |
 
 T-0026/S01 (3 SP within the parent) adds only an opt-in native v1 result
 sidecar for ordinary configured `run`. The report has fixed success, failure,

--- a/crates/emburk-cli/Cargo.toml
+++ b/crates/emburk-cli/Cargo.toml
@@ -11,3 +11,4 @@ path = "src/main.rs"
 [dependencies]
 emburk-core = { path = "../emburk-core" }
 ctrlc = "=3.5.2"
+serde_json = "=1.0.151"

--- a/crates/emburk-cli/src/main.rs
+++ b/crates/emburk-cli/src/main.rs
@@ -24,8 +24,15 @@ fn main() {
         )
     {
         println!(
-            "Usage: emburk guess SEED [-o CONFIG]\n       emburk run CONFIG [--state STATE_DIR]\n       emburk resume CONFIG STATE_DIR\n       emburk transfer-lines INPUT OUTPUT\n       emburk transfer-lines-stdout INPUT\n       emburk transfer-lines-null INPUT"
+            "Usage: emburk guess SEED [-o CONFIG]\n       emburk run CONFIG [--report REPORT.json]\n       emburk run CONFIG [--state STATE_DIR]\n       emburk resume CONFIG STATE_DIR\n       emburk transfer-lines INPUT OUTPUT\n       emburk transfer-lines-stdout INPUT\n       emburk transfer-lines-null INPUT"
         );
+        return;
+    }
+    if let [_, command, config, flag, report] = arguments.as_slice()
+        && command == "run"
+        && flag == "--report"
+    {
+        run_with_report(Path::new(config), Path::new(report));
         return;
     }
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -73,7 +80,9 @@ fn main() {
             ("transfer-lines-null", transfer_null(Path::new(input)))
         }
         _ => {
-            eprintln!("Usage: emburk run CONFIG\n       emburk transfer-lines INPUT OUTPUT");
+            eprintln!(
+                "Usage: emburk run CONFIG [--report REPORT.json]\n       emburk transfer-lines INPUT OUTPUT"
+            );
             std::process::exit(2);
         }
     };
@@ -85,6 +94,82 @@ fn main() {
             1
         });
     }
+}
+
+fn run_with_report(config: &Path, report_path: &Path) {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let signal_flag = Arc::clone(&cancelled);
+    if let Err(error) = ctrlc::set_handler(move || signal_flag.store(true, Ordering::Release)) {
+        eprintln!("emburk: run failed: cannot install SIGINT handler: {error}");
+        std::process::exit(1);
+    }
+
+    let mut report = match create_report(report_path) {
+        Ok(report) => report,
+        Err(error) => {
+            eprintln!("emburk: cannot create run report exclusively: {error}");
+            std::process::exit(2);
+        }
+    };
+
+    let result = if cancelled.load(Ordering::Acquire) {
+        Err("cancelled".to_owned())
+    } else {
+        emburk_core::run_config_with_cancel(config, &cancelled)
+    };
+
+    let (outcome, exit_code, records, error) = match result {
+        Ok(records) => ("succeeded", 0, Some(records), None),
+        Err(error) if cancelled.load(Ordering::Acquire) => {
+            let diagnostic = format!("emburk: run failed: {error}");
+            eprintln!("{diagnostic}");
+            ("cancelled", 130, None, Some(diagnostic))
+        }
+        Err(error) => {
+            let diagnostic = format!("emburk: run failed: {error}");
+            eprintln!("{diagnostic}");
+            ("failed", 1, None, Some(diagnostic))
+        }
+    };
+    let body = run_report_json(outcome, exit_code, records, error.as_deref());
+    if let Err(error) = report
+        .write_all(body.as_bytes())
+        .and_then(|()| report.flush())
+    {
+        eprintln!("emburk: cannot write run report: {error}");
+        std::process::exit(exit_code.max(1));
+    }
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+}
+
+fn create_report(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+fn run_report_json(
+    outcome: &str,
+    exit_code: i32,
+    records: Option<usize>,
+    error: Option<&str>,
+) -> String {
+    let records = records
+        .map(|records| records.to_string())
+        .unwrap_or_else(|| "null".to_owned());
+    let error = error
+        .map(|error| serde_json::to_string(error).expect("string JSON serialization cannot fail"))
+        .unwrap_or_else(|| "null".to_owned());
+    format!(
+        "{{\"schema\":\"emburk.run-result/v1\",\"command\":\"run\",\"outcome\":\"{outcome}\",\"exit_code\":{exit_code},\"records\":{records},\"error\":{error}}}\n"
+    )
 }
 
 #[cfg(unix)]

--- a/crates/emburk-cli/tests/run_result_sidecar.rs
+++ b/crates/emburk-cli/tests/run_result_sidecar.rs
@@ -1,0 +1,275 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output, Stdio},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+static NEXT: AtomicUsize = AtomicUsize::new(0);
+
+fn root(name: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "emburk-run-result-{name}-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir(&root).unwrap();
+    fs::create_dir(root.join("output")).unwrap();
+    root
+}
+
+fn config() -> &'static str {
+    "in:\n  type: file\n  path_prefix: input.csv\n  parser:\n    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    skip_header_lines: 1\n    columns:\n    - {name: id, type: long}\n    - {name: name, type: string}\nout:\n  type: file\n  path_prefix: output/result\n  file_ext: csv\n  formatter:\n    type: csv\n    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n    header_line: true\n    quote_policy: MINIMAL\nexec:\n  max_threads: 1\n  min_output_tasks: 1\n"
+}
+
+fn command(root: &Path, report: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_emburk"));
+    command
+        .args(["run", "config.yml", "--report"])
+        .arg(report)
+        .current_dir(root);
+    command
+}
+
+fn report(path: &Path) -> serde_json::Value {
+    serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+}
+
+#[test]
+fn successful_run_writes_the_exact_v1_result_line() {
+    let root = root("success");
+    fs::write(root.join("config.yml"), config()).unwrap();
+    fs::write(root.join("input.csv"), b"id,name\n1,Ada\n").unwrap();
+    let report_path = root.join("result.json");
+
+    let output = command(&root, &report_path).output().unwrap();
+
+    assert!(output.status.success(), "{:?}", output);
+    assert_eq!(
+        fs::read_to_string(&report_path).unwrap(),
+        "{\"schema\":\"emburk.run-result/v1\",\"command\":\"run\",\"outcome\":\"succeeded\",\"exit_code\":0,\"records\":1,\"error\":null}\n"
+    );
+    assert_eq!(
+        fs::read(root.join("output/result000.00.csv")).unwrap(),
+        b"id,name\n1,Ada\n"
+    );
+}
+
+#[test]
+fn failed_run_records_the_exact_canonical_stderr_line() {
+    let root = root("failure");
+    fs::write(
+        root.join("config.yml"),
+        config().replace("max_threads: 1", "max_threads: 0"),
+    )
+    .unwrap();
+    fs::write(root.join("input.csv"), b"id,name\n1,Ada\n").unwrap();
+    let report_path = root.join("result.json");
+
+    let output = command(&root, &report_path).output().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.starts_with("emburk: run failed: "));
+    assert_eq!(stderr.matches('\n').count(), 1);
+    let result = report(&report_path);
+    assert_eq!(result["schema"], "emburk.run-result/v1");
+    assert_eq!(result["command"], "run");
+    assert_eq!(result["outcome"], "failed");
+    assert_eq!(result["exit_code"], 1);
+    assert!(result["records"].is_null());
+    assert_eq!(result["error"], stderr.trim_end_matches('\n'));
+    assert!(!root.join("output/result000.00.csv").exists());
+}
+
+#[test]
+fn existing_report_is_rejected_before_pipeline_execution() {
+    let root = root("existing");
+    fs::write(root.join("config.yml"), config()).unwrap();
+    fs::write(root.join("input.csv"), b"id,name\n1,Ada\n").unwrap();
+    let report_path = root.join("result.json");
+    fs::write(&report_path, b"sentinel").unwrap();
+
+    let output = command(&root, &report_path).output().unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .starts_with("emburk: cannot create run report exclusively: ")
+    );
+    assert_eq!(fs::read(&report_path).unwrap(), b"sentinel");
+    assert_eq!(fs::read_dir(root.join("output")).unwrap().count(), 0);
+}
+
+#[test]
+fn report_and_configured_output_collision_keeps_the_reserved_failed_report() {
+    let root = root("collision");
+    fs::write(root.join("config.yml"), config()).unwrap();
+    fs::write(root.join("input.csv"), b"id,name\n1,Ada\n").unwrap();
+    let report_path = root.join("output/result000.00.csv");
+
+    let output = command(&root, &report_path).output().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let result = report(&report_path);
+    assert_eq!(result["outcome"], "failed");
+    assert_eq!(result["exit_code"], 1);
+    assert!(result["records"].is_null());
+    assert_eq!(
+        result["error"],
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .trim_end_matches('\n')
+    );
+}
+
+#[test]
+fn report_matching_the_input_prefix_fails_explicitly_without_output() {
+    let root = root("input-prefix");
+    fs::write(root.join("config.yml"), config()).unwrap();
+    fs::write(root.join("input.csv"), b"id,name\n1,Ada\n").unwrap();
+    let report_path = root.join("input.csv.report.json");
+
+    let output = command(&root, &report_path).output().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let result = report(&report_path);
+    assert_eq!(result["outcome"], "failed");
+    assert_eq!(result["exit_code"], 1);
+    assert!(result["records"].is_null());
+    assert_eq!(
+        result["error"],
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .trim_end_matches('\n')
+    );
+    assert_eq!(fs::read_dir(root.join("output")).unwrap().count(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn report_is_created_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = root("mode");
+    fs::write(root.join("config.yml"), config()).unwrap();
+    fs::write(root.join("input.csv"), b"id,name\n").unwrap();
+    let report_path = root.join("result.json");
+
+    assert!(command(&root, &report_path).status().unwrap().success());
+    assert_eq!(
+        fs::metadata(report_path).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn sigint_after_report_reservation_writes_a_cancelled_result() {
+    use std::{
+        io::Write,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    let root = root("sigint-reserved");
+    fs::write(root.join("config.yml"), config()).unwrap();
+    let mut input = fs::File::create(root.join("input.csv")).unwrap();
+    input.write_all(b"id,name\n").unwrap();
+    let block = b"1,abcdefghijklmnopqrstuvwxyz\n".repeat(4096);
+    for _ in 0..128 {
+        input.write_all(&block).unwrap();
+    }
+    drop(input);
+    let report_path = root.join("result.json");
+    let mut child = command(&root, &report_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let start = Instant::now();
+    while !report_path.exists() && start.elapsed() < Duration::from_secs(10) {
+        assert!(child.try_wait().unwrap().is_none(), "pipeline exited early");
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(report_path.exists(), "report was not reserved");
+    assert!(
+        Command::new("/bin/kill")
+            .args(["-INT", &child.id().to_string()])
+            .status()
+            .unwrap()
+            .success()
+    );
+    let output: Output = child.wait_with_output().unwrap();
+
+    assert_eq!(output.status.code(), Some(130));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let result = report(&report_path);
+    assert_eq!(result["outcome"], "cancelled");
+    assert_eq!(result["exit_code"], 130);
+    assert!(result["records"].is_null());
+    assert_eq!(result["error"], stderr.trim_end_matches('\n'));
+    assert!(!root.join("output/result000.00.csv").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn sigint_writes_a_cancelled_result_without_publishing_output() {
+    use std::{
+        io::Write,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    let root = root("sigint");
+    fs::write(root.join("config.yml"), config()).unwrap();
+    let mut input = fs::File::create(root.join("input.csv")).unwrap();
+    input.write_all(b"id,name\n").unwrap();
+    let block = b"1,abcdefghijklmnopqrstuvwxyz\n".repeat(4096);
+    for _ in 0..128 {
+        input.write_all(&block).unwrap();
+    }
+    drop(input);
+    let report_path = root.join("result.json");
+    let mut child = command(&root, &report_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let start = Instant::now();
+    let mut active = false;
+    while start.elapsed() < Duration::from_secs(10) {
+        if fs::read_dir(root.join("output")).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".emburk-output-")
+        }) {
+            active = true;
+            break;
+        }
+        if child.try_wait().unwrap().is_some() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(2));
+    }
+    assert!(active, "pipeline did not become active");
+    assert!(
+        Command::new("/bin/kill")
+            .args(["-INT", &child.id().to_string()])
+            .status()
+            .unwrap()
+            .success()
+    );
+    let output: Output = child.wait_with_output().unwrap();
+
+    assert_eq!(output.status.code(), Some(130));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let result = report(&report_path);
+    assert_eq!(result["outcome"], "cancelled");
+    assert_eq!(result["exit_code"], 130);
+    assert!(result["records"].is_null());
+    assert_eq!(result["error"], stderr.trim_end_matches('\n'));
+    assert!(!root.join("output/result000.00.csv").exists());
+}

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -42,6 +42,11 @@ fresh-process timing, one reference input task and recorded machine are explicit
 it does not change any Native/Verified status or establish scheduler parity or
 general performance superiority.
 
+T-0026/S01 is an active native-only observability slice. Its optional configured
+run result JSON is an Emburk-owned experimental CLI contract, not an observed
+Embulk format, diagnostic taxonomy, plugin result, or compatibility surface.
+It changes no Native/Verified status.
+
 The implementation objective is strict reproduction of observable behavior for
 the pinned core and admitted plugins. Technical constraints, disproportionate
 effort, or unavoidable Java/Rust differences may justify an explicit exception

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,6 +20,17 @@ cargo test --locked --workspace
 
 If `cargo` is unavailable immediately after installation, restart the terminal or run `source "$HOME/.cargo/env"`.
 
+For the experimental native configured pipeline, an ordinary run can also
+write a deterministic result sidecar for local automation:
+
+```sh
+cargo run -p emburk-cli -- run config.yml --report run-result.json
+```
+
+The report is reserved before execution and is never overwritten. See
+[Experimental native pipeline](NATIVE_PIPELINE.md#optional-native-result-report)
+for its exact v1 shape, failure behavior, and non-claims.
+
 ## IntelliJ IDEA
 
 1. Open Settings → Plugins and install JetBrains' **Rust** plugin.

--- a/docs/NATIVE_PIPELINE.md
+++ b/docs/NATIVE_PIPELINE.md
@@ -56,6 +56,39 @@ file's parent. The selected single-task output is `output/result000.00.csv`.
 At most one regular input may match the prefix. An unmatched ordinary run
 produces no output. The output directory must already exist.
 
+### Optional native result report
+
+For an ordinary configured run, reserve a new machine-readable result file:
+
+```sh
+emburk run config.yml --report run-result.json
+```
+
+The report is an experimental Emburk-owned CLI contract. Its fixed v1 object is
+written as UTF-8 JSON followed by LF:
+
+```json
+{"schema":"emburk.run-result/v1","command":"run","outcome":"succeeded","exit_code":0,"records":2,"error":null}
+```
+
+Successful reports contain the exact emitted record count. Failed and cancelled
+reports use `records: null`, exit codes 1 and 130 respectively, and copy the
+complete `emburk: run failed: ...` stderr diagnostic into `error`. The report is
+reserved exclusively with owner-only permissions after successful SIGINT-handler
+installation and before configuration loading. This ordering prevents a handled
+SIGINT from leaving an empty reserved report. An existing report path exits 2
+without executing the pipeline. Choose a report path outside the configured
+input `path_prefix` and distinct from the configured final output. A collision
+can affect the existing input selection or output no-overwrite checks, so the
+pipeline fails explicitly and leaves a failed report rather than silently
+excluding the reserved path.
+
+Report writing is flushed but is not atomic or durability-guaranteed. A crash
+or report I/O failure may leave an empty or partial report; a configured output
+already published before a report-write failure can remain valid. Reports are
+not implemented for stateful run, resume, guess, or `transfer-lines` commands.
+This format is not an Embulk structured-error or report compatibility claim.
+
 ## Selected formats and filters
 
 - JSON input: replace the parser with `type: json` and the same `columns` list;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -256,6 +256,11 @@ bounded ordered parallel formatting and exact selected output bytes, but does
 not close the Arrow-compatible batch, general transaction, or full phase exit
 gates.
 
+T-0026/S01 is active as an operational extension to the experimental native
+MVP. Its opt-in result sidecar makes ordinary configured runs machine-readable
+without changing core execution or claiming Embulk structured-error/report
+compatibility. This slice does not close the Phase 1 exit gate or T-0026.
+
 ## Phase 2: Java Compatibility
 
 - Define the versioned host protocol.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -105,6 +105,13 @@ requirements, architecture, risk, acceptance, verification, and integration
 with Codex and the Project Manager. It changes no runtime, Cargo dependency,
 compatibility behavior, or public API.
 
+T-0026/S01 is In Progress on Issue #135. The candidate adds an opt-in
+`emburk run CONFIG --report REPORT.json` path with a fixed experimental native
+v1 result shape, exclusive report reservation, exact successful record count,
+and explicit failure/cancellation outcomes. Core execution, publication,
+checkpoint, and resume code remain unchanged. Acceptance and PR integration
+are still pending.
+
 T-0012/S08 is integrated through PR #82. The owner approved continuation of
 T-0012/S09 after the reference-execution explanation. Stage A at `7e46379`
 captured 114/93 events with exact selected double bits preserved; primary
@@ -144,6 +151,7 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0012/S13 | Done | PR #107 integrated; primary and independent final-head acceptance passed |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
+| T-0026/S01 | In Progress | Experimental native configured-run result sidecar; Issue #135 |
 | T-0079 | Done | Bounded, non-applying Qwen development assistant; PR #130 integrated |
 | T-0080 | Done | Qwen-first low-level assistance with Codex retaining higher-level authority; PR #133 integrated |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -105,12 +105,13 @@ requirements, architecture, risk, acceptance, verification, and integration
 with Codex and the Project Manager. It changes no runtime, Cargo dependency,
 compatibility behavior, or public API.
 
-T-0026/S01 is In Progress on Issue #135. The candidate adds an opt-in
+T-0026/S01 is in Review on PR #136. The candidate adds an opt-in
 `emburk run CONFIG --report REPORT.json` path with a fixed experimental native
 v1 result shape, exclusive report reservation, exact successful record count,
 and explicit failure/cancellation outcomes. Core execution, publication,
-checkpoint, and resume code remain unchanged. Acceptance and PR integration
-are still pending.
+checkpoint, and resume code remain unchanged. Implementation-stage acceptance,
+independent testing, Security, and Vreji reviews passed; final-head acceptance
+and PR integration are still pending.
 
 T-0012/S08 is integrated through PR #82. The owner approved continuation of
 T-0012/S09 after the reference-execution explanation. Stage A at `7e46379`
@@ -151,7 +152,7 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0012/S13 | Done | PR #107 integrated; primary and independent final-head acceptance passed |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
-| T-0026/S01 | In Progress | Experimental native configured-run result sidecar; Issue #135 |
+| T-0026/S01 | Review | Experimental native configured-run result sidecar; PR #136 |
 | T-0079 | Done | Bounded, non-applying Qwen development assistant; PR #130 integrated |
 | T-0080 | Done | Qwen-first low-level assistance with Codex retaining higher-level authority; PR #133 integrated |
 

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -122,3 +122,35 @@ workflow; this absence and the complete local/reviewer evidence were recorded
 on PR #133. The clean pull request squash-merged as `34f6ee6`, Issue #132
 closed, and its 3 SP Project item moved to Done. T-0080 changes no runtime,
 Cargo manifest, dependency, public API, or compatibility claim.
+
+The owner authorized continued MVP implementation. Jitro selected T-0026/S01,
+an opt-in deterministic native run-result sidecar, as the smallest useful slice
+that did not require new Embulk behavior assumptions. Vreji reviewed and refined
+the packet before Issue #135 publication. Its private Project item was populated
+with 3 SP, P1, Core Runtime, Product Slice, Integration evidence, full dependency
+and Demo metadata, then moved to In Progress on
+`feat/t-0026-run-result-sidecar`.
+
+The required first-pass Qwen request used only allowed original CLI context,
+disabled default project context, and set a 90-second timeout. It timed out with
+no response and was classified rejected without retry. The low-reasoning Rust
+Core Implementer then produced only its four assigned CLI/manifest/test files.
+PM added and tested the explicit input-prefix collision boundary. Focused tests
+passed seven cases; format, check, strict Clippy and diff checks passed. PM
+reran the full workspace suite with enough time for the existing long
+SIGINT/resume case: 133 passed, eight intentional live-oracle tests were
+ignored, and the long case completed in 76.60 seconds. Final review,
+and integration remain pending. The private Project audit passed with 57 items,
+combined WIP 1, and limit 2. An independent read-only Tester reran all seven
+focused cases plus the exact SIGINT case separately; all passed, with no
+behavioral finding. Security review nevertheless found a medium integration
+blocker: the candidate reserved the report before installing its SIGINT handler,
+so a signal in that interval could leave an empty file. PM changed the ordering
+to install the handler before reservation, added a test that signals after
+observing reservation, and queued renewed acceptance and security review.
+The remediation passed eight focused tests and the full authoritative Demo:
+134 tests passed, eight intentional live-oracle tests were ignored, and the
+existing long SIGINT/resume case completed in 81.32 seconds. Security re-review
+resolved the prior blocker with no remaining finding. Vreji found no provenance
+or compatibility blocker and narrowed the black-box test wording to the exact
+evidence: SIGINT was sent after reservation was observed.

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -154,3 +154,8 @@ existing long SIGINT/resume case completed in 81.32 seconds. Security re-review
 resolved the prior blocker with no remaining finding. Vreji found no provenance
 or compatibility blocker and narrowed the black-box test wording to the exact
 evidence: SIGINT was sent after reservation was observed.
+
+The accepted implementation candidate committed as `3d5f71d`, pushed, and
+opened as PR #136. The private Project item moved from In Progress to Review.
+Final-head Demo and independent fixed-revision reviews remain pending before
+integration.

--- a/docs/provenance/T-0026-run-result-sidecar.md
+++ b/docs/provenance/T-0026-run-result-sidecar.md
@@ -1,0 +1,100 @@
+# T-0026/S01 native run-result sidecar
+
+Status: In Progress
+
+## Authority and scope
+
+Issue #135 authorizes a 3 SP Rust Core slice on
+`feat/t-0026-run-result-sidecar`. It adds an opt-in, Emburk-owned result JSON
+for ordinary configured `run` only. The mutation allowlist is limited to the
+CLI manifest/lock, CLI entry point, one integration-test file, native/developer
+documentation, and canonical records. No core execution file changes.
+
+## Original native contract
+
+The fixed UTF-8 JSON v1 shape plus trailing LF is:
+
+```json
+{"schema":"emburk.run-result/v1","command":"run","outcome":"succeeded","exit_code":0,"records":1,"error":null}
+```
+
+Success reports the exact `usize` already returned by
+`run_config_with_cancel`. Failure and cancellation use `records: null`, retain
+exit 1 or 130, and store the complete canonical stderr diagnostic. The report
+is created exclusively with Unix mode 0600 after successful SIGINT-handler
+installation and before configuration loading. An existing path exits 2 before
+execution. Exact report/output collision invokes the existing output
+no-overwrite failure and leaves a failed report.
+Because reservation precedes input selection, callers must also keep the report
+outside the configured input `path_prefix`. A collision remains visible as a
+failed report rather than silently changing selection rules.
+
+Serialization produces one object and LF and explicitly flushes the file. It is
+not atomic, durability-guaranteed, or crash-complete. A report write failure
+after successful publication exits 1 without invalidating an already published
+configured output. After pipeline failure/cancellation, report I/O failure
+preserves the pipeline exit and can leave an empty or partial report.
+
+This contract was independently specified from the repository's existing
+native return and error paths. No Embulk or third-party implementation source
+was consulted or copied.
+
+## Qwen consultation
+
+One `fix` request sent only the Issue-authorized CLI manifest, entry point,
+configured/parallel tests, and a non-sensitive original prompt, with default
+project context disabled. `EMBURK_QWEN_TIMEOUT_SECONDS` was set to 90. The
+request timed out with no response, so its disposition is `rejected`; it was not
+retried and did not influence code or evidence.
+
+## Dependency provenance
+
+The CLI adds a direct `serde_json = "=1.0.151"` edge solely to encode the error
+string safely. The exact package/version/checksum and transitive graph were
+already selected and reviewed for T-0033; Cargo.lock changes only the
+`emburk-cli` dependency list and adds no package, version, or checksum.
+
+The exact archive source recorded by T-0033 is
+`https://static.crates.io/crates/serde_json/serde_json-1.0.151.crate`, accessed
+2026-09-06. Its declared license is MIT OR Apache-2.0; LICENSE-APACHE and
+LICENSE-MIT were present and no NOTICE was found. This record reuses linked
+public APIs only and does not copy crate source. T-0033's security, SBOM,
+redistribution, patent, and freedom-to-operate non-clearance remains unchanged.
+
+## Evidence
+
+Implementation-stage checks passed:
+
+- `cargo fmt --all -- --check`;
+- `cargo check --locked --workspace`;
+- strict workspace Clippy;
+- eight focused CLI integration tests covering success, failure, cancellation,
+  exclusive reservation, mode 0600, and input/output collisions;
+- the remediated full workspace suite: 134 passed and eight intentional
+  live-oracle tests ignored; the existing long SIGINT/resume test completed in
+  81.32 seconds;
+- `git diff --check`.
+
+The initial implementation-stage authoritative Demo passed. An independent
+read-only Tester then reran `git diff --check`, all seven initial focused
+integration tests, and
+the exact SIGINT test separately; all passed. The Tester confirmed exact JSON
+bytes and LF, exit codes 0/1/2/130, diagnostic equality, exclusive no-overwrite,
+both collision boundaries, Unix mode 0600, and no final output after
+cancellation. Final-head acceptance remains pending.
+
+Security review then identified a reservation-to-handler SIGINT race that could
+leave an empty report. The candidate now installs the handler first, reserves
+the report before configuration loading, observes any already-handled signal,
+and includes an eighth test that sends SIGINT after observing reservation.
+Post-remediation authoritative acceptance passed. Security re-review found the
+prior medium blocker resolved and no remaining security or supply-chain
+finding. Final-head acceptance after commit remains pending.
+
+## Non-claims
+
+No complete error taxonomy, schema promise beyond v1, report-on-crash,
+atomic/durable report, partial record count on failure/cancellation, telemetry,
+logging, tracing, metrics, stateful/resume/guess/transfer-lines report, core
+publication/cancellation/resume change, Tokio adoption, plugin API, T-0026 or
+Phase 1 completion, or Embulk structured-error/report compatibility is claimed.

--- a/docs/provenance/T-0026-run-result-sidecar.md
+++ b/docs/provenance/T-0026-run-result-sidecar.md
@@ -1,6 +1,6 @@
 # T-0026/S01 native run-result sidecar
 
-Status: In Progress
+Status: Review
 
 ## Authority and scope
 
@@ -90,6 +90,9 @@ and includes an eighth test that sends SIGINT after observing reservation.
 Post-remediation authoritative acceptance passed. Security re-review found the
 prior medium blocker resolved and no remaining security or supply-chain
 finding. Final-head acceptance after commit remains pending.
+
+The implementation and synchronized Review-state records were published on PR
+#136. That pull request's final-head acceptance and integration remain pending.
 
 ## Non-claims
 


### PR DESCRIPTION
## Summary

- add `emburk run CONFIG --report REPORT.json` for ordinary configured runs
- reserve the native result sidecar exclusively with Unix mode 0600
- report deterministic success, failure, and cancellation outcomes without changing core execution
- document the experimental native contract, provenance, limitations, and project status

## Acceptance evidence

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace`: 134 passed, 8 intentional live-oracle ignores
- existing long SIGINT/resume case passed in 81.32 seconds
- `git diff --check`
- independent Tester: 8/8 focused tests passed, no blocker
- Security & Supply-chain re-review: SIGINT reservation race resolved, no remaining finding
- Vreji provenance/semantic review: pass, no IP or compatibility blocker

## Review notes

The initial candidate reserved the report before installing the SIGINT handler. Security review correctly blocked that ordering because a signal in the interval could leave an empty report. This revision installs the handler first, checks an already-handled signal after reservation, and tests cancellation after observing the reserved path.

The required bounded Qwen first-pass request timed out after 90 seconds with no response. It was recorded as rejected, not retried, and did not influence code or acceptance evidence.

This is an Emburk-owned experimental native CLI contract. It does not claim Embulk report/error compatibility, atomic or durable reporting, a complete error taxonomy, or reports for stateful/resume/guess/transfer-lines commands.

Closes #135
