### PR TITLE
T-0014/S03: observe multi-file path-prefix semantics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,10 @@ scope is not accepted. T-0025/S01 is Done through PR #117 (aac0003), accepting
 ignores and eight CSV comparisons. Parent #22 remains open in Backlog;
 Initial/Current 8 unchanged. T-0014/S02 is Done through PR #118 (ecf9cc4),
 accepting 3 SP after independent five-case agreement and nine tests at dad393c3.
-Parent #17 remains Backlog, S01/S02 total 8 SP, Initial/Current 8 unchanged.
+T-0014/S03 is In Progress on Issue #138 and
+`research/t-0014-multifile-path-prefix-oracle`. It adds a 3 SP bounded
+multi-file File input observation before any native implementation. Parent #17
+remains Backlog; Initial 8 is unchanged and Current refines from 8 to 11.
 T-0033/S01 is Done through PR #119 (95b5592), accepting 8 SP after independent
 97-test/thirteen-comparison Demo at 39c97d8. Parent #26 remains Backlog,
 Current 8 / Initial 5 unchanged. Full T-0033/T-0034/T-0035 parents remain
@@ -101,7 +104,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 and T-0079 are
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S13 Done; remaining contracts queued) | Backlog | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
-| T-0014 | Scaffold the differential harness (S01/S02 Done) | Backlog | P0 | 8 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0014 | Scaffold the differential harness (S01/S02 Done; S03 In Progress) | Backlog | P0 | 11 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
 

--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@ scope is not accepted. T-0025/S01 is Done through PR #117 (aac0003), accepting
 ignores and eight CSV comparisons. Parent #22 remains open in Backlog;
 Initial/Current 8 unchanged. T-0014/S02 is Done through PR #118 (ecf9cc4),
 accepting 3 SP after independent five-case agreement and nine tests at dad393c3.
-T-0014/S03 is In Progress on Issue #138 and
+T-0014/S03 is in Review on Issue #138 and PR #139 from
 `research/t-0014-multifile-path-prefix-oracle`. It adds a 3 SP bounded
 multi-file File input observation before any native implementation. Parent #17
 remains Backlog; Initial 8 is unchanged and Current refines from 8 to 11.
@@ -104,7 +104,7 @@ T-0071 and T-0076 are `Verification`; and T-0072–T-0075 and T-0079 are
 | T-0011 | Pin reference versions | Done | P0 | 3 | None | Project Manager | Planning |
 | T-0012 | Specify configuration, schema, and value semantics (S13 Done; remaining contracts queued) | Backlog | P0 | 55 | T-0011 | Compatibility Host Implementer | Integration |
 | T-0013 | Specify lifecycle, transaction, cleanup, and resume semantics (S01–S08 integrated) | Backlog | P0 | 34 | T-0011 | Compatibility Host Implementer | Differential (Embulk) |
-| T-0014 | Scaffold the differential harness (S01/S02 Done; S03 In Progress) | Backlog | P0 | 11 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
+| T-0014 | Scaffold the differential harness (S01/S02 Done; S03 Review) | Backlog | P0 | 11 | T-0012, T-0013 | Compatibility Host Implementer | Differential (Embulk) |
 
 ## T-0020 — Compact Rust execution core
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ plugin types become public, and the empty lifecycle coordinator stays separate.
 
 ## Principles
 
-T-0014/S03 is an active evidence-only observation of multi-file File input
+T-0014/S03 is an evidence-only observation in Review of multi-file File input
 selection. It does not choose native input ordering, per-file parser lifecycle,
 task fan-out, or output naming. Any later native multi-file boundary must be
 designed from reviewed raw reference evidence in a separate task.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,11 @@ plugin types become public, and the empty lifecycle coordinator stays separate.
 
 ## Principles
 
+T-0014/S03 is an active evidence-only observation of multi-file File input
+selection. It does not choose native input ordering, per-file parser lifecycle,
+task fan-out, or output naming. Any later native multi-file boundary must be
+designed from reviewed raw reference evidence in a separate task.
+
 ADR-0022 admits a bounded private guess adapter using existing dependencies.
 It preserves explicit schema/charset, emits JSON syntax accepted by the YAML
 adapter and does not infer JSON columns. S02 integrated through PR #124;

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -23,6 +23,13 @@ PR #114 accepted that experiment. T-0014/S01 admits the four version-pinned
 bundled File/CSV modules only for local observation; no Native/Verified plugin
 claim or redistribution approval follows.
 T-0014/S01 is now accepted through PR #115 as reference-only evidence.
+T-0014/S03 is active on Issue #138 as three additional multi-file File input
+observations. Primary raw capture and semantic projection passed; it changes no
+Native/Verified status and is not multi-file compatibility certification.
+Primary evidence observes lexical selection, one task/output per regular file,
+per-file header skipping, and exclusion of the one selected empty matching
+directory. Independent reproduction matches those bounded projections and
+exact output bytes; final-head acceptance and integration remain pending.
 T-0032/S01 integrated through PR #116: eight explicitly configured single-file
 long/string CSV projections match real Embulk outputs and exits in primary and
 independent runs. This is a private native consumer, not a verified generic

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -23,7 +23,7 @@ PR #114 accepted that experiment. T-0014/S01 admits the four version-pinned
 bundled File/CSV modules only for local observation; no Native/Verified plugin
 claim or redistribution approval follows.
 T-0014/S01 is now accepted through PR #115 as reference-only evidence.
-T-0014/S03 is active on Issue #138 as three additional multi-file File input
+T-0014/S03 is in Review on Issue #138 and PR #139 as three additional multi-file File input
 observations. Primary raw capture and semantic projection passed; it changes no
 Native/Verified status and is not multi-file compatibility certification.
 Primary evidence observes lexical selection, one task/output per regular file,

--- a/docs/IMPLEMENTATION_SEQUENCE.md
+++ b/docs/IMPLEMENTATION_SEQUENCE.md
@@ -24,6 +24,10 @@ PR #123/#124/#125: reference observation, native implementation and combined
 acceptance. General guessing/plugin support, Java/JRuby hosts and full Embulk
 resume semantics remain separate backlog work.
 
+T-0014/S03 is a follow-on observation outside the completed seven-stage bounded
+sequence. It must capture multi-file `path_prefix` behavior before a separately
+authorized native expansion; it does not reopen or complete any prior stage.
+
 | Stage | Canonical task | Exit evidence |
 | --- | --- | --- |
 | 1. Parser | T-0022/S01 | Pinned dependency/license inventory and original syntax experiment; retained mismatches against S13 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,6 +15,8 @@ ordered formatting/cancellation integrated as T-0024/S01 through PR #120.
 T-0025/S02 integrated validated native checkpoint/resume through PR #121.
 The bounded seven-stage sequence is complete; broader parent gates remain open,
 including format guessing, general plugin profiles and Embulk resume parity.
+T-0014/S03 is now active as a bounded multi-file File input observation before
+any native expansion of the current single-match profile.
 
 ## Phase 0: Governance and Compatibility Contract
 
@@ -249,6 +251,10 @@ passed at `65a2fb3`. It does not adopt a parser or native policy or complete thi
 - Implement file/config inputs; file/stdout/null outputs; CSV/JSON; gzip/bzip2; rename/remove-columns; and format guessing.
 
 Exit gate: representative File-to-File jobs match Embulk under normal execution, interruption, cleanup, and resume.
+
+T-0014/S03 observes selected multi-file input ordering, per-file header,
+output-task, and empty-directory behavior. Observation alone does not satisfy
+this exit gate or authorize a native implementation.
 
 T-0071/S01, integrated through PR #127, adds a reproducible File-to-File benchmark
 and measured 1/4/8-worker execution at source revision `6762f6c`. It demonstrates

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ ordered formatting/cancellation integrated as T-0024/S01 through PR #120.
 T-0025/S02 integrated validated native checkpoint/resume through PR #121.
 The bounded seven-stage sequence is complete; broader parent gates remain open,
 including format guessing, general plugin profiles and Embulk resume parity.
-T-0014/S03 is now active as a bounded multi-file File input observation before
+T-0014/S03 is in Review as a bounded multi-file File input observation before
 any native expansion of the current single-match profile.
 
 ## Phase 0: Governance and Compatibility Contract

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -113,6 +113,18 @@ checkpoint, and resume code remain unchanged. Primary and independent
 final-head acceptance, Security, and Vreji reviews passed at `a377b6e` before
 integration.
 
+T-0014/S03 is In Progress on Issue #138. It observes three bounded multi-file
+File input `path_prefix` cases through the already-admitted pinned Embulk 0.11.5
+runtime before any native multi-file policy is selected. The evidence-only
+slice changes no Rust runtime, Cargo dependency, plugin admission, or current
+compatibility status. The first raw capture and primary asserted rerun both
+completed: two regular files were selected lexically into two per-file outputs
+with per-file header skipping, while the selected empty matching directory was
+excluded. Primary and independent current-candidate acceptance pass with
+thirteen focused tests; the full workspace result is 134 passed with eight
+intentional external-oracle ignores. Security reports no remaining High or
+Medium finding. Final-head acceptance and integration remain pending.
+
 T-0012/S08 is integrated through PR #82. The owner approved continuation of
 T-0012/S09 after the reference-execution explanation. Stage A at `7e46379`
 captured 114/93 events with exact selected double bits preserved; primary
@@ -151,6 +163,7 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0012/S12 | Done | Seven-case reference observation and validator; PR #105 integrated |
 | T-0012/S13 | Done | PR #107 integrated; primary and independent final-head acceptance passed |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
+| T-0014/S03 | In Progress | Bounded multi-file File input reference observation; Issue #138 |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 | T-0026/S01 | Done | Experimental native configured-run result sidecar; PR #136 integrated |
 | T-0079 | Done | Bounded, non-applying Qwen development assistant; PR #130 integrated |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -113,7 +113,7 @@ checkpoint, and resume code remain unchanged. Primary and independent
 final-head acceptance, Security, and Vreji reviews passed at `a377b6e` before
 integration.
 
-T-0014/S03 is In Progress on Issue #138. It observes three bounded multi-file
+T-0014/S03 is in Review on Issue #138 and PR #139. It observes three bounded multi-file
 File input `path_prefix` cases through the already-admitted pinned Embulk 0.11.5
 runtime before any native multi-file policy is selected. The evidence-only
 slice changes no Rust runtime, Cargo dependency, plugin admission, or current
@@ -163,7 +163,7 @@ file/plugin parent stays open. Core transfer semantics remain unchanged.
 | T-0012/S12 | Done | Seven-case reference observation and validator; PR #105 integrated |
 | T-0012/S13 | Done | PR #107 integrated; primary and independent final-head acceptance passed |
 | T-0013 | Backlog | S01–S08 integrated; remaining cleanup/recovery contracts |
-| T-0014/S03 | In Progress | Bounded multi-file File input reference observation; Issue #138 |
+| T-0014/S03 | Review | Bounded multi-file File input reference observation; Issue #138, PR #139 |
 | T-0021 | Backlog | S06 handoff integrated; remaining runtime contracts |
 | T-0026/S01 | Done | Experimental native configured-run result sidecar; PR #136 integrated |
 | T-0079 | Done | Bounded, non-applying Qwen development assistant; PR #130 integrated |

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -167,3 +167,62 @@ provenance, IP, privacy, or compatibility blocker. The environment-sensitive
 long SIGINT/resume case passed in each run. Acceptance evidence was recorded on
 PR #136, which squash-merged as `8577ffd`. Issue #135 closed, its 3 SP Project
 item moved to Done, and the live Project audit passed with combined WIP 0/2.
+
+After T-0026/S01 closeout, a candidate stateful result-reporting slice failed
+pre-publication safety review and was not activated; private review detail is
+not copied into repository records. Jitro instead selected T-0014/S03 to
+observe bounded multi-file File input behavior before native expansion. Vreji cleared the exact Issue packet
+after narrowing Qwen context, fixing deterministic fixture mappings, and
+linking the existing File/CSV artifact record. Issue #138 was created with P0,
+3 SP, Compatibility Contract/Research metadata and moved to In Progress; the
+Project audit passed at 58 items and WIP 1/2. The pinned JAR hash and Java
+17.0.20 were confirmed locally. The one sanitized Qwen request timed out at 90
+seconds with no response and was classified rejected without retry.
+
+The low-reasoning Compatibility Host Implementer added only the Issue-authorized
+new harness and test. Eleven focused tests pass. PM executed the pinned runtime
+once before semantic assertions and again after admitting only stable selected
+projections. Both three-case runs exited 0 without timeout or stderr. In the two
+regular-file cases, Embulk selected lexical names into two tasks and two output
+files, skipped each file's header independently, and followed filename order
+when contents were exchanged. The matching empty directory was excluded and
+the regular file produced the only task/output. Independent reproduction and
+full acceptance remain pending.
+
+The first independent read-only reproduction matched all stable stdout
+projections and exact output bytes; its retained summary is
+`586a706a0c2f1ced8e5842c50aa4b420026b0ee1d0dc9bae25a0237853889174`.
+Security review then blocked integration on evidence-integrity gaps: normal and
+interrupted JVM waits did not unconditionally stop surviving descendants, and
+arbitrary case-tree entries outside the selected input/output inventories were
+not rejected. PM remediated both without changing the three observations. The
+runner now terminates the isolated process group from a `finally` path, passes
+an explicit case-local `java.io.tmpdir`, validates a complete retained case
+tree including JVM temporary artifacts, rejects extra entries, and revalidates
+the JAR snapshot after all cases. Real normal-exit and interrupted-wait delayed
+descendant regressions bring the focused suite to thirteen tests.
+
+The post-remediation primary exact Demo completed with evidence under
+`/private/tmp/emburk-t0014-s03-a84e4rh5`, summary SHA-256
+`a4114afb67dc4946b0bb2bea277a2ca0b4f9b4099f16ac57d26a18bc1db66d4e`.
+The three reference cases passed, followed by 134 workspace tests with eight
+intentional external-oracle ignores and `git diff --check`. OS-level write
+containment, authenticated Java identity, same-UID hostile-process defense, and
+immutable evidence remain explicit non-claims. At this checkpoint,
+post-final-remediation independent and Security reviews remained pending.
+
+The final-remediation independent capture passed thirteen focused tests and all
+three exact observations under `/private/tmp/emburk-t0014-s03-pbqcvmd9`,
+summary SHA-256
+`5362f83b5e4e27ef6c9fefd335fc83cacfc1e9a39a54ff823eb07f7adf18ff48`.
+Security re-review cleared both Medium findings and reported no remaining High
+or Medium issue. PM's current-candidate exact Demo then passed thirteen focused
+tests, all three reference cases, 134 workspace tests with eight intentional
+external-oracle ignores, and the diff check. Its evidence is
+`/private/tmp/emburk-t0014-s03-1frgdxve`, summary SHA-256
+`212cdc90c5fae3af08668ceb335752f76f7db1af072110acf01fb92983ed2659`.
+Vreji identified and PM corrected one Issue wording mismatch: the harness
+rejects unexpected entries within the retained private evidence tree but does
+not claim host-level write containment. The final Vreji review found no IP,
+provenance, scope, or record-consistency blocker. Final-head acceptance and
+integration remain pending.

--- a/docs/log/2026-09-09.md
+++ b/docs/log/2026-09-09.md
@@ -225,4 +225,5 @@ Vreji identified and PM corrected one Issue wording mismatch: the harness
 rejects unexpected entries within the retained private evidence tree but does
 not claim host-level write containment. The final Vreji review found no IP,
 provenance, scope, or record-consistency blocker. Final-head acceptance and
-integration remain pending.
+integration remain pending. Candidate `b631ee3` was pushed as PR #139 and the
+Issue-linked private Project item moved to Review with combined WIP 1/2.

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -40,7 +40,7 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0032/S01 configured CSV](T-0032-configured-csv.md) | Done through PR #116; eight selected comparisons and 81 tests |
 | [T-0025/S01 safe publication](T-0025-safe-publication.md) | Done through PR #117; fault/interruption acceptance |
 | [T-0014/S02 format/filter observations](T-0014-formats-oracle.md) | Done through PR #118; five real reference cases |
-| [T-0014/S03 multi-file File input observation](T-0014-multifile-path-prefix-oracle.md) | In Progress on Issue #138; three bounded reference cases |
+| [T-0014/S03 multi-file File input observation](T-0014-multifile-path-prefix-oracle.md) | Review on Issue #138 and PR #139; three bounded reference cases |
 | [T-0033/S01 native formats](T-0033-native-formats.md) | Done through PR #119; thirteen selected comparisons |
 | [T-0024/S01 bounded workers](T-0024-bounded-parallel.md) | Done through PR #120; native ordering/admission/cancellation |
 | [T-0025/S02 validated resume](T-0025-validated-resume.md) | Done through PR #121; private validated spool recovery |

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -40,6 +40,7 @@ Use the schema and rules in [Traceable, License-Aware Reimplementation](../PROVE
 | [T-0032/S01 configured CSV](T-0032-configured-csv.md) | Done through PR #116; eight selected comparisons and 81 tests |
 | [T-0025/S01 safe publication](T-0025-safe-publication.md) | Done through PR #117; fault/interruption acceptance |
 | [T-0014/S02 format/filter observations](T-0014-formats-oracle.md) | Done through PR #118; five real reference cases |
+| [T-0014/S03 multi-file File input observation](T-0014-multifile-path-prefix-oracle.md) | In Progress on Issue #138; three bounded reference cases |
 | [T-0033/S01 native formats](T-0033-native-formats.md) | Done through PR #119; thirteen selected comparisons |
 | [T-0024/S01 bounded workers](T-0024-bounded-parallel.md) | Done through PR #120; native ordering/admission/cancellation |
 | [T-0025/S02 validated resume](T-0025-validated-resume.md) | Done through PR #121; private validated spool recovery |

--- a/docs/provenance/T-0014-multifile-path-prefix-oracle.md
+++ b/docs/provenance/T-0014-multifile-path-prefix-oracle.md
@@ -1,6 +1,6 @@
 # T-0014/S03 multi-file File input observation
 
-Status: In Progress
+Status: Review on PR #139
 
 ## Authority and boundary
 

--- a/docs/provenance/T-0014-multifile-path-prefix-oracle.md
+++ b/docs/provenance/T-0014-multifile-path-prefix-oracle.md
@@ -1,0 +1,117 @@
+# T-0014/S03 multi-file File input observation
+
+Status: In Progress
+
+## Authority and boundary
+
+Issue #138 authorizes a 3 SP reference-only observation on
+`research/t-0014-multifile-path-prefix-oracle`. It captures three selected
+multi-file File input `path_prefix` outcomes before any native implementation.
+No Rust runtime, Cargo file, existing oracle, reference artifact, or plugin
+source is mutable in this slice.
+
+The only external runtime is the already-admitted local Embulk 0.11.5 JAR,
+SHA-256
+`e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47`,
+under Java 17. The official URL, core commit, four bundled File/CSV module
+versions, hashes and commits, 2026-09-06 access date, Apache-2.0 license
+findings, outer NOTICE, and unresolved SBOM/security/redistribution/patent/FTO
+questions remain recorded in
+[T-0014/S01](T-0014-file-csv-oracle.md#artifacts). This slice reuses that local
+runtime boundary and original fixtures; it inspects or copies no upstream
+implementation source.
+
+## Selected observations
+
+Raw capture precedes semantic assertions for:
+
+1. `input.10.csv` with `10,alpha` and `input.20.csv` with `20,beta`;
+2. the same filenames with those complete contents exchanged;
+3. one `input.10.csv` regular file and one newly created empty
+   `input.15.csv` directory.
+
+Every case uses explicit File/CSV configuration, `max_threads: 1`,
+`min_output_tasks: 1`, a new private `/private/tmp` tree, the allowlisted Java
+child environment, a read-only exclusive snapshot of verified JAR bytes, and a
+60-second process timeout. The runner gives the JVM an explicit case-local
+`java.io.tmpdir`, terminates its isolated process group on every completion or
+interruption path, and retains the complete case tree, including JVM temporary
+artifacts. Exact inputs, entry types, process outputs, exit, timeout state,
+output inventory/bytes/hashes, Java version, artifact identity, and run
+identity are retained and structurally validated.
+
+## Primary observations
+
+The first raw capture completed before these expectations were added. A second
+run then reproduced the resulting semantic projections:
+
+| Case | Selected files and tasks | Exact output |
+| --- | --- | --- |
+| `two-regular` | `[input.10.csv, input.20.csv]`; two tasks; `last_path` is `input.20.csv` | `result000.00.csv` is `id,name\n10,alpha\n`; `result001.00.csv` is `id,name\n20,beta\n` |
+| `two-regular-swapped` | `[input.10.csv, input.20.csv]`; two tasks; `last_path` is `input.20.csv` | `result000.00.csv` is `id,name\n20,beta\n`; `result001.00.csv` is `id,name\n10,alpha\n` |
+| `regular-and-directory` | `[input.10.csv]`; one task; `last_path` is `input.10.csv` | only `result000.00.csv`, equal to `id,name\n10,alpha\n` |
+
+Within this matrix, regular files are selected in lexical filename order, one
+task/output is used per selected regular file, each file's configured header is
+skipped independently, and the selected empty matching directory is excluded.
+Those statements are bounded observations, not general File plugin policy.
+All three processes exited 0 without timeout or stderr. Timestamped stdout is
+retained raw but is not compared byte-for-byte across runs; validation projects
+only the stable selected-file, task-count, and `last_path` lines.
+
+Raw pre-assertion evidence is under
+`/private/tmp/emburk-t0014-s03-gcmq68yc`, with summary SHA-256
+`2c326dc4648fd6491779eac55a4882bf9f076b0dae31f049a68ca594a4a53b03`;
+the first asserted primary rerun is under
+`/private/tmp/emburk-t0014-s03-vliuo1sl`, with summary SHA-256
+`5f801ad0949ee76772e7fa0468e5c2a30f18cd6e3d8c6f4f2b548cbef21bb39b`.
+These directories are local evidence and are not repository or release
+artifacts.
+
+The first independent reproduction is under
+`/private/tmp/emburk-t0014-s03-ivah2o2i`, with summary SHA-256
+`586a706a0c2f1ced8e5842c50aa4b420026b0ee1d0dc9bae25a0237853889174`.
+It matched the stable projections and exact output bytes. Security review then
+identified evidence-integrity gaps in normal-exit descendant cleanup and
+unrecorded case-tree entries. The candidate now terminates the process group
+on normal, timeout, and interrupted waits; rejects an extra case-tree entry;
+explicitly locates JVM temporary files; rechecks the JAR snapshot after all
+cases; and exercises real delayed-descendant regressions. Post-remediation
+primary evidence is under `/private/tmp/emburk-t0014-s03-a84e4rh5`, with
+summary SHA-256
+`a4114afb67dc4946b0bb2bea277a2ca0b4f9b4099f16ac57d26a18bc1db66d4e`.
+The final-remediation independent capture is under
+`/private/tmp/emburk-t0014-s03-pbqcvmd9`, with summary SHA-256
+`5362f83b5e4e27ef6c9fefd335fc83cacfc1e9a39a54ff823eb07f7adf18ff48`.
+It passed all thirteen focused tests and reproduced all three stable
+projections and exact outputs. The primary exact Demo then captured
+`/private/tmp/emburk-t0014-s03-1frgdxve`, with summary SHA-256
+`212cdc90c5fae3af08668ceb335752f76f7db1af072110acf01fb92983ed2659`.
+
+## Qwen consultation
+
+One `fix` consultation sent only the original existing File/CSV harness and its
+unit test with default project context disabled. It contained no documentation,
+provenance, JAR, evidence, generated log, upstream source, credential, legal,
+security, `.git`, or `.codex` material. The sandbox-denied call made no outbound
+request; the same authorized consultation then reached its 90-second timeout
+without a response. Its disposition is `rejected`; it was not retried and does
+not influence code, observations, or evidence.
+
+## Evidence state
+
+The harness implementation, first raw capture, thirteen focused unit tests,
+primary and independent semantic reproduction, and the primary full Demo pass.
+The full workspace result is 134 passed with eight intentional external-oracle
+ignores. Security review reports no remaining High or Medium finding.
+Final-head acceptance and integration remain pending.
+
+## Non-claims
+
+No native implementation, multi-file compatibility certification, general
+ordering/header/task/output policy, glob or recursive traversal semantics,
+symlink/FIFO/device behavior, authenticated Java host, OS-level filesystem
+containment, defense against a hostile same-UID process that changes sessions,
+signed or immutable evidence, plugin admission, redistribution, security
+clearance, patent/FTO conclusion, T-0014 completion, or Phase 1 completion is
+claimed.

--- a/tests/test_multifile_path_prefix_oracle.py
+++ b/tests/test_multifile_path_prefix_oracle.py
@@ -1,0 +1,217 @@
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("multifile_oracle", ROOT / "tools/multifile-path-prefix-oracle/run.py")
+oracle = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(oracle)
+
+
+class MultiFilePathPrefixOracleTests(unittest.TestCase):
+    def valid_case(self, directory, case="two-regular", run_uuid="00000000-0000-4000-8000-000000000000"):
+        root = Path(directory)
+        (root / "output").mkdir()
+        for name, contents in oracle.fixture(case).items():
+            target = root / name
+            target.mkdir() if contents is None else target.write_bytes(contents)
+        stdout = ("timestamped preface\n" + "\n".join(oracle.STDOUT_PROJECTIONS[case]) + "\n").encode()
+        for name, data in {"config.yml": b"config\n", "java-version.txt": b"java 17\n", "stdout.log": stdout, "stderr.log": b"", "exit.txt": b"0\n"}.items():
+            (root / name).write_bytes(data)
+        for name, contents in oracle.OBSERVATIONS[case]:
+            (root / "output" / name).write_bytes(contents)
+        value = {"case": case, "run_uuid": run_uuid, "reference": {"sha256": oracle.EXPECTED_JAR_SHA256}, "java_version": oracle.detail(root / "java-version.txt", root), "inputs": [item for item in oracle.inventory(root) if item["name"].startswith("input.")], "config": oracle.detail(root / "config.yml", root), "process": {"exit": 0, "timed_out": False, "stdout": oracle.detail(root / "stdout.log", root), "stderr": oracle.detail(root / "stderr.log", root)}, "outputs": oracle.inventory(root / "output")}
+        value["case_tree"] = oracle.inventory(root)
+        path = root / "manifest.json"
+        path.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+        return path, value
+
+    def test_fixture_has_exactly_three_selected_cases(self):
+        self.assertEqual(oracle.CASES, ("two-regular", "two-regular-swapped", "regular-and-directory"))
+        self.assertEqual(set(oracle.fixture("two-regular")), {"input.10.csv", "input.20.csv"})
+        self.assertEqual(oracle.fixture("regular-and-directory")["input.15.csv"], None)
+
+    def test_observation_has_exact_case_mappings(self):
+        self.assertEqual(oracle.OBSERVATIONS, {
+            "two-regular": (("result000.00.csv", b"id,name\n10,alpha\n"), ("result001.00.csv", b"id,name\n20,beta\n")),
+            "two-regular-swapped": (("result000.00.csv", b"id,name\n20,beta\n"), ("result001.00.csv", b"id,name\n10,alpha\n")),
+            "regular-and-directory": (("result000.00.csv", b"id,name\n10,alpha\n"),),
+        })
+        self.assertEqual(oracle.STDOUT_PROJECTIONS, {
+            "two-regular": (
+                "Loading files [input.10.csv, input.20.csv]",
+                "Using local thread executor with max_threads=1 / tasks=2",
+                'Next config diff: {"in":{"last_path":"input.20.csv"},"out":{}',
+            ),
+            "two-regular-swapped": (
+                "Loading files [input.10.csv, input.20.csv]",
+                "Using local thread executor with max_threads=1 / tasks=2",
+                'Next config diff: {"in":{"last_path":"input.20.csv"},"out":{}',
+            ),
+            "regular-and-directory": (
+                "Loading files [input.10.csv]",
+                "Using local thread executor with max_threads=1 / tasks=1",
+                'Next config diff: {"in":{"last_path":"input.10.csv"},"out":{}',
+            ),
+        })
+
+    def test_rejects_checksum_mismatch_before_execution(self):
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "wrong.jar"; artifact.write_bytes(b"wrong")
+            with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+                oracle.reference_bytes({"EMBURK_REFERENCE_JAR": str(artifact)})
+
+    def test_snapshot_is_pinned_and_independent_from_source(self):
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(oracle, "EXPECTED_JAR_SHA256", oracle.sha256(b"pinned")):
+            root, source = Path(directory) / "root", Path(directory) / "source.jar"
+            root.mkdir(); source.write_bytes(b"pinned")
+            snapshot = oracle.snapshot_reference(oracle.reference_bytes({"EMBURK_REFERENCE_JAR": str(source)}), root)
+            source.write_bytes(b"changed")
+            self.assertEqual(snapshot.read_bytes(), b"pinned")
+
+    def test_child_environment_is_allowlisted(self):
+        with tempfile.TemporaryDirectory() as directory:
+            environment = oracle.jvm_environment(Path(directory), "/java-home")
+            self.assertEqual(set(environment), {"PATH", "JAVA_HOME", "EMBULK_HOME", "HOME", "TMPDIR"})
+            self.assertNotIn("T0014_SECRET_SENTINEL", environment)
+
+    def test_normal_exit_descendant_cannot_mutate_evidence_after_cleanup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            marker = Path(directory) / "late-write"
+            child = "import pathlib,sys,time; time.sleep(0.4); pathlib.Path(sys.argv[1]).write_text('late')"
+            parent = "import subprocess,sys; subprocess.Popen([sys.executable, '-c', sys.argv[1], sys.argv[2]])"
+            process = subprocess.Popen(
+                [sys.executable, "-c", parent, child, str(marker)], start_new_session=True
+            )
+            exit_code, timed_out = oracle.wait_and_terminate_process_group(process)
+            time.sleep(0.6)
+            self.assertEqual(exit_code, 0)
+            self.assertFalse(timed_out)
+            self.assertFalse(marker.exists())
+
+    def test_interrupted_wait_still_terminates_descendant_process_group(self):
+        with tempfile.TemporaryDirectory() as directory:
+            marker, ready = Path(directory) / "late-write", Path(directory) / "ready"
+            child = "import pathlib,sys,time; time.sleep(0.4); pathlib.Path(sys.argv[1]).write_text('late')"
+            parent = (
+                "import pathlib,subprocess,sys,time; "
+                "subprocess.Popen([sys.executable, '-c', sys.argv[1], sys.argv[2]]); "
+                "pathlib.Path(sys.argv[3]).write_text('ready'); time.sleep(5)"
+            )
+            process = subprocess.Popen(
+                [sys.executable, "-c", parent, child, str(marker), str(ready)],
+                start_new_session=True,
+            )
+            for _ in range(100):
+                if ready.exists():
+                    break
+                time.sleep(0.01)
+            self.assertTrue(ready.exists())
+
+            class InterruptedWait:
+                pid = process.pid
+
+                @staticmethod
+                def wait(timeout=None):
+                    raise KeyboardInterrupt
+
+            with self.assertRaises(KeyboardInterrupt):
+                oracle.wait_and_terminate_process_group(InterruptedWait())
+            process.wait(timeout=2)
+            time.sleep(0.6)
+            self.assertFalse(marker.exists())
+
+    def test_manifest_rejects_changed_input_config_output_and_exit(self):
+        for changed in ("input.10.csv", "config.yml", "output/result.csv", "exit.txt"):
+            with self.subTest(changed=changed), tempfile.TemporaryDirectory() as directory:
+                path, _ = self.valid_case(directory)
+                target = Path(directory) / changed
+                target.write_bytes(b"changed\n" if changed != "exit.txt" else b"1\n")
+                with self.assertRaises(ValueError): oracle.validate_case_manifest(path)
+
+    def test_manifest_rejects_extra_or_missing_and_symlink_entries(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path, _ = self.valid_case(directory)
+            (Path(directory) / "input.extra.csv").write_bytes(b"x")
+            with self.assertRaises(ValueError): oracle.validate_case_manifest(path)
+        with tempfile.TemporaryDirectory() as directory:
+            path, _ = self.valid_case(directory)
+            (Path(directory) / "input.20.csv").unlink()
+            with self.assertRaises(ValueError): oracle.validate_case_manifest(path)
+        with tempfile.TemporaryDirectory() as directory:
+            path, _ = self.valid_case(directory)
+            (Path(directory) / "output" / "link.csv").symlink_to(Path(directory) / "output" / "result.csv")
+            with self.assertRaises(ValueError): oracle.validate_case_manifest(path)
+        with tempfile.TemporaryDirectory() as directory:
+            path, _ = self.valid_case(directory)
+            (Path(directory) / "unexpected.txt").write_bytes(b"unexpected")
+            with self.assertRaisesRegex(ValueError, "case tree"):
+                oracle.validate_case_manifest(path)
+
+    def test_manifest_rejects_path_escape_and_malformed_structure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path, value = self.valid_case(directory)
+            value["config"]["name"] = "../outside.yml"
+            path.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaises(ValueError): oracle.validate_case_manifest(path)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "manifest.json"; path.write_text("{}", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "structure"): oracle.validate_case_manifest(path)
+
+    def test_observation_rejects_exit_timeout_stderr_and_output_mutation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path, value = self.valid_case(directory)
+            oracle.validate_observation(value, path)
+            for field, changed in (("exit", 1), ("timed_out", True)):
+                altered = json.loads(json.dumps(value)); altered["process"][field] = changed
+                with self.subTest(field=field), self.assertRaises(ValueError): oracle.validate_observation(altered, path)
+            (Path(directory) / "stderr.log").write_bytes(b"unexpected\n")
+            with self.assertRaises(ValueError): oracle.validate_observation(value, path)
+        with tempfile.TemporaryDirectory() as directory:
+            path, value = self.valid_case(directory)
+            (Path(directory) / "output" / "result000.00.csv").write_bytes(b"changed\n")
+            with self.assertRaises(ValueError): oracle.validate_observation(value, path)
+
+    def test_observation_rejects_missing_or_altered_stdout_projection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path, value = self.valid_case(directory)
+            oracle.validate_observation(value, path)
+            stdout = Path(directory) / "stdout.log"
+            stdout.write_bytes(b"timestamped preface\n")
+            with self.assertRaises(ValueError): oracle.validate_observation(value, path)
+        with tempfile.TemporaryDirectory() as directory:
+            path, value = self.valid_case(directory)
+            stdout = Path(directory) / "stdout.log"
+            stdout.write_text(stdout.read_text().replace("tasks=2", "tasks=9"), encoding="utf-8")
+            with self.assertRaises(ValueError): oracle.validate_observation(value, path)
+
+    def test_summary_rejects_missing_extra_and_mixed_run_identity(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory); (root / "cases").mkdir()
+            entries = []
+            for case in oracle.CASES:
+                case_root = root / "cases" / case; case_root.mkdir()
+                manifest, _ = self.valid_case(case_root, case)
+                entries.append({"case": case, "path": str(manifest.parent.relative_to(root)), "manifest_sha256": oracle.sha256(manifest.read_bytes())})
+            summary = root / "manifest.json"
+            value = {"run_uuid": "00000000-0000-4000-8000-000000000000", "reference_sha256": oracle.EXPECTED_JAR_SHA256, "cases": entries}
+            summary.write_text(json.dumps(value), encoding="utf-8"); oracle.validate_summary(summary)
+            value["cases"] = entries[:-1]; summary.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaises(ValueError): oracle.validate_summary(summary)
+            value["cases"] = entries + [entries[-1]]; summary.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaises(ValueError): oracle.validate_summary(summary)
+            value["cases"] = entries
+            changed = json.loads((root / entries[0]["path"] / "manifest.json").read_text()); changed["run_uuid"] = "00000000-0000-4000-8000-000000000001"
+            altered = root / entries[0]["path"] / "manifest.json"; altered.write_text(json.dumps(changed), encoding="utf-8")
+            value["cases"][0]["manifest_sha256"] = oracle.sha256(altered.read_bytes()); summary.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaises(ValueError): oracle.validate_summary(summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/multifile-path-prefix-oracle/run.py
+++ b/tools/multifile-path-prefix-oracle/run.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Capture three bounded multi-file File-input observations without inferring policy."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import uuid
+
+EXPECTED_JAR_SHA256 = "e2f298db60c2fe1cc17c377edf7215c7005b5d106d151b1a4278a508e4a32e47"
+JAVA_MAJOR = "17"
+TIMEOUT_SECONDS = 60
+CASES = ("two-regular", "two-regular-swapped", "regular-and-directory")
+OBSERVATIONS = {
+    "two-regular": (("result000.00.csv", b"id,name\n10,alpha\n"), ("result001.00.csv", b"id,name\n20,beta\n")),
+    "two-regular-swapped": (("result000.00.csv", b"id,name\n20,beta\n"), ("result001.00.csv", b"id,name\n10,alpha\n")),
+    "regular-and-directory": (("result000.00.csv", b"id,name\n10,alpha\n"),),
+}
+STDOUT_PROJECTIONS = {
+    "two-regular": (
+        "Loading files [input.10.csv, input.20.csv]",
+        "Using local thread executor with max_threads=1 / tasks=2",
+        'Next config diff: {"in":{"last_path":"input.20.csv"},"out":{}',
+    ),
+    "two-regular-swapped": (
+        "Loading files [input.10.csv, input.20.csv]",
+        "Using local thread executor with max_threads=1 / tasks=2",
+        'Next config diff: {"in":{"last_path":"input.20.csv"},"out":{}',
+    ),
+    "regular-and-directory": (
+        "Loading files [input.10.csv]",
+        "Using local thread executor with max_threads=1 / tasks=1",
+        'Next config diff: {"in":{"last_path":"input.10.csv"},"out":{}',
+    ),
+}
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def confined(path: Path, root: Path) -> Path:
+    resolved, boundary = path.resolve(), root.resolve()
+    if resolved == boundary or boundary not in resolved.parents:
+        raise ValueError("path escapes evidence tree")
+    return resolved
+
+
+def detail(path: Path, root: Path) -> dict[str, object]:
+    confined(path, root)
+    if not path.is_file() or path.is_symlink():
+        raise ValueError("raw artifact is not a regular file")
+    data = path.read_bytes()
+    return {"name": str(path.relative_to(root)), "size": len(data), "sha256": sha256(data)}
+
+
+def inventory(root: Path) -> list[dict[str, object]]:
+    """Return a deterministic, symlink-free inventory including empty directories."""
+    confined(root, root.parent)
+    result = []
+    for path in sorted(root.rglob("*")):
+        confined(path, root)
+        if path.is_symlink():
+            raise ValueError("symlink in captured tree")
+        name = str(path.relative_to(root))
+        if path.is_dir():
+            result.append({"name": name, "type": "directory"})
+        elif path.is_file():
+            result.append({"type": "regular", **detail(path, root)})
+        else:
+            raise ValueError("non-regular entry in captured tree")
+    return result
+
+
+def reference_bytes(environment: dict[str, str]) -> bytes:
+    value = environment.get("EMBURK_REFERENCE_JAR")
+    if not value:
+        raise ValueError("EMBURK_REFERENCE_JAR is required")
+    path = Path(value)
+    if not path.is_file() or path.is_symlink():
+        raise ValueError("reference artifact is not a regular file")
+    data = path.read_bytes()
+    if sha256(data) != EXPECTED_JAR_SHA256:
+        raise ValueError("reference artifact checksum mismatch")
+    return data
+
+
+def snapshot_reference(data: bytes, root: Path) -> Path:
+    path = root / "embulk.jar"
+    with path.open("xb") as stream:
+        stream.write(data)
+    path.chmod(0o400)
+    if sha256(path.read_bytes()) != EXPECTED_JAR_SHA256:
+        raise ValueError("reference snapshot checksum mismatch")
+    return path
+
+
+def java_command(environment: dict[str, str]) -> tuple[Path, bytes]:
+    home = environment.get("JAVA_HOME")
+    if not home:
+        raise ValueError("JAVA_HOME is required")
+    executable = Path(home) / "bin" / "java"
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise ValueError("JAVA_HOME does not provide java")
+    completed = subprocess.run(
+        [str(executable), "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env={"PATH": os.defpath, "JAVA_HOME": str(Path(home).resolve())}, timeout=10, check=False,
+    )
+    version = completed.stdout + completed.stderr
+    if completed.returncode != 0 or f'version "{JAVA_MAJOR}.'.encode() not in version:
+        raise ValueError("Java 17 is required")
+    return executable.resolve(), version
+
+
+def jvm_environment(case_root: Path, java_home: str) -> dict[str, str]:
+    home, temporary = case_root / "home", case_root / "tmp"
+    home.mkdir()
+    temporary.mkdir()
+    return {
+        "PATH": os.defpath, "JAVA_HOME": java_home, "EMBULK_HOME": str(home),
+        "HOME": str(home), "TMPDIR": str(temporary),
+    }
+
+
+def fixture(case: str) -> dict[str, bytes | None]:
+    header = b"id,name\n"
+    regular = {"input.10.csv": header + b"10,alpha\n", "input.20.csv": header + b"20,beta\n"}
+    if case == "two-regular":
+        return regular
+    if case == "two-regular-swapped":
+        return {"input.10.csv": regular["input.20.csv"], "input.20.csv": regular["input.10.csv"]}
+    if case == "regular-and-directory":
+        return {"input.10.csv": regular["input.10.csv"], "input.15.csv": None}
+    raise ValueError("unknown case")
+
+
+def config_bytes() -> bytes:
+    return (
+        b"in:\n  type: file\n  path_prefix: input.\n  parser:\n    type: csv\n"
+        b"    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n"
+        b"    skip_header_lines: 1\n    columns:\n    - {name: id, type: long}\n    - {name: name, type: string}\n"
+        b"out:\n  type: file\n  path_prefix: output/result\n  file_ext: csv\n  formatter:\n    type: csv\n"
+        b"    charset: UTF-8\n    newline: LF\n    delimiter: ','\n    quote: '\"'\n    escape: '\"'\n"
+        b"    header_line: true\n    quote_policy: MINIMAL\nexec:\n  max_threads: 1\n  min_output_tasks: 1\n"
+    )
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def wait_and_terminate_process_group(process: subprocess.Popen) -> tuple[int, bool]:
+    """Wait for the leader and stop every descendant in its isolated process group."""
+    timed_out = False
+    try:
+        exit_code = process.wait(timeout=TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        exit_code = None
+    finally:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if exit_code is None:
+        exit_code = process.wait()
+    return exit_code, timed_out
+
+
+def validate_case_manifest(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    required = {"case", "run_uuid", "reference", "java_version", "inputs", "config", "process", "outputs", "case_tree"}
+    if not isinstance(value, dict) or set(value) != required or value["case"] not in CASES:
+        raise ValueError("manifest structure")
+    if str(uuid.UUID(value["run_uuid"])) != value["run_uuid"]:
+        raise ValueError("manifest UUID")
+    if value["reference"] != {"sha256": EXPECTED_JAR_SHA256}:
+        raise ValueError("manifest artifact")
+    root = path.parent.resolve()
+    for field in ("java_version", "config"):
+        item = value[field]
+        if not isinstance(item, dict) or set(item) != {"name", "size", "sha256"}:
+            raise ValueError("manifest raw file")
+        candidate = confined(root / item["name"], root)
+        if item != detail(candidate, root):
+            raise ValueError("manifest raw file")
+    process = value["process"]
+    if not isinstance(process, dict) or set(process) != {"exit", "timed_out", "stdout", "stderr"} or not isinstance(process["exit"], int) or not isinstance(process["timed_out"], bool):
+        raise ValueError("manifest process")
+    for field in ("stdout", "stderr"):
+        item = process[field]
+        if not isinstance(item, dict) or set(item) != {"name", "size", "sha256"}:
+            raise ValueError("manifest process")
+        if item != detail(confined(root / item["name"], root), root):
+            raise ValueError("manifest process")
+    exit_file = confined(root / "exit.txt", root)
+    if not exit_file.is_file() or exit_file.read_text(encoding="ascii") != f"{process['exit']}\n":
+        raise ValueError("manifest process")
+    for field, directory in (("inputs", root), ("outputs", root / "output")):
+        items = value[field]
+        actual = inventory(directory)
+        if field == "inputs":
+            actual = [item for item in actual if item["name"].startswith("input.")]
+        if not isinstance(items, list) or items != actual:
+            raise ValueError("manifest inventory")
+        names = [item.get("name") for item in items if isinstance(item, dict)]
+        if len(names) != len(set(names)):
+            raise ValueError("manifest duplicate inventory")
+    actual_tree = [item for item in inventory(root) if item["name"] != "manifest.json"]
+    if not isinstance(value["case_tree"], list) or value["case_tree"] != actual_tree:
+        raise ValueError("manifest case tree")
+    return value
+
+
+def validate_observation(value: dict[str, object], path: Path) -> None:
+    """Check selected, post-capture projections without comparing variable stdout."""
+    root = path.parent.resolve()
+    process = value["process"]
+    if process["exit"] != 0 or process["timed_out"] is not False:
+        raise ValueError("observation process")
+    stderr = confined(root / process["stderr"]["name"], root)
+    if stderr.read_bytes() != b"":
+        raise ValueError("observation stderr")
+    stdout = confined(root / process["stdout"]["name"], root).read_text(encoding="utf-8")
+    if any(fragment not in stdout for fragment in STDOUT_PROJECTIONS[value["case"]]):
+        raise ValueError("observation stdout")
+    expected = []
+    for name, contents in OBSERVATIONS[value["case"]]:
+        candidate = confined(root / "output" / name, root / "output")
+        if not candidate.is_file() or candidate.is_symlink() or candidate.read_bytes() != contents:
+            raise ValueError("observation output")
+        expected.append({"type": "regular", "name": name, "size": len(contents), "sha256": sha256(contents)})
+    if value["outputs"] != expected:
+        raise ValueError("observation output")
+
+
+def validate_summary(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or set(value) != {"run_uuid", "reference_sha256", "cases"}:
+        raise ValueError("summary structure")
+    if str(uuid.UUID(value["run_uuid"])) != value["run_uuid"] or value["reference_sha256"] != EXPECTED_JAR_SHA256:
+        raise ValueError("summary identity")
+    entries = value["cases"]
+    if not isinstance(entries, list) or [entry.get("case") for entry in entries if isinstance(entry, dict)] != list(CASES):
+        raise ValueError("summary cases")
+    for entry in entries:
+        if not isinstance(entry, dict) or set(entry) != {"case", "path", "manifest_sha256"}:
+            raise ValueError("summary case")
+        manifest = confined(path.parent / entry["path"] / "manifest.json", path.parent)
+        if sha256(manifest.read_bytes()) != entry["manifest_sha256"]:
+            raise ValueError("summary manifest")
+        observed = validate_case_manifest(manifest)
+        if observed["case"] != entry["case"] or observed["run_uuid"] != value["run_uuid"]:
+            raise ValueError("summary case")
+        validate_observation(observed, manifest)
+    return value
+
+
+def run_case(case: str, jar: Path, java: Path, java_version: bytes, run_uuid: str, run_root: Path) -> Path:
+    case_root = run_root / "cases" / case
+    case_root.mkdir(parents=True)
+    for name, contents in fixture(case).items():
+        target = confined(case_root / name, case_root)
+        if contents is None:
+            target.mkdir()
+        else:
+            target.write_bytes(contents)
+    output_dir = case_root / "output"
+    output_dir.mkdir()
+    config_path = case_root / "config.yml"
+    config_path.write_bytes(config_bytes())
+    (case_root / "java-version.txt").write_bytes(java_version)
+    input_snapshot, config_snapshot = inventory(case_root), detail(config_path, case_root)
+    environment = jvm_environment(case_root, str(java.parent.parent))
+    command = [
+        str(java), f"-Duser.home={environment['HOME']}",
+        f"-Djava.io.tmpdir={environment['TMPDIR']}", "-jar", str(jar),
+        f"-Xembulk_home={environment['EMBULK_HOME']}", "run", str(config_path),
+    ]
+    stdout_path, stderr_path = case_root / "stdout.log", case_root / "stderr.log"
+    with stdout_path.open("xb") as stdout, stderr_path.open("xb") as stderr:
+        process = subprocess.Popen(command, stdout=stdout, stderr=stderr, env=environment, cwd=case_root, start_new_session=True)
+        exit_code, timed_out = wait_and_terminate_process_group(process)
+    (case_root / "exit.txt").write_text(f"{exit_code}\n", encoding="ascii")
+    if detail(config_path, case_root) != config_snapshot:
+        raise ValueError("reference process changed captured config")
+    # The fixture inventory is captured before execution; only its selected entries are compared.
+    current_inputs = [item for item in inventory(case_root) if item["name"].startswith("input.")]
+    if current_inputs != [item for item in input_snapshot if item["name"].startswith("input.")]:
+        raise ValueError("reference process changed captured inputs")
+    manifest = {
+        "case": case, "run_uuid": run_uuid, "reference": {"sha256": EXPECTED_JAR_SHA256},
+        "java_version": detail(case_root / "java-version.txt", case_root), "inputs": current_inputs,
+        "config": config_snapshot,
+        "process": {"exit": exit_code, "timed_out": timed_out, "stdout": detail(stdout_path, case_root), "stderr": detail(stderr_path, case_root)},
+        "outputs": inventory(output_dir),
+    }
+    manifest["case_tree"] = inventory(case_root)
+    manifest_path = case_root / "manifest.json"
+    write_json(manifest_path, manifest)
+    validate_case_manifest(manifest_path)
+    print(f"T0014_S03_CASE={case}|exit={exit_code}|timed_out={str(timed_out).lower()}|evidence={case_root}", flush=True)
+    return case_root
+
+
+def main() -> int:
+    run_root = Path(tempfile.mkdtemp(prefix="emburk-t0014-s03-", dir="/private/tmp"))
+    run_root.chmod(0o700)
+    jar = snapshot_reference(reference_bytes(dict(os.environ)), run_root)
+    java, version = java_command(dict(os.environ))
+    run_uuid = str(uuid.uuid4())
+    entries = []
+    for case in CASES:
+        root = run_case(case, jar, java, version, run_uuid, run_root)
+        manifest = root / "manifest.json"
+        entries.append({"case": case, "path": str(root.relative_to(run_root)), "manifest_sha256": sha256(manifest.read_bytes())})
+    if sha256(jar.read_bytes()) != EXPECTED_JAR_SHA256:
+        raise ValueError("reference snapshot changed during execution")
+    summary = run_root / "manifest.json"
+    write_json(summary, {"run_uuid": run_uuid, "reference_sha256": EXPECTED_JAR_SHA256, "cases": entries})
+    validate_summary(summary)
+    print(f"T0014_S03_EVIDENCE_DIR={run_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, subprocess.SubprocessError) as failure:
+        print(f"T0014_S03_CAPTURE_ERROR={failure}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Summary

- add a bounded, license-aware Embulk 0.11.5 oracle for three multi-file File input `path_prefix` cases
- retain and validate complete private evidence trees, exact inputs/outputs, stable stdout projections, and pinned runtime identity
- document observed lexical selection, per-file header handling, task/output count, and empty-directory exclusion without selecting native policy

## Safety and provenance

- executes only a byte-verified, private read-only snapshot of the already-admitted local JAR under Java 17
- forwards an allowlisted environment, uses case-local home/tmp paths, terminates the isolated process group on every wait outcome, and rejects evidence mutation or extra case-tree entries
- copies no upstream implementation source and adds no dependency, Rust runtime change, plugin admission, redistribution approval, security clearance, or patent/FTO conclusion
- records the bounded Qwen consultation as timed out, rejected, and unused

## Evidence at `b631ee3`

- focused oracle suite: 13 passed
- primary and independent live captures: all three cases exited 0 without timeout or stderr and matched exact stable projections/output bytes
- full workspace: 134 passed; 8 intentional external-oracle tests ignored
- Security & Supply-chain: no remaining High or Medium finding
- Vreji: no IP, provenance, scope, or record-consistency blocker
- `git diff --check`: passed

Final-head primary and independent acceptance will be recorded before integration.

Closes #138
